### PR TITLE
feat(interview): 建立分段式逐题面试后端基础

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -450,7 +450,7 @@ service/scene/{IELTSSceneService,InterviewSceneService}.java
 service/scene/impl/{IELTSSceneServiceImpl,InterviewSceneServiceImpl}.java
 domain/dto/scene
 domain/vo/scene
-controller/{IELTSSceneController,InterviewSceneController}.java
+controller/{IELTSSceneController,InterviewController}.java
 ```
 
 不得新增 `service/ielts`、`service/interview`、`domain/dto/ielts` 或
@@ -461,22 +461,32 @@ controller/{IELTSSceneController,InterviewSceneController}.java
 
 - `IELTSSceneService`：查询 IELTS 题库、准备题组和编排 IELTS 特有规则；不管理公共
   会话生命周期，不实现评分供应商能力。
-- `InterviewSceneService`：校验面试材料与时长，准备 `INTERVIEW_SCENE` 的岗位快照、
-  问题计划和场景 Prompt；不建立会话、不推进公共流程、不保存逐轮消息，也不生成
-  评分结果。
+- `InterviewSceneService`：拥有 Interview 完整用例编排，负责材料校验、岗位摘要、
+  五题计划、逐题回答、有限追问、恢复、结束、五维报告、完整录音和学习资产；通过公共
+  Service、Provider 和 Repository 完成工作，不复制它们的底层能力。
 - `SceneFlowService`：为任意 Scene 创建、读取、幂等推进和完成流程状态；只接受
-  Scene 特化提供的流程定义或下一步决策，不解析简历、不生成面试问题、不管理实时
-  连接、不执行评分。
-- 公共 `SessionService`：绑定已就绪的 Scene 与当前用户，负责所有 Scene 类型的会话
-  建立、归属校验、状态迁移、完整消息追加和结束；可以在会话用例中协调
-  `SceneFlowService` 并在结束事实落库后把报告任务交给 `EvaluationService`，但不拥有
-  面试下一题决策或评分算法。不得新增 `InterviewSessionService`，也不得把面试提问
-  策略或评分规则写入公共 Session。
-- 公共 `EvaluationService`：接收已授权会话的文本/音频与场景评分上下文，负责单轮
-  评分、整场报告生成和结果查询；不推进 Scene Flow，不改变 Session 业务状态，
-  Interview 结果只评价英语口语表现，不输出岗位匹配或录用判断。
+  Scene 特化提供的流程定义或下一步决策，不解析简历、不生成面试问题、不接收音频、
+  不执行转写或评分。
+- 公共 `SessionService`：注册 Scene 特化已创建的 `AbstractSceneSession`，创建
+  `practice_session`，校验会话归属并写入 `COMPLETED`/`FAILED` 终态；不得编排
+  Interview 的 ASR、LLM、TTS、追问、报告或录音，也不得在用户点击结束时提前完成
+  Interview。
+- 公共 `EvaluationService`：提供无持久化副作用的语音评分能力；不查询 Scene 或
+  Session，不推进流程，不保存 Interview 逐轮评分或转写。Interview 的五维聚合和报告
+  由 `InterviewSceneService` 编排，且只评价英语口语表现。
 
-Realtime、TTS、LLM 和语音评分继续复用 Provider；不得创建
+Interview 固定使用“材料准备 → 分段式逐题问答 → 完成与报告”三段式链路，固定五个
+主问题；BASIC/STANDARD 每题最多一次追问，CHALLENGE 每题最多两次。问题经 TTS 播放，
+回答以最长 210 秒的 16 kHz 单声道 16-bit PCM WAV 通过 HTTP 提交，再执行 ASR 和无副作用
+语音评分；需要追问时使用普通 LLM 单次调用。简历可选且只支持文本、文本型 PDF 和
+DOCX。Interview 不交换 SDP、不建立 WebRTC/DataChannel，也不使用 Realtime 模型。
+
+Interview 只有在完整五维报告和包含实际 AI 问题与用户回答的 MP3 录音都成功后才进入
+`COMPLETED`。FULL 与 PARTIAL 都必须包含同字段、同量尺的完整报告；报告或录音任一失败
+都不得形成学习资产。AI 问题短音频可在运行态 JSON 中使用 Base64 返回，用户转写、原始
+材料和分题回答音频不得作为长期资产或公开 API 字段。
+
+TTS、Transcription、LLM 和语音评分继续复用 Provider；不得创建
 `InterviewTtsService`、`InterviewLlmService` 或同类厂商能力包装 Service。详细契约、
 ADR、失败补偿和场景伪代码见
 [`docs/interview-foundation-architecture.md`](docs/interview-foundation-architecture.md)。

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/document/DocumentTextExtractor.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/document/DocumentTextExtractor.java
@@ -57,7 +57,7 @@ public final class DocumentTextExtractor {
 		if (normalized.isEmpty()) {
 			throw new DocumentException(DocumentErrorCode.TEXT_EMPTY);
 		}
-		if (normalized.length() > MAX_TEXT_CHARS) {
+		if (normalized.codePointCount(0, normalized.length()) > MAX_TEXT_CHARS) {
 			throw new DocumentException(DocumentErrorCode.TEXT_TOO_LARGE);
 		}
 		return normalized;
@@ -110,7 +110,7 @@ public final class DocumentTextExtractor {
 		if (text == null) {
 			return "";
 		}
-		return text.replace("\r\n", "\n").replace('\r', '\n').trim();
+		return text.replace("\r\n", "\n").replace('\r', '\n').strip();
 	}
 
 	private static boolean isBlank(String value) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/calculation/InterviewReportAssembler.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/calculation/InterviewReportAssembler.java
@@ -1,0 +1,83 @@
+package com.unispeaking.common.evaluation.calculation;
+
+import com.unispeaking.domain.vo.scene.InterviewDimensionFeedback;
+import com.unispeaking.domain.vo.scene.InterviewReportCalculation;
+import com.unispeaking.domain.vo.scene.InterviewReportDimension;
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import com.unispeaking.domain.vo.scene.InterviewSpeechReportScores;
+import com.unispeaking.domain.vo.scene.InterviewStructuredReportAssessment;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Objects;
+
+/**
+ * Pure Interview-specific five-dimension report calculation and assembly.
+ *
+ * <p>Each dimension has an equal 20% weight. The arithmetic mean is rounded
+ * to one decimal with {@link RoundingMode#HALF_UP}; report type is metadata and
+ * never changes the algorithm.</p>
+ */
+public final class InterviewReportAssembler {
+
+	private static final BigDecimal DIMENSION_COUNT = new BigDecimal("5");
+	private static final int OVERALL_SCORE_SCALE = 1;
+	private static final RoundingMode OVERALL_SCORE_ROUNDING = RoundingMode.HALF_UP;
+
+	private InterviewReportAssembler() {
+	}
+
+	public static InterviewReportCalculation assemble(
+			InterviewReportType reportType,
+			InterviewSpeechReportScores speechScores,
+			InterviewStructuredReportAssessment structuredAssessment) {
+		Objects.requireNonNull(reportType, "reportType must not be null");
+		Objects.requireNonNull(speechScores, "speechScores must not be null");
+		Objects.requireNonNull(
+				structuredAssessment,
+				"structuredAssessment must not be null");
+
+		InterviewReportDimension fluency = scored(
+				speechScores.fluency(),
+				structuredAssessment.fluency());
+		InterviewReportDimension pronunciationIntelligibility = scored(
+				speechScores.pronunciationIntelligibility(),
+				structuredAssessment.pronunciationIntelligibility());
+
+		BigDecimal overallScore = arithmeticMean(
+				fluency.score(),
+				structuredAssessment.logicCoherence().score(),
+				structuredAssessment.grammarControl().score(),
+				pronunciationIntelligibility.score(),
+				structuredAssessment.vocabularyExpression().score());
+
+		return new InterviewReportCalculation(
+				reportType,
+				overallScore,
+				structuredAssessment.overallSummary(),
+				fluency,
+				structuredAssessment.logicCoherence(),
+				structuredAssessment.grammarControl(),
+				pronunciationIntelligibility,
+				structuredAssessment.vocabularyExpression());
+	}
+
+	private static InterviewReportDimension scored(
+			BigDecimal score,
+			InterviewDimensionFeedback feedback) {
+		return new InterviewReportDimension(
+				score,
+				feedback.evaluation(),
+				feedback.actionSuggestion());
+	}
+
+	private static BigDecimal arithmeticMean(BigDecimal... scores) {
+		BigDecimal sum = BigDecimal.ZERO;
+		for (BigDecimal score : scores) {
+			sum = sum.add(score);
+		}
+		return sum.divide(
+				DIMENSION_COUNT,
+				OVERALL_SCORE_SCALE,
+				OVERALL_SCORE_ROUNDING);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/GlobalExceptionHandler.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/GlobalExceptionHandler.java
@@ -1,19 +1,25 @@
 package com.unispeaking.common.exception;
 
+import com.unispeaking.common.exception.interview.InterviewException;
 import com.unispeaking.common.response.ApiResponse;
+import com.unispeaking.domain.dto.scene.InterviewApiRequest;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
 	@ExceptionHandler(BusinessException.class)
 	public ResponseEntity<ApiResponse<Void>> handleBusinessException(BusinessException exception) {
-		HttpStatus status = switch (exception.code()) {
+		HttpStatus status = exception instanceof InterviewException interviewException
+				? interviewException.errorCode().status()
+				: switch (exception.code()) {
 			case "AUTHENTICATION_REQUIRED", "INVALID_ACCESS_TOKEN", "ACCESS_TOKEN_REVOKED",
 					"INVALID_CREDENTIALS", "USER_NOT_ACTIVE" -> HttpStatus.UNAUTHORIZED;
 			case "SESSION_ACCESS_DENIED", "ADMIN_ACCESS_DENIED" -> HttpStatus.FORBIDDEN;
@@ -33,18 +39,56 @@ public class GlobalExceptionHandler {
 			case "AVATAR_DIMENSION_INVALID", "AVATAR_CONTENT_INVALID" ->
 					HttpStatus.UNPROCESSABLE_ENTITY;
 			default -> HttpStatus.BAD_REQUEST;
-		};
+			};
 		return ResponseEntity.status(status)
 				.body(ApiResponse.failure(exception.code(), exception.getMessage()));
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
-	@ResponseStatus(HttpStatus.BAD_REQUEST)
-	public ApiResponse<Void> handleValidationException(MethodArgumentNotValidException exception) {
+	public ResponseEntity<ApiResponse<Void>> handleValidationException(
+			MethodArgumentNotValidException exception) {
 		String message = exception.getBindingResult().getFieldErrors().stream()
 				.findFirst()
 				.map(error -> error.getField() + " " + error.getDefaultMessage())
 				.orElse("Invalid request");
-		return ApiResponse.failure("VALIDATION_ERROR", message);
+		boolean interviewRequest = exception.getBindingResult().getTarget()
+				instanceof InterviewApiRequest;
+		String code = interviewRequest ? "INTERVIEW_INPUT_INVALID" : "VALIDATION_ERROR";
+		HttpStatus status = interviewRequest
+				? HttpStatus.UNPROCESSABLE_ENTITY
+				: HttpStatus.BAD_REQUEST;
+		return ResponseEntity.status(status).body(ApiResponse.failure(code, message));
+	}
+
+	@ExceptionHandler(MaxUploadSizeExceededException.class)
+	public ResponseEntity<ApiResponse<Void>> handleUploadTooLarge(
+			MaxUploadSizeExceededException exception,
+			HttpServletRequest request) {
+		boolean interviewRequest = isInterviewRequest(request);
+		String code = interviewRequest
+				? "INTERVIEW_PAYLOAD_TOO_LARGE"
+				: "PAYLOAD_TOO_LARGE";
+		return ResponseEntity.status(HttpStatus.PAYLOAD_TOO_LARGE)
+				.body(ApiResponse.failure(code, "Request payload is too large"));
+	}
+
+	@ExceptionHandler(HttpMediaTypeNotSupportedException.class)
+	public ResponseEntity<ApiResponse<Void>> handleUnsupportedMediaType(
+			HttpMediaTypeNotSupportedException exception,
+			HttpServletRequest request) {
+		boolean interviewRequest = isInterviewRequest(request);
+		String code = interviewRequest
+				? "INTERVIEW_MEDIA_TYPE_UNSUPPORTED"
+				: "MEDIA_TYPE_UNSUPPORTED";
+		return ResponseEntity.status(HttpStatus.UNSUPPORTED_MEDIA_TYPE)
+				.body(ApiResponse.failure(code, "Request media type is not supported"));
+	}
+
+	private static boolean isInterviewRequest(HttpServletRequest request) {
+		if (request == null) {
+			return false;
+		}
+		String uri = request.getRequestURI();
+		return uri.equals("/api/interviews") || uri.startsWith("/api/interviews/");
 	}
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewErrorCode.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewErrorCode.java
@@ -1,0 +1,78 @@
+package com.unispeaking.common.exception.interview;
+
+import org.springframework.http.HttpStatus;
+
+public enum InterviewErrorCode {
+
+	NOT_FOUND("INTERVIEW_NOT_FOUND", "Interview was not found", HttpStatus.NOT_FOUND),
+	QUESTION_CONFLICT(
+			"INTERVIEW_QUESTION_CONFLICT",
+			"Answer does not match the current interview question",
+			HttpStatus.CONFLICT),
+	SUBMISSION_CONFLICT(
+			"INTERVIEW_SUBMISSION_CONFLICT",
+			"Submission identifier conflicts with an existing answer",
+			HttpStatus.CONFLICT),
+	SUBMISSION_RETRY_REQUIRED(
+			"INTERVIEW_SUBMISSION_RETRY_REQUIRED",
+			"A retryable answer submission must be retried before ending",
+			HttpStatus.CONFLICT),
+	DATA_CONFIRMATION_REQUIRED(
+			"INTERVIEW_DATA_CONFIRMATION_REQUIRED",
+			"Ending this interview requires insufficient-data confirmation",
+			HttpStatus.CONFLICT),
+	FINALIZATION_IN_PROGRESS(
+			"INTERVIEW_FINALIZATION_IN_PROGRESS",
+			"Interview finalization is already in progress",
+			HttpStatus.CONFLICT),
+	INPUT_INVALID(
+			"INTERVIEW_INPUT_INVALID",
+			"Interview input is invalid",
+			HttpStatus.UNPROCESSABLE_ENTITY),
+	STATE_INVALID(
+			"INTERVIEW_STATE_INVALID",
+			"Interview state does not allow this operation",
+			HttpStatus.UNPROCESSABLE_ENTITY),
+	AUDIO_INVALID(
+			"INTERVIEW_AUDIO_INVALID",
+			"Answer audio must be a supported PCM WAV file",
+			HttpStatus.UNPROCESSABLE_ENTITY),
+	PAYLOAD_TOO_LARGE(
+			"INTERVIEW_PAYLOAD_TOO_LARGE",
+			"Interview request exceeds the supported size limit",
+			HttpStatus.PAYLOAD_TOO_LARGE),
+	MEDIA_TYPE_UNSUPPORTED(
+			"INTERVIEW_MEDIA_TYPE_UNSUPPORTED",
+			"Interview request media type is not supported",
+			HttpStatus.UNSUPPORTED_MEDIA_TYPE),
+	DEPENDENCY_FAILED(
+			"INTERVIEW_DEPENDENCY_FAILED",
+			"An interview dependency failed",
+			HttpStatus.BAD_GATEWAY),
+	FINALIZATION_FAILED(
+			"INTERVIEW_FINALIZATION_FAILED",
+			"Interview assets could not be finalized",
+			HttpStatus.BAD_GATEWAY),
+	EXECUTOR_REJECTED(
+			"INTERVIEW_EXECUTOR_REJECTED",
+			"Interview processing capacity is temporarily unavailable",
+			HttpStatus.SERVICE_UNAVAILABLE),
+	SERVICE_UNAVAILABLE(
+			"INTERVIEW_SERVICE_UNAVAILABLE",
+			"Interview service is temporarily unavailable",
+			HttpStatus.SERVICE_UNAVAILABLE);
+
+	private final String code;
+	private final String defaultMessage;
+	private final HttpStatus status;
+
+	InterviewErrorCode(String code, String defaultMessage, HttpStatus status) {
+		this.code = code;
+		this.defaultMessage = defaultMessage;
+		this.status = status;
+	}
+
+	public String code() { return code; }
+	public String defaultMessage() { return defaultMessage; }
+	public HttpStatus status() { return status; }
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewException.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewException.java
@@ -1,0 +1,29 @@
+package com.unispeaking.common.exception.interview;
+
+import com.unispeaking.common.exception.BusinessException;
+import java.util.Objects;
+
+public final class InterviewException extends BusinessException {
+
+	private final InterviewErrorCode errorCode;
+
+	public InterviewException(InterviewErrorCode errorCode) {
+		this(errorCode, null);
+	}
+
+	public InterviewException(InterviewErrorCode errorCode, Throwable cause) {
+		super(required(errorCode).code(), errorCode.defaultMessage());
+		this.errorCode = errorCode;
+		if (cause != null) {
+			initCause(cause);
+		}
+	}
+
+	public InterviewErrorCode errorCode() {
+		return errorCode;
+	}
+
+	private static InterviewErrorCode required(InterviewErrorCode errorCode) {
+		return Objects.requireNonNull(errorCode, "errorCode must not be null");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewInputExceptionMapper.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/exception/interview/InterviewInputExceptionMapper.java
@@ -1,0 +1,42 @@
+package com.unispeaking.common.exception.interview;
+
+import com.unispeaking.common.exception.document.DocumentErrorCode;
+import com.unispeaking.common.exception.document.DocumentException;
+import com.unispeaking.common.exception.ocr.OcrErrorCode;
+import com.unispeaking.common.exception.ocr.OcrException;
+import java.util.Objects;
+
+/**
+ * Maps reusable document and OCR failures to the stable Interview API boundary.
+ */
+public final class InterviewInputExceptionMapper {
+
+	private InterviewInputExceptionMapper() {
+	}
+
+	public static InterviewException fromDocument(DocumentException exception) {
+		Objects.requireNonNull(exception, "exception must not be null");
+		DocumentErrorCode errorCode = exception.errorCode();
+		InterviewErrorCode mapped = switch (errorCode) {
+			case INPUT_REQUIRED, CONTENT_INVALID, PDF_PAGE_LIMIT_EXCEEDED,
+					TEXT_EMPTY, TEXT_TOO_LARGE -> InterviewErrorCode.INPUT_INVALID;
+			case TOO_LARGE -> InterviewErrorCode.PAYLOAD_TOO_LARGE;
+			case FORMAT_UNSUPPORTED -> InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED;
+		};
+		return new InterviewException(mapped, exception);
+	}
+
+	public static InterviewException fromOcr(OcrException exception) {
+		Objects.requireNonNull(exception, "exception must not be null");
+		OcrErrorCode errorCode = exception.errorCode();
+		InterviewErrorCode mapped = switch (errorCode) {
+			case INPUT_REQUIRED, TOO_MANY_IMAGES, CONTENT_INVALID, PIXEL_LIMIT_EXCEEDED ->
+					InterviewErrorCode.INPUT_INVALID;
+			case TOTAL_SIZE_EXCEEDED -> InterviewErrorCode.PAYLOAD_TOO_LARGE;
+			case FORMAT_UNSUPPORTED -> InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED;
+			case UNAVAILABLE -> InterviewErrorCode.SERVICE_UNAVAILABLE;
+			case TIMEOUT, PROCESS_FAILED, RESPONSE_INVALID -> InterviewErrorCode.DEPENDENCY_FAILED;
+		};
+		return new InterviewException(mapped, exception);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ActiveSessionRegistry.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ActiveSessionRegistry.java
@@ -1,6 +1,7 @@
 package com.unispeaking.component.session;
 
 import com.unispeaking.domain.po.session.AbstractSceneSession;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
@@ -26,6 +27,16 @@ public class ActiveSessionRegistry {
 
 	public Optional<AbstractSceneSession> findById(String sessionId) {
 		return Optional.ofNullable(sessions.get(sessionId));
+	}
+
+	public <T extends AbstractSceneSession> Optional<T> findById(
+			String sessionId,
+			Class<T> sessionType) {
+		return findById(sessionId).filter(sessionType::isInstance).map(sessionType::cast);
+	}
+
+	public List<AbstractSceneSession> snapshot() {
+		return List.copyOf(sessions.values());
 	}
 
 	public void remove(String sessionId) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewCleanup.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewCleanup.java
@@ -1,0 +1,12 @@
+package com.unispeaking.component.session;
+
+@FunctionalInterface
+public interface ExpiredInterviewCleanup {
+
+	/**
+	 * Handles the cross-service effects for an interview that can no longer be
+	 * resumed: fail its practice session, complete its flow as unsuccessful,
+	 * delete the unfinished interview, and remove remaining temporary data.
+	 */
+	void cleanup(ExpiredInterviewCleanupRequest request);
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewCleanupRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewCleanupRequest.java
@@ -1,0 +1,27 @@
+package com.unispeaking.component.session;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ExpiredInterviewCleanupRequest(
+		String sessionId,
+		String interviewId,
+		String userId,
+		Instant lastSeen,
+		Instant expiredAt) {
+
+	public ExpiredInterviewCleanupRequest {
+		sessionId = requireText(sessionId, "sessionId");
+		interviewId = requireText(interviewId, "interviewId");
+		userId = requireText(userId, "userId");
+		lastSeen = Objects.requireNonNull(lastSeen, "lastSeen");
+		expiredAt = Objects.requireNonNull(expiredAt, "expiredAt");
+	}
+
+	private static String requireText(String value, String name) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+		return value.trim();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewSubmissionCleanup.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewSubmissionCleanup.java
@@ -1,0 +1,7 @@
+package com.unispeaking.component.session;
+
+@FunctionalInterface
+public interface ExpiredInterviewSubmissionCleanup {
+
+	void cleanup(ExpiredInterviewSubmissionCleanupRequest request);
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewSubmissionCleanupRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/ExpiredInterviewSubmissionCleanupRequest.java
@@ -1,0 +1,27 @@
+package com.unispeaking.component.session;
+
+import java.time.Instant;
+import java.util.Objects;
+
+public record ExpiredInterviewSubmissionCleanupRequest(
+		String sessionId,
+		String interviewId,
+		String submissionId,
+		Instant acceptedAt,
+		Instant deadline) {
+
+	public ExpiredInterviewSubmissionCleanupRequest {
+		sessionId = requireText(sessionId, "sessionId");
+		interviewId = requireText(interviewId, "interviewId");
+		submissionId = requireText(submissionId, "submissionId");
+		acceptedAt = Objects.requireNonNull(acceptedAt, "acceptedAt");
+		deadline = Objects.requireNonNull(deadline, "deadline");
+	}
+
+	private static String requireText(String value, String name) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+		return value.trim();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionCoordinator.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionCoordinator.java
@@ -1,0 +1,240 @@
+package com.unispeaking.component.session;
+
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InterviewExecutionCoordinator {
+
+	private final Executor executor;
+	private final Runnable stateReadBarrier;
+	private final ConcurrentHashMap<String, Slot> slots = new ConcurrentHashMap<>();
+
+	@Autowired
+	public InterviewExecutionCoordinator(
+			@Qualifier("interviewTaskExecutor") Executor executor) {
+		this(executor, () -> { });
+	}
+
+	InterviewExecutionCoordinator(Executor executor, Runnable stateReadBarrier) {
+		this.executor = Objects.requireNonNull(executor, "executor");
+		this.stateReadBarrier = Objects.requireNonNull(stateReadBarrier, "stateReadBarrier");
+	}
+
+	public <T> T withLock(String interviewId, Supplier<T> action) {
+		String requiredId = requireInterviewId(interviewId);
+		Objects.requireNonNull(action, "action");
+		Slot slot = retain(requiredId);
+		slot.lock();
+		try {
+			return action.get();
+		} finally {
+			slot.unlock();
+			release(requiredId, slot);
+		}
+	}
+
+	public void withLock(String interviewId, Runnable action) {
+		Objects.requireNonNull(action, "action");
+		withLock(interviewId, () -> {
+			action.run();
+			return null;
+		});
+	}
+
+	public void execute(
+			String interviewId,
+			InterviewTaskType taskType,
+			Runnable task) {
+		String requiredId = requireInterviewId(interviewId);
+		InterviewTaskType requiredType = Objects.requireNonNull(taskType, "taskType");
+		Objects.requireNonNull(task, "task");
+		Slot slot = retain(requiredId);
+		QueuedTask queuedTask = new QueuedTask(requiredType, task);
+		boolean scheduleDrain = slot.enqueue(queuedTask);
+		if (!scheduleDrain) {
+			return;
+		}
+		try {
+			executor.execute(() -> drain(requiredId, slot));
+			slot.completeScheduling();
+		} catch (RuntimeException | Error exception) {
+			slot.rejectScheduling(queuedTask);
+			release(requiredId, slot);
+			throw exception;
+		}
+	}
+
+	public InterviewExecutionState state(String interviewId) {
+		String requiredId = requireInterviewId(interviewId);
+		Slot slot = retain(requiredId);
+		try {
+			stateReadBarrier.run();
+			return slot.state();
+		} finally {
+			release(requiredId, slot);
+		}
+	}
+
+	public boolean isBusy(String interviewId) {
+		return state(interviewId).busy();
+	}
+
+	private void drain(String interviewId, Slot slot) {
+		Throwable firstFailure = null;
+		QueuedTask task;
+		while ((task = slot.nextTask()) != null) {
+			slot.lock();
+			try {
+				task.action().run();
+			} catch (RuntimeException | Error failure) {
+				if (firstFailure == null) {
+					firstFailure = failure;
+				}
+			} finally {
+				slot.unlock();
+				slot.completeTask(task.type());
+				release(interviewId, slot);
+			}
+		}
+		if (firstFailure instanceof Error error) {
+			throw error;
+		}
+		if (firstFailure instanceof RuntimeException exception) {
+			throw exception;
+		}
+	}
+
+	private Slot retain(String interviewId) {
+		return slots.compute(interviewId, (key, existing) -> {
+			Slot slot = existing == null ? new Slot() : existing;
+			slot.retain();
+			return slot;
+		});
+	}
+
+	private void release(String interviewId, Slot expected) {
+		slots.computeIfPresent(interviewId, (key, existing) -> {
+			if (existing != expected) {
+				return existing;
+			}
+			return existing.release() ? null : existing;
+		});
+	}
+
+	private static String requireInterviewId(String interviewId) {
+		if (interviewId == null || interviewId.isBlank()) {
+			throw new IllegalArgumentException("interviewId must not be blank");
+		}
+		return interviewId.trim();
+	}
+
+	private static final class Slot {
+
+		private final ReentrantLock lock = new ReentrantLock(true);
+		private final Deque<QueuedTask> tasks = new ArrayDeque<>();
+		private int references;
+		private int processingTasks;
+		private int finalizingTasks;
+		private boolean drainScheduled;
+		private boolean scheduling;
+
+		private void lock() {
+			lock.lock();
+		}
+
+		private void unlock() {
+			lock.unlock();
+		}
+
+		private synchronized void retain() {
+			references++;
+		}
+
+		private synchronized boolean release() {
+			if (references < 1) {
+				throw new IllegalStateException("interview execution slot is not retained");
+			}
+			return --references == 0;
+		}
+
+		private synchronized boolean enqueue(QueuedTask task) {
+			waitForSchedulingAttempt();
+			tasks.addLast(task);
+			if (task.type() == InterviewTaskType.PROCESSING) {
+				processingTasks++;
+			} else {
+				finalizingTasks++;
+			}
+			if (drainScheduled) {
+				return false;
+			}
+			drainScheduled = true;
+			scheduling = true;
+			return true;
+		}
+
+		private synchronized QueuedTask nextTask() {
+			QueuedTask task = tasks.pollFirst();
+			if (task == null) {
+				drainScheduled = false;
+			}
+			return task;
+		}
+
+		private synchronized void completeScheduling() {
+			scheduling = false;
+			notifyAll();
+		}
+
+		private synchronized void rejectScheduling(QueuedTask expected) {
+			if (!tasks.removeFirstOccurrence(expected)) {
+				throw new IllegalStateException("rejected interview task is not queued");
+			}
+			decrementTaskCount(expected.type());
+			drainScheduled = false;
+			scheduling = false;
+			notifyAll();
+		}
+
+		private synchronized void completeTask(InterviewTaskType taskType) {
+			decrementTaskCount(taskType);
+		}
+
+		private void decrementTaskCount(InterviewTaskType taskType) {
+			if (taskType == InterviewTaskType.PROCESSING) {
+				processingTasks--;
+			} else {
+				finalizingTasks--;
+			}
+		}
+
+		private void waitForSchedulingAttempt() {
+			boolean interrupted = false;
+			while (scheduling) {
+				try {
+					wait();
+				} catch (InterruptedException exception) {
+					interrupted = true;
+				}
+			}
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
+		private synchronized InterviewExecutionState state() {
+			return new InterviewExecutionState(processingTasks, finalizingTasks);
+		}
+	}
+
+	private record QueuedTask(InterviewTaskType type, Runnable action) { }
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionCoordinator.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionCoordinator.java
@@ -1,12 +1,24 @@
 package com.unispeaking.component.session;
 
+import com.unispeaking.domain.po.session.InterviewSubmission;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -14,18 +26,37 @@ import org.springframework.stereotype.Component;
 @Component
 public class InterviewExecutionCoordinator {
 
+	private static final Logger LOGGER = LoggerFactory.getLogger(
+			InterviewExecutionCoordinator.class);
+
 	private final Executor executor;
+	private final Clock clock;
 	private final Runnable stateReadBarrier;
 	private final ConcurrentHashMap<String, Slot> slots = new ConcurrentHashMap<>();
+	private final ConcurrentLinkedQueue<PendingTimeoutCallback> pendingTimeoutCallbacks =
+			new ConcurrentLinkedQueue<>();
 
 	@Autowired
 	public InterviewExecutionCoordinator(
-			@Qualifier("interviewTaskExecutor") Executor executor) {
-		this(executor, () -> { });
+			@Qualifier("interviewTaskExecutor") Executor executor,
+			@Qualifier("interviewClock") Clock clock) {
+		this(executor, clock, () -> { });
 	}
 
 	InterviewExecutionCoordinator(Executor executor, Runnable stateReadBarrier) {
+		this(executor, Clock.systemUTC(), stateReadBarrier);
+	}
+
+	InterviewExecutionCoordinator(Executor executor) {
+		this(executor, Clock.systemUTC(), () -> { });
+	}
+
+	InterviewExecutionCoordinator(
+			Executor executor,
+			Clock clock,
+			Runnable stateReadBarrier) {
 		this.executor = Objects.requireNonNull(executor, "executor");
+		this.clock = Objects.requireNonNull(clock, "clock");
 		this.stateReadBarrier = Objects.requireNonNull(stateReadBarrier, "stateReadBarrier");
 	}
 
@@ -54,11 +85,88 @@ public class InterviewExecutionCoordinator {
 			String interviewId,
 			InterviewTaskType taskType,
 			Runnable task) {
+		executeUntil(
+				interviewId,
+				taskType,
+				clock.instant(),
+				InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT,
+				lease -> task.run(),
+				() -> { });
+	}
+
+	public void executeSubmission(
+			String interviewId,
+			InterviewSubmission submission,
+			GuardedTask task,
+			Runnable temporaryDataCleanup) {
+		InterviewSubmission requiredSubmission = Objects.requireNonNull(
+				submission, "submission");
+		Runnable requiredCleanup = Objects.requireNonNull(
+				temporaryDataCleanup, "temporaryDataCleanup");
+		executeUntil(
+				interviewId,
+				InterviewTaskType.PROCESSING,
+				requiredSubmission.acceptedAt(),
+				InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT,
+				task,
+				() -> {
+					requiredSubmission.markTimedOut(
+							true,
+							"INTERVIEW_SUBMISSION_TIMEOUT",
+							"Interview submission exceeded its processing deadline",
+							clock.instant());
+				},
+				requiredCleanup);
+	}
+
+	public void executeFinalizer(
+			String interviewId,
+			Instant startedAt,
+			GuardedTask task,
+			Runnable timeoutHandler) {
+		executeUntil(
+				interviewId,
+				InterviewTaskType.FINALIZING,
+				startedAt,
+				InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT,
+				task,
+				timeoutHandler);
+	}
+
+	public void executeUntil(
+			String interviewId,
+			InterviewTaskType taskType,
+			Instant startedAt,
+			Duration requestedTimeout,
+			GuardedTask task,
+			Runnable timeoutHandler) {
+		executeUntil(
+				interviewId,
+				taskType,
+				startedAt,
+				requestedTimeout,
+				task,
+				timeoutHandler,
+				() -> { });
+	}
+
+	private void executeUntil(
+			String interviewId,
+			InterviewTaskType taskType,
+			Instant startedAt,
+			Duration requestedTimeout,
+			GuardedTask task,
+			Runnable timeoutHandler,
+			Runnable timeoutCleanup) {
 		String requiredId = requireInterviewId(interviewId);
 		InterviewTaskType requiredType = Objects.requireNonNull(taskType, "taskType");
+		Instant deadline = deadline(startedAt, requestedTimeout);
 		Objects.requireNonNull(task, "task");
+		Objects.requireNonNull(timeoutHandler, "timeoutHandler");
+		Objects.requireNonNull(timeoutCleanup, "timeoutCleanup");
 		Slot slot = retain(requiredId);
-		QueuedTask queuedTask = new QueuedTask(requiredType, task);
+		QueuedTask queuedTask = new QueuedTask(
+				requiredType, deadline, task, timeoutHandler, timeoutCleanup);
 		boolean scheduleDrain = slot.enqueue(queuedTask);
 		if (!scheduleDrain) {
 			return;
@@ -71,6 +179,36 @@ public class InterviewExecutionCoordinator {
 			release(requiredId, slot);
 			throw exception;
 		}
+	}
+
+	public int expireTasks(Instant now) {
+		Instant requiredNow = Objects.requireNonNull(now, "now");
+		retryPendingTimeoutCallbacks();
+		List<ExpiredTask> expired = new ArrayList<>();
+		for (var entry : slots.entrySet()) {
+			Slot slot = entry.getValue();
+			for (QueuedTask task : slot.expire(requiredNow)) {
+				expired.add(new ExpiredTask(entry.getKey(), slot, task));
+			}
+		}
+		for (ExpiredTask task : expired) {
+			if (task.queued()) {
+				release(task.interviewId(), task.slot());
+			}
+			runTimeoutCallback(
+					task.interviewId(), task.task().type(), task.task().timeoutHandler());
+			if (task.queued()) {
+				runTimeoutCallback(
+						task.interviewId(), task.task().type(), task.task().timeoutCleanup());
+			}
+		}
+		return expired.size();
+	}
+
+	public boolean hasPendingTimeoutCallback(String interviewId) {
+		String requiredId = requireInterviewId(interviewId);
+		return pendingTimeoutCallbacks.stream()
+				.anyMatch(callback -> callback.interviewId().equals(requiredId));
 	}
 
 	public InterviewExecutionState state(String interviewId) {
@@ -88,21 +226,43 @@ public class InterviewExecutionCoordinator {
 		return state(interviewId).busy();
 	}
 
+	public boolean runIfIdle(String interviewId, Runnable maintenance) {
+		String requiredId = requireInterviewId(interviewId);
+		Objects.requireNonNull(maintenance, "maintenance");
+		Slot slot = retain(requiredId);
+		if (!slot.beginMaintenance()) {
+			release(requiredId, slot);
+			return false;
+		}
+		try {
+			maintenance.run();
+			return true;
+		} finally {
+			slot.endMaintenance();
+			release(requiredId, slot);
+		}
+	}
+
 	private void drain(String interviewId, Slot slot) {
 		Throwable firstFailure = null;
 		QueuedTask task;
 		while ((task = slot.nextTask()) != null) {
 			slot.lock();
 			try {
-				task.action().run();
+				if (task.shouldRun()) {
+					task.action().run(new TaskLease(task));
+				}
 			} catch (RuntimeException | Error failure) {
 				if (firstFailure == null) {
 					firstFailure = failure;
 				}
 			} finally {
 				slot.unlock();
-				slot.completeTask(task.type());
+				Runnable deferredCleanup = slot.completeTask(task);
 				release(interviewId, slot);
+				if (deferredCleanup != null) {
+					runTimeoutCallback(interviewId, task.type(), deferredCleanup);
+				}
 			}
 		}
 		if (firstFailure instanceof Error error) {
@@ -111,6 +271,51 @@ public class InterviewExecutionCoordinator {
 		if (firstFailure instanceof RuntimeException exception) {
 			throw exception;
 		}
+	}
+
+	private void runTimeoutCallback(
+			String interviewId,
+			InterviewTaskType taskType,
+			Runnable callback) {
+		try {
+			callback.run();
+		} catch (RuntimeException | Error exception) {
+			PendingTimeoutCallback pending = new PendingTimeoutCallback(
+					interviewId, taskType, callback);
+			pendingTimeoutCallbacks.offer(pending);
+			logTimeoutCallbackFailure(pending, exception);
+		}
+	}
+
+	private void retryPendingTimeoutCallbacks() {
+		for (PendingTimeoutCallback pending : List.copyOf(pendingTimeoutCallbacks)) {
+			if (!pending.tryStart()) {
+				continue;
+			}
+			boolean completed = false;
+			try {
+				pending.callback().run();
+				completed = true;
+			} catch (RuntimeException | Error exception) {
+				logTimeoutCallbackFailure(pending, exception);
+			} finally {
+				if (completed) {
+					pendingTimeoutCallbacks.remove(pending);
+				} else {
+					pending.finishAttempt();
+				}
+			}
+		}
+	}
+
+	private static void logTimeoutCallbackFailure(
+			PendingTimeoutCallback pending,
+			Throwable exception) {
+		LOGGER.warn(
+				"Interview timeout callback failed interviewId={} taskType={}",
+				pending.interviewId(),
+				pending.taskType(),
+				exception);
 	}
 
 	private Slot retain(String interviewId) {
@@ -137,15 +342,53 @@ public class InterviewExecutionCoordinator {
 		return interviewId.trim();
 	}
 
+	@FunctionalInterface
+	public interface GuardedTask {
+		void run(TaskLease lease);
+	}
+
+	public static final class TaskLease {
+
+		private final QueuedTask task;
+
+		private TaskLease(QueuedTask task) {
+			this.task = task;
+		}
+
+		public boolean isActive() {
+			return task.isActive();
+		}
+
+		public boolean commitIfActive(Runnable commit) {
+			return task.commitIfActive(commit);
+		}
+	}
+
+	private static Instant deadline(Instant startedAt, Duration requestedTimeout) {
+		Instant requiredStart = Objects.requireNonNull(startedAt, "startedAt");
+		Duration requiredTimeout = Objects.requireNonNull(requestedTimeout, "requestedTimeout");
+		if (requiredTimeout.isZero() || requiredTimeout.isNegative()) {
+			throw new IllegalArgumentException("requestedTimeout must be positive");
+		}
+		Duration boundedTimeout = requiredTimeout.compareTo(
+				InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT) > 0
+						? InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT
+						: requiredTimeout;
+		return requiredStart.plus(boundedTimeout);
+	}
+
 	private static final class Slot {
 
 		private final ReentrantLock lock = new ReentrantLock(true);
 		private final Deque<QueuedTask> tasks = new ArrayDeque<>();
+		private final Set<QueuedTask> trackedTasks = new HashSet<>();
 		private int references;
 		private int processingTasks;
 		private int finalizingTasks;
+		private int runningTasks;
 		private boolean drainScheduled;
 		private boolean scheduling;
+		private boolean maintenance;
 
 		private void lock() {
 			lock.lock();
@@ -167,8 +410,9 @@ public class InterviewExecutionCoordinator {
 		}
 
 		private synchronized boolean enqueue(QueuedTask task) {
-			waitForSchedulingAttempt();
+			waitForAdmission();
 			tasks.addLast(task);
+			trackedTasks.add(task);
 			if (task.type() == InterviewTaskType.PROCESSING) {
 				processingTasks++;
 			} else {
@@ -186,6 +430,9 @@ public class InterviewExecutionCoordinator {
 			QueuedTask task = tasks.pollFirst();
 			if (task == null) {
 				drainScheduled = false;
+			} else {
+				task.markStarted();
+				runningTasks++;
 			}
 			return task;
 		}
@@ -200,13 +447,55 @@ public class InterviewExecutionCoordinator {
 				throw new IllegalStateException("rejected interview task is not queued");
 			}
 			decrementTaskCount(expected.type());
+			trackedTasks.remove(expected);
 			drainScheduled = false;
 			scheduling = false;
 			notifyAll();
 		}
 
-		private synchronized void completeTask(InterviewTaskType taskType) {
-			decrementTaskCount(taskType);
+		private synchronized Runnable completeTask(QueuedTask task) {
+			if (task.completeOccupancy()) {
+				decrementTaskCount(task.type());
+			}
+			runningTasks--;
+			trackedTasks.remove(task);
+			return task.claimDeferredTimeoutCleanup();
+		}
+
+		private synchronized List<QueuedTask> expire(Instant now) {
+			waitForSchedulingAttempt();
+			List<QueuedTask> expired = new ArrayList<>();
+			for (QueuedTask task : List.copyOf(trackedTasks)) {
+				if (!task.deadline().isAfter(now) && task.expire()) {
+					decrementTaskCount(task.type());
+					task.queued(tasks.remove(task));
+					if (task.queued()) {
+						trackedTasks.remove(task);
+					}
+					expired.add(task);
+				}
+			}
+			return expired;
+		}
+
+		private synchronized boolean beginMaintenance() {
+			waitForSchedulingAttempt();
+			if (processingTasks > 0
+					|| finalizingTasks > 0
+					|| runningTasks > 0
+					|| maintenance) {
+				return false;
+			}
+			maintenance = true;
+			return true;
+		}
+
+		private synchronized void endMaintenance() {
+			if (!maintenance) {
+				throw new IllegalStateException("interview maintenance is not active");
+			}
+			maintenance = false;
+			notifyAll();
 		}
 
 		private void decrementTaskCount(InterviewTaskType taskType) {
@@ -231,10 +520,133 @@ public class InterviewExecutionCoordinator {
 			}
 		}
 
+		private void waitForAdmission() {
+			boolean interrupted = false;
+			while (scheduling || maintenance) {
+				try {
+					wait();
+				} catch (InterruptedException exception) {
+					interrupted = true;
+				}
+			}
+			if (interrupted) {
+				Thread.currentThread().interrupt();
+			}
+		}
+
 		private synchronized InterviewExecutionState state() {
 			return new InterviewExecutionState(processingTasks, finalizingTasks);
 		}
 	}
 
-	private record QueuedTask(InterviewTaskType type, Runnable action) { }
+	private static final class QueuedTask {
+
+		private final InterviewTaskType type;
+		private final Instant deadline;
+		private final GuardedTask action;
+		private final Runnable timeoutHandler;
+		private final Runnable timeoutCleanup;
+		private boolean occupancyActive = true;
+		private boolean queued;
+		private boolean started;
+		private boolean committed;
+		private boolean expired;
+		private boolean timeoutCleanupClaimed;
+
+		private QueuedTask(
+				InterviewTaskType type,
+				Instant deadline,
+				GuardedTask action,
+				Runnable timeoutHandler,
+				Runnable timeoutCleanup) {
+			this.type = type;
+			this.deadline = deadline;
+			this.action = action;
+			this.timeoutHandler = timeoutHandler;
+			this.timeoutCleanup = timeoutCleanup;
+		}
+
+		private InterviewTaskType type() { return type; }
+		private Instant deadline() { return deadline; }
+		private GuardedTask action() { return action; }
+		private Runnable timeoutHandler() { return timeoutHandler; }
+		private Runnable timeoutCleanup() { return timeoutCleanup; }
+
+		private synchronized void markStarted() { started = true; }
+
+		private synchronized boolean expire() {
+			if (!occupancyActive || committed) {
+				return false;
+			}
+			occupancyActive = false;
+			expired = true;
+			return true;
+		}
+
+		private synchronized boolean completeOccupancy() {
+			if (!occupancyActive) {
+				return false;
+			}
+			occupancyActive = false;
+			return true;
+		}
+
+		private synchronized boolean isActive() {
+			return occupancyActive && !committed;
+		}
+
+		private synchronized boolean commitIfActive(Runnable commit) {
+			Objects.requireNonNull(commit, "commit");
+			if (!occupancyActive || committed) {
+				return false;
+			}
+			commit.run();
+			committed = true;
+			return true;
+		}
+
+		private synchronized Runnable claimDeferredTimeoutCleanup() {
+			if (!expired || !started || timeoutCleanupClaimed) {
+				return null;
+			}
+			timeoutCleanupClaimed = true;
+			return timeoutCleanup;
+		}
+
+		private synchronized boolean shouldRun() { return occupancyActive; }
+
+		private synchronized void queued(boolean value) { queued = value; }
+		private synchronized boolean queued() { return queued; }
+	}
+
+	private record ExpiredTask(
+			String interviewId,
+			Slot slot,
+			QueuedTask task) {
+
+		private boolean queued() { return task.queued(); }
+	}
+
+	private static final class PendingTimeoutCallback {
+
+		private final String interviewId;
+		private final InterviewTaskType taskType;
+		private final Runnable callback;
+		private final AtomicBoolean executing = new AtomicBoolean();
+
+		private PendingTimeoutCallback(
+				String interviewId,
+				InterviewTaskType taskType,
+				Runnable callback) {
+			this.interviewId = interviewId;
+			this.taskType = taskType;
+			this.callback = callback;
+		}
+
+		private String interviewId() { return interviewId; }
+		private InterviewTaskType taskType() { return taskType; }
+		private Runnable callback() { return callback; }
+		private boolean tryStart() { return executing.compareAndSet(false, true); }
+		private void finishAttempt() { executing.set(false); }
+	}
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionState.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewExecutionState.java
@@ -1,0 +1,20 @@
+package com.unispeaking.component.session;
+
+public record InterviewExecutionState(
+		int processingTasks,
+		int finalizingTasks) {
+
+	public InterviewExecutionState {
+		if (processingTasks < 0 || finalizingTasks < 0) {
+			throw new IllegalArgumentException("task counts must not be negative");
+		}
+	}
+
+	public boolean busy() {
+		return processingTasks > 0 || finalizingTasks > 0;
+	}
+
+	public static InterviewExecutionState idle() {
+		return new InterviewExecutionState(0, 0);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewRuntimePolicy.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewRuntimePolicy.java
@@ -1,0 +1,42 @@
+package com.unispeaking.component.session;
+
+import java.time.Duration;
+import java.util.Objects;
+
+public record InterviewRuntimePolicy(
+		Duration idleTimeout,
+		Duration recoveryWindow,
+		Duration taskTimeout,
+		Duration scanInterval) {
+
+	public static final Duration MAXIMUM_TASK_TIMEOUT = Duration.ofMinutes(10);
+
+	public InterviewRuntimePolicy {
+		idleTimeout = requirePositive(idleTimeout, "idleTimeout");
+		recoveryWindow = requirePositive(recoveryWindow, "recoveryWindow");
+		taskTimeout = requirePositive(taskTimeout, "taskTimeout");
+		scanInterval = requirePositive(scanInterval, "scanInterval");
+		if (taskTimeout.compareTo(MAXIMUM_TASK_TIMEOUT) > 0) {
+			throw new IllegalArgumentException("taskTimeout must not exceed 10 minutes");
+		}
+		if (idleTimeout.compareTo(recoveryWindow) >= 0) {
+			throw new IllegalArgumentException("idleTimeout must be shorter than recoveryWindow");
+		}
+	}
+
+	public static InterviewRuntimePolicy defaults() {
+		return new InterviewRuntimePolicy(
+				Duration.ofMinutes(1),
+				Duration.ofMinutes(10),
+				MAXIMUM_TASK_TIMEOUT,
+				Duration.ofMinutes(1));
+	}
+
+	private static Duration requirePositive(Duration value, String name) {
+		Duration required = Objects.requireNonNull(value, name);
+		if (required.isZero() || required.isNegative()) {
+			throw new IllegalArgumentException(name + " must be positive");
+		}
+		return required;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewRuntimeSupervisor.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewRuntimeSupervisor.java
@@ -1,0 +1,347 @@
+package com.unispeaking.component.session;
+
+import com.unispeaking.domain.po.session.AbstractSceneSession;
+import com.unispeaking.domain.po.session.InterviewSession;
+import com.unispeaking.domain.po.session.InterviewSubmission;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.time.Clock;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class InterviewRuntimeSupervisor implements AutoCloseable {
+
+	private static final Logger LOGGER = LoggerFactory.getLogger(
+			InterviewRuntimeSupervisor.class);
+
+	private final ActiveSessionRegistry sessions;
+	private final InterviewExecutionCoordinator coordinator;
+	private final Clock clock;
+	private final InterviewRuntimePolicy policy;
+	private final ScheduledExecutorService scheduler;
+	private final List<ExpiredInterviewCleanup> cleanupPorts;
+	private final List<ExpiredInterviewSubmissionCleanup> submissionCleanupPorts;
+	private final ConcurrentHashMap<SubmissionCleanupKey, PendingSubmissionCleanup>
+			pendingSubmissionCleanups = new ConcurrentHashMap<>();
+	private ScheduledFuture<?> scanTask;
+
+	public InterviewRuntimeSupervisor(
+			ActiveSessionRegistry sessions,
+			InterviewExecutionCoordinator coordinator,
+			@Qualifier("interviewClock") Clock clock,
+			InterviewRuntimePolicy policy,
+			@Qualifier("interviewWatchdogScheduler") ScheduledExecutorService scheduler,
+			List<ExpiredInterviewCleanup> cleanupPorts,
+			List<ExpiredInterviewSubmissionCleanup> submissionCleanupPorts) {
+		this.sessions = Objects.requireNonNull(sessions, "sessions");
+		this.coordinator = Objects.requireNonNull(coordinator, "coordinator");
+		this.clock = Objects.requireNonNull(clock, "clock");
+		this.policy = Objects.requireNonNull(policy, "policy");
+		this.scheduler = Objects.requireNonNull(scheduler, "scheduler");
+		this.cleanupPorts = List.copyOf(
+				Objects.requireNonNull(cleanupPorts, "cleanupPorts"));
+		this.submissionCleanupPorts = List.copyOf(
+				Objects.requireNonNull(submissionCleanupPorts, "submissionCleanupPorts"));
+	}
+
+	@PostConstruct
+	public synchronized void start() {
+		if (scanTask != null && !scanTask.isCancelled() && !scanTask.isDone()) {
+			return;
+		}
+		long intervalMillis = policy.scanInterval().toMillis();
+		scanTask = scheduler.scheduleAtFixedRate(
+				this::scanSafely,
+				intervalMillis,
+				intervalMillis,
+				TimeUnit.MILLISECONDS);
+	}
+
+	public Optional<InterviewSession> recordStateQuery(String sessionId) {
+		return recordActivity(sessionId);
+	}
+
+	public Optional<InterviewSession> recordHeartbeat(String sessionId) {
+		return recordActivity(sessionId);
+	}
+
+	public Optional<InterviewSession> recordBusinessActivity(String sessionId) {
+		return recordActivity(sessionId);
+	}
+
+	public int scan() {
+		Instant now = clock.instant();
+		retryPendingSubmissionCleanups();
+		int changes = coordinator.expireTasks(now);
+		for (AbstractSceneSession candidate : sessions.snapshot()) {
+			if (!(candidate instanceof InterviewSession session)) {
+				continue;
+			}
+			try {
+				changes += expireOrphanedSubmissions(session, now);
+				changes += scanSession(session, now);
+			} catch (RuntimeException | Error exception) {
+				LOGGER.warn(
+						"Interview runtime scan failed sessionId={} interviewId={}",
+						session.getId(),
+						session.interviewId(),
+						exception);
+			}
+		}
+		return changes;
+	}
+
+	private int expireOrphanedSubmissions(InterviewSession session, Instant now) {
+		int expired = 0;
+		for (InterviewSubmission submission : session.submissions()) {
+			Instant deadline = submission.acceptedAt().plus(policy.taskTimeout());
+			if (!submission.status().isInFlight() || now.isBefore(deadline)) {
+				continue;
+			}
+			ExpiredInterviewSubmissionCleanupRequest request =
+					new ExpiredInterviewSubmissionCleanupRequest(
+							session.getId(),
+							session.interviewId(),
+							submission.submissionId(),
+							submission.acceptedAt(),
+							deadline);
+			SubmissionCleanupKey key = new SubmissionCleanupKey(
+					request.sessionId(), request.submissionId());
+			PendingSubmissionCleanup pending = new PendingSubmissionCleanup(request);
+			if (pendingSubmissionCleanups.putIfAbsent(key, pending) != null) {
+				continue;
+			}
+			if (!submission.markTimedOut(
+					true,
+					"INTERVIEW_SUBMISSION_TIMEOUT",
+					"Interview submission exceeded its processing deadline",
+					now)) {
+				pendingSubmissionCleanups.remove(key, pending);
+				continue;
+			}
+			pending.markReady();
+			expired++;
+			attemptSubmissionCleanup(key, pending);
+		}
+		return expired;
+	}
+
+	private void retryPendingSubmissionCleanups() {
+		for (var entry : List.copyOf(pendingSubmissionCleanups.entrySet())) {
+			attemptSubmissionCleanup(entry.getKey(), entry.getValue());
+		}
+	}
+
+	private void attemptSubmissionCleanup(
+			SubmissionCleanupKey key,
+			PendingSubmissionCleanup pending) {
+		if (!pending.tryStart()) {
+			return;
+		}
+		boolean completed = false;
+		try {
+			completed = publishSubmissionCleanup(pending.request());
+		} finally {
+			if (completed) {
+				pendingSubmissionCleanups.remove(key, pending);
+			} else {
+				pending.finishAttempt();
+			}
+		}
+	}
+
+	public synchronized boolean isRunning() {
+		return scanTask != null && !scanTask.isCancelled() && !scanTask.isDone();
+	}
+
+	@PreDestroy
+	@Override
+	public synchronized void close() {
+		if (scanTask != null) {
+			scanTask.cancel(false);
+			scanTask = null;
+		}
+	}
+
+	private Optional<InterviewSession> recordActivity(String sessionId) {
+		String requiredId = requireSessionId(sessionId);
+		Optional<InterviewSession> found = sessions.findById(
+				requiredId, InterviewSession.class);
+		if (found.isEmpty()) {
+			found = sessions.snapshot().stream()
+					.filter(InterviewSession.class::isInstance)
+					.map(InterviewSession.class::cast)
+					.filter(session -> session.interviewId().equals(requiredId))
+					.findFirst();
+		}
+		if (found.isEmpty()) {
+			return Optional.empty();
+		}
+		InterviewSession session = found.orElseThrow();
+		Instant now = clock.instant();
+		synchronized (session) {
+			if (isTerminal(session.getStatus())) {
+				return Optional.empty();
+			}
+			if (session.expirationCleanupClaimed()) {
+				return Optional.empty();
+			}
+			if (session.getStatus() == SessionStatus.INTERRUPTED) {
+				Instant deadline = session.interruptedAt()
+						.orElse(session.lastSeen())
+						.plus(policy.recoveryWindow());
+				if (!now.isBefore(deadline)) {
+					return Optional.empty();
+				}
+				session.resume();
+			}
+			session.touch(now);
+		}
+		return Optional.of(session);
+	}
+
+	private int scanSession(InterviewSession session, Instant now) {
+		if (coordinator.hasPendingTimeoutCallback(session.interviewId())
+				|| hasPendingSubmissionCleanup(session.interviewId())) {
+			return 0;
+		}
+		int[] changes = new int[1];
+		boolean idle = coordinator.runIfIdle(
+				session.interviewId(),
+				() -> changes[0] = scanIdleSession(session, now));
+		return idle ? changes[0] : 0;
+	}
+
+	private int scanIdleSession(InterviewSession session, Instant now) {
+		if (session.hasInFlightSubmissions()) {
+			return 0;
+		}
+		ExpiredInterviewCleanupRequest cleanupRequest = null;
+		boolean interrupted = false;
+		synchronized (session) {
+			SessionStatus status = session.getStatus();
+			if (isTerminal(status)) {
+				return 0;
+			}
+			Instant lastSeen = session.lastSeen();
+			if (status == SessionStatus.INTERRUPTED
+					&& !now.isBefore(session.interruptedAt()
+							.orElse(lastSeen)
+							.plus(policy.recoveryWindow()))) {
+				if (!session.claimExpirationCleanup()) {
+					return 0;
+				}
+				cleanupRequest = new ExpiredInterviewCleanupRequest(
+						session.getId(),
+						session.interviewId(),
+						session.getUserId(),
+						lastSeen,
+						now);
+			} else if (status != SessionStatus.INTERRUPTED
+					&& !now.isBefore(lastSeen.plus(policy.idleTimeout()))) {
+				session.recordInterrupt(now);
+				interrupted = true;
+			}
+		}
+		if (cleanupRequest == null) {
+			return interrupted ? 1 : 0;
+		}
+		if (!publishCleanup(cleanupRequest)) {
+			session.releaseExpirationCleanupClaim();
+			return interrupted ? 1 : 0;
+		}
+		return sessions.remove(session.getId(), session) ? (interrupted ? 2 : 1) : 0;
+	}
+
+	private boolean hasPendingSubmissionCleanup(String interviewId) {
+		return pendingSubmissionCleanups.values().stream()
+				.anyMatch(pending -> pending.request().interviewId().equals(interviewId));
+	}
+
+	private boolean publishCleanup(ExpiredInterviewCleanupRequest request) {
+		boolean successful = true;
+		for (ExpiredInterviewCleanup cleanup : cleanupPorts) {
+			try {
+				cleanup.cleanup(request);
+			} catch (RuntimeException | Error exception) {
+				successful = false;
+				LOGGER.warn(
+						"Expired interview cleanup callback failed sessionId={} interviewId={}",
+						request.sessionId(),
+						request.interviewId(),
+						exception);
+			}
+		}
+		return successful;
+	}
+
+	private boolean publishSubmissionCleanup(
+			ExpiredInterviewSubmissionCleanupRequest request) {
+		boolean successful = true;
+		for (ExpiredInterviewSubmissionCleanup cleanup : submissionCleanupPorts) {
+			try {
+				cleanup.cleanup(request);
+			} catch (RuntimeException | Error exception) {
+				successful = false;
+				LOGGER.warn(
+						"Expired submission cleanup callback failed sessionId={} "
+								+ "interviewId={} submissionId={}",
+						request.sessionId(),
+						request.interviewId(),
+						request.submissionId(),
+						exception);
+			}
+		}
+		return successful;
+	}
+
+	private void scanSafely() {
+		try {
+			scan();
+		} catch (RuntimeException | Error exception) {
+			LOGGER.warn("Interview runtime scan failed", exception);
+		}
+	}
+
+	private static boolean isTerminal(SessionStatus status) {
+		return status == SessionStatus.COMPLETED || status == SessionStatus.FAILED;
+	}
+
+	private static String requireSessionId(String sessionId) {
+		if (sessionId == null || sessionId.isBlank()) {
+			throw new IllegalArgumentException("sessionId must not be blank");
+		}
+		return sessionId.trim();
+	}
+
+	private record SubmissionCleanupKey(String sessionId, String submissionId) { }
+
+	private static final class PendingSubmissionCleanup {
+
+		private final ExpiredInterviewSubmissionCleanupRequest request;
+		private final AtomicBoolean running = new AtomicBoolean();
+		private volatile boolean ready;
+
+		private PendingSubmissionCleanup(ExpiredInterviewSubmissionCleanupRequest request) {
+			this.request = request;
+		}
+
+		private ExpiredInterviewSubmissionCleanupRequest request() { return request; }
+		private void markReady() { ready = true; }
+		private boolean tryStart() { return ready && running.compareAndSet(false, true); }
+		private void finishAttempt() { running.set(false); }
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewTaskType.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/InterviewTaskType.java
@@ -1,0 +1,6 @@
+package com.unispeaking.component.session;
+
+public enum InterviewTaskType {
+	PROCESSING,
+	FINALIZING
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewRequest.java
@@ -1,0 +1,13 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record CreateInterviewRequest(
+		@NotBlank @Size(max = 255) String jobTitle,
+		@NotNull InterviewDifficulty difficulty,
+		@Size(max = 5000) String jobDescription,
+		@Size(max = 20000) String resumeText) implements InterviewApiRequest {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewRequest.java
@@ -8,6 +8,6 @@ import jakarta.validation.constraints.Size;
 public record CreateInterviewRequest(
 		@NotBlank @Size(max = 255) String jobTitle,
 		@NotNull InterviewDifficulty difficulty,
-		@Size(max = 5000) String jobDescription,
-		@Size(max = 20000) String resumeText) implements InterviewApiRequest {
+		String jobDescription,
+		String resumeText) implements InterviewApiRequest {
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/CreateInterviewResponse.java
@@ -1,0 +1,13 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.TargetRoleSummary;
+
+public record CreateInterviewResponse(
+		String interviewId,
+		String sessionId,
+		InterviewDifficulty difficulty,
+		InterviewRuntimeStatus status,
+		TargetRoleSummary roleSummary,
+		InterviewAiQuestionResponse firstQuestion) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DeleteInterviewResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DeleteInterviewResponse.java
@@ -1,0 +1,6 @@
+package com.unispeaking.domain.dto.scene;
+
+public record DeleteInterviewResponse(
+		String interviewId,
+		boolean deleted) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/EndInterviewRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/EndInterviewRequest.java
@@ -1,0 +1,7 @@
+package com.unispeaking.domain.dto.scene;
+
+import jakarta.validation.constraints.NotNull;
+
+public record EndInterviewRequest(
+		@NotNull Boolean confirmInsufficientData) implements InterviewApiRequest {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/EndInterviewResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/EndInterviewResponse.java
@@ -1,0 +1,12 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+
+public record EndInterviewResponse(
+		String interviewId,
+		InterviewEndStatus processingStatus,
+		InterviewReportType reportType,
+		boolean confirmationRequired,
+		int actualWords,
+		int minimumWords) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAiQuestionResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAiQuestionResponse.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewQuestionType;
+
+public record InterviewAiQuestionResponse(
+		int questionNo,
+		InterviewQuestionType questionType,
+		String text,
+		InterviewAudioResponse audio) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAnswerAcceptedResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAnswerAcceptedResponse.java
@@ -1,0 +1,6 @@
+package com.unispeaking.domain.dto.scene;
+
+public record InterviewAnswerAcceptedResponse(
+		InterviewSubmissionResponse submission,
+		String statePath) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAnswerRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAnswerRequest.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.dto.scene;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record InterviewAnswerRequest(
+		@NotBlank @Size(max = 64) String submissionId,
+		@Min(1) int questionNo) implements InterviewApiRequest {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewApiContractCatalog.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewApiContractCatalog.java
@@ -1,0 +1,52 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.util.List;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+public final class InterviewApiContractCatalog {
+
+	private static final String ROOT = "/api/interviews";
+
+	private static final List<InterviewEndpointContract> ENDPOINTS = List.of(
+			endpoint(HttpMethod.POST, ROOT + "/job-description/ocr", HttpStatus.OK,
+					Void.class, InterviewJobDescriptionOcrResponse.class),
+			endpoint(HttpMethod.POST, ROOT, HttpStatus.CREATED,
+					CreateInterviewRequest.class, CreateInterviewResponse.class),
+			endpoint(HttpMethod.POST, ROOT + "/{id}/answers", HttpStatus.ACCEPTED,
+					InterviewAnswerRequest.class, InterviewAnswerAcceptedResponse.class),
+			endpoint(HttpMethod.GET, ROOT + "/{id}/state", HttpStatus.OK,
+					Void.class, InterviewStateResponse.class),
+			endpoint(HttpMethod.POST, ROOT + "/{id}/heartbeat", HttpStatus.OK,
+					Void.class, InterviewHeartbeatResponse.class),
+			endpoint(HttpMethod.POST, ROOT + "/{id}/end", HttpStatus.ACCEPTED,
+					EndInterviewRequest.class, EndInterviewResponse.class),
+			endpoint(HttpMethod.GET, ROOT, HttpStatus.OK,
+					Void.class, InterviewHistoryResponse.class),
+			endpoint(HttpMethod.GET, ROOT + "/{id}", HttpStatus.OK,
+					Void.class, InterviewDetailResponse.class),
+			endpoint(HttpMethod.GET, ROOT + "/{id}/recording", HttpStatus.OK,
+					Void.class, InterviewRecordingResponse.class),
+			endpoint(HttpMethod.GET, ROOT + "/trends", HttpStatus.OK,
+					Void.class, InterviewTrendResponse.class),
+			endpoint(HttpMethod.POST, ROOT + "/{sourceId}/repractice", HttpStatus.CREATED,
+					Void.class, CreateInterviewResponse.class),
+			endpoint(HttpMethod.DELETE, ROOT + "/{id}", HttpStatus.OK,
+					Void.class, DeleteInterviewResponse.class));
+
+	private InterviewApiContractCatalog() {
+	}
+
+	public static List<InterviewEndpointContract> endpoints() {
+		return ENDPOINTS;
+	}
+
+	private static InterviewEndpointContract endpoint(
+			HttpMethod method,
+			String path,
+			HttpStatus status,
+			Class<?> requestType,
+			Class<?> responseType) {
+		return new InterviewEndpointContract(method, path, status, requestType, responseType);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewApiRequest.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewApiRequest.java
@@ -1,0 +1,4 @@
+package com.unispeaking.domain.dto.scene;
+
+public interface InterviewApiRequest {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAudioResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewAudioResponse.java
@@ -1,0 +1,17 @@
+package com.unispeaking.domain.dto.scene;
+
+public record InterviewAudioResponse(
+		String mimeType,
+		String base64) {
+
+	public InterviewAudioResponse {
+		requireText(mimeType, "mimeType");
+		requireText(base64, "base64");
+	}
+
+	private static void requireText(String value, String name) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewDetailResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewDetailResponse.java
@@ -1,0 +1,29 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.TargetRoleSummary;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Objects;
+
+public record InterviewDetailResponse(
+		String interviewId,
+		String jobTitle,
+		InterviewDifficulty difficulty,
+		TargetRoleSummary roleSummary,
+		List<InterviewQuestionResponse> questions,
+		InterviewReportResponse report,
+		InterviewRecordingMetadataResponse recording,
+		OffsetDateTime completedAt) {
+
+	public InterviewDetailResponse {
+		Objects.requireNonNull(roleSummary, "roleSummary");
+		questions = questions == null ? List.of() : List.copyOf(questions);
+		if (questions.isEmpty()) {
+			throw new IllegalArgumentException("questions must not be empty");
+		}
+		Objects.requireNonNull(report, "report");
+		Objects.requireNonNull(recording, "recording");
+		Objects.requireNonNull(completedAt, "completedAt");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewEndStatus.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewEndStatus.java
@@ -1,0 +1,9 @@
+package com.unispeaking.domain.dto.scene;
+
+public enum InterviewEndStatus {
+	WAITING_FOR_SUBMISSIONS,
+	CONFIRMATION_REQUIRED,
+	FINALIZING,
+	COMPLETED,
+	FAILED
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewEndpointContract.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewEndpointContract.java
@@ -1,0 +1,23 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.util.Objects;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+public record InterviewEndpointContract(
+		HttpMethod method,
+		String path,
+		HttpStatus successStatus,
+		Class<?> requestType,
+		Class<?> responseType) {
+
+	public InterviewEndpointContract {
+		Objects.requireNonNull(method, "method");
+		if (path == null || path.isBlank()) {
+			throw new IllegalArgumentException("path must not be blank");
+		}
+		Objects.requireNonNull(successStatus, "successStatus");
+		Objects.requireNonNull(requestType, "requestType");
+		Objects.requireNonNull(responseType, "responseType");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHeartbeatResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHeartbeatResponse.java
@@ -1,0 +1,9 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.time.Instant;
+
+public record InterviewHeartbeatResponse(
+		String interviewId,
+		InterviewRuntimeStatus status,
+		Instant lastSeen) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHistoryItemResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHistoryItemResponse.java
@@ -1,0 +1,34 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public record InterviewHistoryItemResponse(
+		String interviewId,
+		String jobTitle,
+		InterviewDifficulty difficulty,
+		InterviewReportType reportType,
+		BigDecimal overallScore,
+		int recordingDurationSeconds,
+		OffsetDateTime completedAt) {
+
+	public InterviewHistoryItemResponse {
+		if (interviewId == null || interviewId.isBlank()) {
+			throw new IllegalArgumentException("interviewId must not be blank");
+		}
+		if (jobTitle == null || jobTitle.isBlank()) {
+			throw new IllegalArgumentException("jobTitle must not be blank");
+		}
+		Objects.requireNonNull(difficulty, "difficulty");
+		Objects.requireNonNull(reportType, "reportType");
+		Objects.requireNonNull(overallScore, "overallScore");
+		if (recordingDurationSeconds < 0) {
+			throw new IllegalArgumentException(
+					"recordingDurationSeconds must not be negative");
+		}
+		Objects.requireNonNull(completedAt, "completedAt");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHistoryResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewHistoryResponse.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.util.List;
+
+public record InterviewHistoryResponse(List<InterviewHistoryItemResponse> interviews) {
+
+	public InterviewHistoryResponse {
+		interviews = interviews == null ? List.of() : List.copyOf(interviews);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewJobDescriptionOcrResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewJobDescriptionOcrResponse.java
@@ -1,0 +1,4 @@
+package com.unispeaking.domain.dto.scene;
+
+public record InterviewJobDescriptionOcrResponse(String text) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewProcessingStatus.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewProcessingStatus.java
@@ -1,0 +1,8 @@
+package com.unispeaking.domain.dto.scene;
+
+public enum InterviewProcessingStatus {
+	ACCEPTED,
+	PROCESSING,
+	COMPLETED,
+	FAILED
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewQuestionResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewQuestionResponse.java
@@ -1,0 +1,9 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewQuestionType;
+
+public record InterviewQuestionResponse(
+		int questionNo,
+		InterviewQuestionType questionType,
+		String text) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRecordingMetadataResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRecordingMetadataResponse.java
@@ -1,0 +1,11 @@
+package com.unispeaking.domain.dto.scene;
+
+public record InterviewRecordingMetadataResponse(
+		int durationSeconds) {
+
+	public InterviewRecordingMetadataResponse {
+		if (durationSeconds < 0) {
+			throw new IllegalArgumentException("durationSeconds must not be negative");
+		}
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRecordingResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRecordingResponse.java
@@ -1,0 +1,8 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.time.Instant;
+
+public record InterviewRecordingResponse(
+		String url,
+		Instant expiresAt) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewReportDimensionResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewReportDimensionResponse.java
@@ -1,0 +1,22 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record InterviewReportDimensionResponse(
+		BigDecimal score,
+		String evaluation,
+		String actionSuggestion) {
+
+	public InterviewReportDimensionResponse {
+		Objects.requireNonNull(score, "score");
+		requireText(evaluation, "evaluation");
+		requireText(actionSuggestion, "actionSuggestion");
+	}
+
+	private static void requireText(String value, String name) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewReportResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewReportResponse.java
@@ -1,0 +1,30 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+public record InterviewReportResponse(
+		InterviewReportType reportType,
+		BigDecimal overallScore,
+		String overallSummary,
+		InterviewReportDimensionResponse fluency,
+		InterviewReportDimensionResponse logicCoherence,
+		InterviewReportDimensionResponse grammarControl,
+		InterviewReportDimensionResponse pronunciationIntelligibility,
+		InterviewReportDimensionResponse vocabularyExpression) {
+
+	public InterviewReportResponse {
+		Objects.requireNonNull(reportType, "reportType");
+		Objects.requireNonNull(overallScore, "overallScore");
+		if (overallSummary == null || overallSummary.isBlank()) {
+			throw new IllegalArgumentException("overallSummary must not be blank");
+		}
+		Objects.requireNonNull(fluency, "fluency");
+		Objects.requireNonNull(logicCoherence, "logicCoherence");
+		Objects.requireNonNull(grammarControl, "grammarControl");
+		Objects.requireNonNull(pronunciationIntelligibility,
+				"pronunciationIntelligibility");
+		Objects.requireNonNull(vocabularyExpression, "vocabularyExpression");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRuntimeStatus.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewRuntimeStatus.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.dto.scene;
+
+public enum InterviewRuntimeStatus {
+	ACTIVE,
+	INTERRUPTED,
+	WAITING_FOR_SUBMISSIONS,
+	FINALIZING,
+	COMPLETED,
+	FAILED
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewStateResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewStateResponse.java
@@ -1,0 +1,21 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.time.Instant;
+
+public record InterviewStateResponse(
+		String interviewId,
+		String sessionId,
+		InterviewRuntimeStatus status,
+		String errorCode,
+		String message,
+		boolean retryable,
+		int currentQuestionNo,
+		boolean acceptingSubmissions,
+		boolean endRequested,
+		boolean confirmationRequired,
+		int actualWords,
+		int minimumWords,
+		Instant lastSeen,
+		InterviewSubmissionResponse latestSubmission,
+		InterviewAiQuestionResponse nextQuestion) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewSubmissionResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewSubmissionResponse.java
@@ -1,0 +1,13 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.time.Instant;
+
+public record InterviewSubmissionResponse(
+		String submissionId,
+		int questionNo,
+		InterviewProcessingStatus processingStatus,
+		boolean retryable,
+		String errorCode,
+		String message,
+		Instant updatedAt) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewTrendPointResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewTrendPointResponse.java
@@ -1,0 +1,35 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.Objects;
+
+public record InterviewTrendPointResponse(
+		String interviewId,
+		InterviewReportType reportType,
+		OffsetDateTime completedAt,
+		BigDecimal overallScore,
+		BigDecimal fluency,
+		BigDecimal logicCoherence,
+		BigDecimal grammarControl,
+		BigDecimal pronunciationIntelligibility,
+		BigDecimal vocabularyExpression) {
+
+	public InterviewTrendPointResponse {
+		if (interviewId == null || interviewId.isBlank()) {
+			throw new IllegalArgumentException("interviewId must not be blank");
+		}
+		if (reportType != InterviewReportType.FULL) {
+			throw new IllegalArgumentException("trend points require a FULL report");
+		}
+		Objects.requireNonNull(completedAt, "completedAt");
+		Objects.requireNonNull(overallScore, "overallScore");
+		Objects.requireNonNull(fluency, "fluency");
+		Objects.requireNonNull(logicCoherence, "logicCoherence");
+		Objects.requireNonNull(grammarControl, "grammarControl");
+		Objects.requireNonNull(pronunciationIntelligibility,
+				"pronunciationIntelligibility");
+		Objects.requireNonNull(vocabularyExpression, "vocabularyExpression");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewTrendResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/InterviewTrendResponse.java
@@ -1,0 +1,15 @@
+package com.unispeaking.domain.dto.scene;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import java.util.List;
+import java.util.Objects;
+
+public record InterviewTrendResponse(
+		InterviewDifficulty difficulty,
+		List<InterviewTrendPointResponse> points) {
+
+	public InterviewTrendResponse {
+		Objects.requireNonNull(difficulty, "difficulty");
+		points = points == null ? List.of() : List.copyOf(points);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSession.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSession.java
@@ -24,11 +24,13 @@ public final class InterviewSession extends AbstractSceneSession {
 	private final Map<Integer, InterviewTurn> turns = new LinkedHashMap<>();
 	private final Map<String, InterviewSubmission> submissions = new LinkedHashMap<>();
 	private Instant lastSeen;
+	private Instant interruptedAt;
 	private boolean acceptingSubmissions = true;
 	private boolean endRequested;
 	private boolean confirmationRequired;
 	private boolean insufficientDataConfirmed;
 	private boolean flowCleanupPending;
+	private boolean expirationCleanupClaimed;
 
 	public InterviewSession(
 			String id,
@@ -156,6 +158,19 @@ public final class InterviewSession extends AbstractSceneSession {
 	public synchronized boolean flowCleanupPending() { return flowCleanupPending; }
 	public synchronized void markFlowCleanupPending() { flowCleanupPending = true; }
 	public synchronized void clearFlowCleanupPending() { flowCleanupPending = false; }
+	public synchronized boolean expirationCleanupClaimed() {
+		return expirationCleanupClaimed;
+	}
+	public synchronized boolean claimExpirationCleanup() {
+		if (expirationCleanupClaimed || getStatus() != SessionStatus.INTERRUPTED) {
+			return false;
+		}
+		expirationCleanupClaimed = true;
+		return true;
+	}
+	public synchronized void releaseExpirationCleanupClaim() {
+		expirationCleanupClaimed = false;
+	}
 	public synchronized Instant lastSeen() { return lastSeen; }
 	public InterviewQuestionPlan questionPlan() { return questionPlan; }
 	public String interviewId() { return interviewId; }
@@ -173,7 +188,10 @@ public final class InterviewSession extends AbstractSceneSession {
 	public synchronized void pause() { super.pause(); }
 
 	@Override
-	public synchronized void resume() { super.resume(); }
+	public synchronized void resume() {
+		super.resume();
+		interruptedAt = null;
+	}
 
 	@Override
 	public synchronized void bindProviderSession(String providerSessionId) {
@@ -221,7 +239,21 @@ public final class InterviewSession extends AbstractSceneSession {
 	}
 
 	@Override
-	public synchronized void recordInterrupt() { super.recordInterrupt(); }
+	public synchronized void recordInterrupt() {
+		recordInterrupt(lastSeen);
+	}
+
+	public synchronized void recordInterrupt(Instant at) {
+		Instant required = Objects.requireNonNull(at, "at");
+		super.recordInterrupt();
+		if (interruptedAt == null) {
+			interruptedAt = required;
+		}
+	}
+
+	public synchronized Optional<Instant> interruptedAt() {
+		return Optional.ofNullable(interruptedAt);
+	}
 
 	@Override
 	public synchronized void complete(Instant stopTime) { super.complete(stopTime); }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSession.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSession.java
@@ -1,0 +1,300 @@
+package com.unispeaking.domain.po.session;
+
+import com.unispeaking.domain.vo.scene.InterviewEndReason;
+import com.unispeaking.domain.vo.scene.InterviewQuestionPlan;
+import com.unispeaking.domain.vo.scene.InterviewQuestionPrompt;
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import com.unispeaking.domain.po.session.ConversationMessage;
+import com.unispeaking.domain.vo.provider.ProviderType;
+import com.unispeaking.domain.vo.session.SessionPrompt;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+public final class InterviewSession extends AbstractSceneSession {
+
+	private final InterviewQuestionPlan questionPlan;
+	private final com.unispeaking.domain.vo.scene.InterviewProgress progress;
+	private final String interviewId;
+	private final Map<Integer, InterviewTurn> turns = new LinkedHashMap<>();
+	private final Map<String, InterviewSubmission> submissions = new LinkedHashMap<>();
+	private Instant lastSeen;
+	private boolean acceptingSubmissions = true;
+	private boolean endRequested;
+	private boolean confirmationRequired;
+	private boolean insufficientDataConfirmed;
+	private boolean flowCleanupPending;
+
+	public InterviewSession(
+			String id,
+			String userId,
+			String interviewId,
+			InterviewQuestionPlan questionPlan) {
+		super(id, userId);
+		if (interviewId == null || interviewId.isBlank()) {
+			throw new IllegalArgumentException("interviewId must not be blank");
+		}
+		this.interviewId = interviewId.trim();
+		this.questionPlan = Objects.requireNonNull(questionPlan, "questionPlan");
+		this.progress = new com.unispeaking.domain.vo.scene.InterviewProgress(questionPlan);
+		super.setSceneId(this.interviewId);
+		super.setSceneType(SceneType.INTERVIEW_SCENE);
+		lastSeen = getCreatedAt();
+	}
+
+	public synchronized InterviewQuestionPrompt recordMainQuestion(String text) {
+		InterviewQuestionPrompt prompt = progress.recordMainQuestion(text);
+		turns.put(prompt.questionNo(), new InterviewTurn(prompt));
+		return prompt;
+	}
+
+	public synchronized InterviewQuestionPrompt recordFollowUp(String text) {
+		InterviewQuestionPrompt prompt = progress.recordFollowUp(text);
+		turns.put(prompt.questionNo(), new InterviewTurn(prompt));
+		return prompt;
+	}
+
+	public synchronized void moveToNextMainQuestion() {
+		progress.moveToNextMainQuestion();
+		if (progress.isComplete()) {
+			acceptingSubmissions = false;
+			endRequested = false;
+		}
+	}
+
+	public synchronized void end(InterviewEndReason reason) {
+		progress.end(reason);
+		acceptingSubmissions = false;
+		endRequested = false;
+	}
+
+	public synchronized void touch(Instant at) {
+		Instant required = Objects.requireNonNull(at, "at");
+		if (required.isAfter(lastSeen)) {
+			lastSeen = required;
+		}
+	}
+
+	public synchronized void registerSubmission(InterviewSubmission submission) {
+		Objects.requireNonNull(submission, "submission");
+		if (!acceptingSubmissions) {
+			throw new IllegalStateException("interview is not accepting submissions");
+		}
+		if (progress.currentQuestionNo() != submission.questionNo()) {
+			throw new IllegalArgumentException("submission question is not current");
+		}
+		if (submissions.values().stream()
+				.anyMatch(existing -> existing.questionNo() == submission.questionNo()
+						&& existing.status() != InterviewSubmissionStatus.FAILED_TERMINAL)) {
+			throw new IllegalStateException("current question already has a reusable submission");
+		}
+		if (submissions.putIfAbsent(submission.submissionId(), submission) != null) {
+			throw new IllegalStateException("submissionId is already registered");
+		}
+	}
+
+	public synchronized Optional<InterviewSubmission> submission(String submissionId) {
+		return Optional.ofNullable(submissions.get(submissionId));
+	}
+
+	public synchronized List<InterviewSubmission> submissions() {
+		return List.copyOf(submissions.values());
+	}
+
+	public synchronized Optional<InterviewTurn> turn(int questionNo) {
+		return Optional.ofNullable(turns.get(questionNo));
+	}
+
+	public synchronized List<InterviewTurn> turns() {
+		return List.copyOf(turns.values());
+	}
+
+	public synchronized List<InterviewQuestionPrompt> actualQuestions() {
+		return progress.actualQuestions();
+	}
+
+	public synchronized void requestEnd() {
+		endRequested = true;
+		acceptingSubmissions = false;
+	}
+
+	public synchronized void clearEndRequest() {
+		ensureCanAcceptSubmissionsAgain();
+		endRequested = false;
+		acceptingSubmissions = true;
+	}
+
+	public synchronized void requireConfirmation() {
+		ensureCanAcceptSubmissionsAgain();
+		confirmationRequired = true;
+		endRequested = false;
+		acceptingSubmissions = true;
+	}
+
+	public synchronized void confirmInsufficientData() {
+		if (!confirmationRequired) {
+			throw new IllegalStateException("insufficient data confirmation is not required");
+		}
+		insufficientDataConfirmed = true;
+		acceptingSubmissions = false;
+	}
+
+	public synchronized boolean hasInFlightSubmissions() {
+		return submissions.values().stream()
+				.anyMatch(submission -> submission.status().isInFlight());
+	}
+
+	public synchronized boolean acceptingSubmissions() { return acceptingSubmissions; }
+	public synchronized boolean endRequested() { return endRequested; }
+	public synchronized boolean confirmationRequired() { return confirmationRequired; }
+	public synchronized boolean insufficientDataConfirmed() { return insufficientDataConfirmed; }
+	public synchronized boolean flowCleanupPending() { return flowCleanupPending; }
+	public synchronized void markFlowCleanupPending() { flowCleanupPending = true; }
+	public synchronized void clearFlowCleanupPending() { flowCleanupPending = false; }
+	public synchronized Instant lastSeen() { return lastSeen; }
+	public InterviewQuestionPlan questionPlan() { return questionPlan; }
+	public String interviewId() { return interviewId; }
+
+	@Override
+	public synchronized void activate() { super.activate(); }
+
+	@Override
+	public synchronized void markConnecting() { super.markConnecting(); }
+
+	@Override
+	public synchronized void waitForClient() { super.waitForClient(); }
+
+	@Override
+	public synchronized void pause() { super.pause(); }
+
+	@Override
+	public synchronized void resume() { super.resume(); }
+
+	@Override
+	public synchronized void bindProviderSession(String providerSessionId) {
+		super.bindProviderSession(providerSessionId);
+	}
+
+	@Override
+	public synchronized void addMessage(ConversationMessage message) {
+		throw new UnsupportedOperationException("Interview does not persist conversation messages");
+	}
+
+	@Override
+	public synchronized void setSceneId(String sceneId) {
+		if (!interviewId.equals(sceneId)) {
+			throw new IllegalArgumentException("Interview sceneId is immutable");
+		}
+		super.setSceneId(sceneId);
+	}
+
+	@Override
+	public synchronized void setSceneType(SceneType sceneType) {
+		if (sceneType != SceneType.INTERVIEW_SCENE) {
+			throw new IllegalArgumentException("Interview scene type is immutable");
+		}
+		super.setSceneType(sceneType);
+	}
+
+	@Override
+	public synchronized void setPrompt(SessionPrompt prompt) { super.setPrompt(prompt); }
+
+	@Override
+	public synchronized void setProviderType(ProviderType providerType) {
+		super.setProviderType(providerType);
+	}
+
+	@Override
+	public synchronized void setModel(String model) { super.setModel(model); }
+
+	@Override
+	public synchronized void setVoiceId(String voiceId) { super.setVoiceId(voiceId); }
+
+	@Override
+	public synchronized void setCredentialExpiresAt(Instant expiresAt) {
+		super.setCredentialExpiresAt(expiresAt);
+	}
+
+	@Override
+	public synchronized void recordInterrupt() { super.recordInterrupt(); }
+
+	@Override
+	public synchronized void complete(Instant stopTime) { super.complete(stopTime); }
+
+	@Override
+	public synchronized void fail(Instant stopTime) { super.fail(stopTime); }
+
+	@Override
+	public synchronized void fail(String errorCode, String errorMessage) {
+		super.fail(errorCode, errorMessage);
+	}
+
+	@Override
+	public synchronized SessionStatus getStatus() { return super.getStatus(); }
+
+	@Override
+	public synchronized String getId() { return super.getId(); }
+
+	@Override
+	public synchronized String getUserId() { return super.getUserId(); }
+
+	@Override
+	public synchronized Instant getCreatedAt() { return super.getCreatedAt(); }
+
+	@Override
+	public synchronized String getSceneId() { return super.getSceneId(); }
+
+	@Override
+	public synchronized SceneType getSceneType() { return super.getSceneType(); }
+
+	@Override
+	public synchronized String getProviderSessionId() { return super.getProviderSessionId(); }
+
+	@Override
+	public synchronized Instant getEndedAt() { return super.getEndedAt(); }
+
+	@Override
+	public synchronized SessionPrompt getPrompt() { return super.getPrompt(); }
+
+	@Override
+	public synchronized ProviderType getProviderType() { return super.getProviderType(); }
+
+	@Override
+	public synchronized String getModel() { return super.getModel(); }
+
+	@Override
+	public synchronized String getVoiceId() { return super.getVoiceId(); }
+
+	@Override
+	public synchronized Instant getCredentialExpiresAt() {
+		return super.getCredentialExpiresAt();
+	}
+
+	@Override
+	public synchronized String getErrorCode() { return super.getErrorCode(); }
+
+	@Override
+	public synchronized String getErrorMessage() { return super.getErrorMessage(); }
+
+	private void ensureCanAcceptSubmissionsAgain() {
+		if (insufficientDataConfirmed
+				|| progress.endReason() != null
+				|| getStatus() == SessionStatus.COMPLETED
+				|| getStatus() == SessionStatus.FAILED) {
+			throw new IllegalStateException("terminal interview cannot accept submissions");
+		}
+	}
+
+	@Override
+	public synchronized boolean equals(Object other) {
+		return this == other;
+	}
+
+	@Override
+	public synchronized int hashCode() { return System.identityHashCode(this); }
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSubmission.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSubmission.java
@@ -1,0 +1,113 @@
+package com.unispeaking.domain.po.session;
+
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import java.time.Instant;
+import java.util.Objects;
+
+public final class InterviewSubmission {
+
+	private final String submissionId;
+	private final int questionNo;
+	private final String payloadDigest;
+	private final Instant acceptedAt;
+	private InterviewSubmissionStatus status = InterviewSubmissionStatus.ACCEPTED;
+	private Instant updatedAt;
+	private String errorCode;
+	private String errorMessage;
+
+	public InterviewSubmission(
+			String submissionId,
+			int questionNo,
+			String payloadDigest,
+			Instant acceptedAt) {
+		if (submissionId == null || submissionId.isBlank()) {
+			throw new IllegalArgumentException("submissionId must not be blank");
+		}
+		if (questionNo < 1) {
+			throw new IllegalArgumentException("questionNo must be positive");
+		}
+		if (payloadDigest == null || payloadDigest.isBlank()) {
+			throw new IllegalArgumentException("payloadDigest must not be blank");
+		}
+		this.submissionId = submissionId.trim();
+		this.questionNo = questionNo;
+		this.payloadDigest = payloadDigest.trim();
+		this.acceptedAt = Objects.requireNonNull(acceptedAt, "acceptedAt");
+		this.updatedAt = acceptedAt;
+	}
+
+	public synchronized void markProcessing(Instant at) {
+		requireStatus(InterviewSubmissionStatus.ACCEPTED,
+				"submission must be accepted before processing");
+		validateTime(at);
+		status = InterviewSubmissionStatus.PROCESSING;
+		updatedAt = at;
+	}
+
+	public synchronized void markCompleted(Instant at) {
+		requireStatus(InterviewSubmissionStatus.PROCESSING,
+				"submission must be processing before completion");
+		validateTime(at);
+		status = InterviewSubmissionStatus.COMPLETED;
+		updatedAt = at;
+		errorCode = null;
+		errorMessage = null;
+	}
+
+	public synchronized void markFailed(
+			boolean retryable,
+			String errorCode,
+			String errorMessage,
+			Instant at) {
+		requireStatus(InterviewSubmissionStatus.PROCESSING,
+				"submission must be processing before failure");
+		String requiredCode = requireText(errorCode, "errorCode");
+		String requiredMessage = requireText(errorMessage, "errorMessage");
+		validateTime(at);
+		status = retryable
+				? InterviewSubmissionStatus.FAILED_RETRYABLE
+				: InterviewSubmissionStatus.FAILED_TERMINAL;
+		this.errorCode = requiredCode;
+		this.errorMessage = requiredMessage;
+		updatedAt = at;
+	}
+
+	public synchronized void retry(Instant at) {
+		requireStatus(InterviewSubmissionStatus.FAILED_RETRYABLE,
+				"only retryable failures can be retried");
+		validateTime(at);
+		status = InterviewSubmissionStatus.ACCEPTED;
+		updatedAt = at;
+		errorCode = null;
+		errorMessage = null;
+	}
+
+	public String submissionId() { return submissionId; }
+	public int questionNo() { return questionNo; }
+	public String payloadDigest() { return payloadDigest; }
+	public Instant acceptedAt() { return acceptedAt; }
+	public synchronized InterviewSubmissionStatus status() { return status; }
+	public synchronized Instant updatedAt() { return updatedAt; }
+	public synchronized String errorCode() { return errorCode; }
+	public synchronized String errorMessage() { return errorMessage; }
+
+	private void requireStatus(InterviewSubmissionStatus expected, String message) {
+		if (status != expected) {
+			throw new IllegalStateException(message);
+		}
+	}
+
+	private void validateTime(Instant at) {
+		Objects.requireNonNull(at, "at");
+		if (at.isBefore(updatedAt)) {
+			throw new IllegalArgumentException("submission time must not move backwards");
+		}
+	}
+
+	private static String requireText(String value, String name) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(name + " must not be blank");
+		}
+		return value.trim();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSubmission.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewSubmission.java
@@ -72,6 +72,26 @@ public final class InterviewSubmission {
 		updatedAt = at;
 	}
 
+	public synchronized boolean markTimedOut(
+			boolean retryable,
+			String errorCode,
+			String errorMessage,
+			Instant at) {
+		if (!status.isInFlight()) {
+			return false;
+		}
+		String requiredCode = requireText(errorCode, "errorCode");
+		String requiredMessage = requireText(errorMessage, "errorMessage");
+		validateTime(at);
+		status = retryable
+				? InterviewSubmissionStatus.FAILED_RETRYABLE
+				: InterviewSubmissionStatus.FAILED_TERMINAL;
+		this.errorCode = requiredCode;
+		this.errorMessage = requiredMessage;
+		updatedAt = at;
+		return true;
+	}
+
 	public synchronized void retry(Instant at) {
 		requireStatus(InterviewSubmissionStatus.FAILED_RETRYABLE,
 				"only retryable failures can be retried");

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewTurn.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/InterviewTurn.java
@@ -1,0 +1,49 @@
+package com.unispeaking.domain.po.session;
+
+import com.unispeaking.domain.dto.evaluation.SpeechEvaluationResult;
+import com.unispeaking.domain.vo.scene.InterviewQuestionPrompt;
+import java.util.Objects;
+
+public final class InterviewTurn {
+
+	private final InterviewQuestionPrompt question;
+	private String aiAudioBase64;
+	private String answerObjectKey;
+	private String transcript;
+	private int validWordCount;
+	private SpeechEvaluationResult speechEvaluation;
+
+	public InterviewTurn(InterviewQuestionPrompt question) {
+		this.question = Objects.requireNonNull(question, "question");
+	}
+
+	public synchronized void setAiAudioBase64(String value) {
+		aiAudioBase64 = value == null || value.isBlank() ? null : value;
+	}
+
+	public synchronized void setAnswerObjectKey(String value) {
+		answerObjectKey = value == null || value.isBlank() ? null : value;
+	}
+
+	public synchronized void setTranscript(String value) {
+		transcript = value == null || value.isBlank() ? null : value.trim();
+	}
+
+	public synchronized void setValidWordCount(int value) {
+		if (value < 0) {
+			throw new IllegalArgumentException("validWordCount must not be negative");
+		}
+		validWordCount = value;
+	}
+
+	public synchronized void setSpeechEvaluation(SpeechEvaluationResult value) {
+		speechEvaluation = value;
+	}
+
+	public InterviewQuestionPrompt question() { return question; }
+	public synchronized String aiAudioBase64() { return aiAudioBase64; }
+	public synchronized String answerObjectKey() { return answerObjectKey; }
+	public synchronized String transcript() { return transcript; }
+	public synchronized int validWordCount() { return validWordCount; }
+	public synchronized SpeechEvaluationResult speechEvaluation() { return speechEvaluation; }
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewDimensionFeedback.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewDimensionFeedback.java
@@ -1,0 +1,24 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * Provider-independent feedback for one Interview report dimension.
+ *
+ * <p>Providing Chinese, anonymized and synthesized text rather than source
+ * answers is the caller's prerequisite. This type enforces only structural
+ * presence and deterministic length limits.</p>
+ */
+public record InterviewDimensionFeedback(
+		String evaluation,
+		String actionSuggestion) {
+
+	public InterviewDimensionFeedback {
+		evaluation = InterviewReportConstraints.requireText(
+				evaluation,
+				"evaluation",
+				InterviewReportConstraints.MAX_FEEDBACK_CODE_POINTS);
+		actionSuggestion = InterviewReportConstraints.requireText(
+				actionSuggestion,
+				"actionSuggestion",
+				InterviewReportConstraints.MAX_FEEDBACK_CODE_POINTS);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewEndReason.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewEndReason.java
@@ -1,0 +1,7 @@
+package com.unispeaking.domain.vo.scene;
+
+public enum InterviewEndReason {
+
+	PLAN_COMPLETED,
+	USER_ENDED
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewFollowUpFocus.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewFollowUpFocus.java
@@ -1,0 +1,7 @@
+package com.unispeaking.domain.vo.scene;
+
+public enum InterviewFollowUpFocus {
+	CLARIFICATION,
+	REASON_ACTION_RESULT,
+	TRADE_OFF_REFLECTION_COMPLEX_SCENARIO
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrBatch.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrBatch.java
@@ -1,0 +1,60 @@
+package com.unispeaking.domain.vo.scene;
+
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import com.unispeaking.domain.dto.ocr.OcrImage;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Validated transient JD screenshot batch. It has no persistence representation.
+ */
+public final class InterviewJobDescriptionOcrBatch {
+
+	static final int MAX_IMAGE_COUNT = 5;
+	static final int MAX_TOTAL_BYTES = 10 * 1024 * 1024;
+
+	private final List<OcrImage> images;
+	private final int totalBytes;
+
+	public InterviewJobDescriptionOcrBatch(List<OcrImage> images) {
+		if (images == null || images.isEmpty()) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		if (images.size() > MAX_IMAGE_COUNT) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		long totalBytes = 0;
+		List<OcrImage> copied = new ArrayList<>(images.size());
+		for (OcrImage image : images) {
+			if (image == null) {
+				throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+			}
+			byte[] content = image.content();
+			if (content == null || content.length == 0) {
+				throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+			}
+			totalBytes += content.length;
+			if (totalBytes > MAX_TOTAL_BYTES) {
+				throw new InterviewException(InterviewErrorCode.PAYLOAD_TOO_LARGE);
+			}
+			copied.add(new OcrImage(content));
+		}
+		this.images = List.copyOf(copied);
+		this.totalBytes = (int) totalBytes;
+	}
+
+	public List<OcrImage> images() {
+		return images;
+	}
+
+	public int totalBytes() {
+		return totalBytes;
+	}
+
+	@Override
+	public String toString() {
+		return "InterviewJobDescriptionOcrBatch[imageCount=" + images.size()
+				+ ", totalBytes=" + totalBytes() + "]";
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrRecognizer.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrRecognizer.java
@@ -1,0 +1,57 @@
+package com.unispeaking.domain.vo.scene;
+
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import com.unispeaking.common.exception.interview.InterviewInputExceptionMapper;
+import com.unispeaking.common.exception.ocr.OcrException;
+import com.unispeaking.domain.dto.ocr.OcrImage;
+import com.unispeaking.provider.OcrProvider;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Recognizes temporary JD text without persistence or logging side effects.
+ */
+public final class InterviewJobDescriptionOcrRecognizer {
+
+	static final int MAX_TEXT_CODE_POINTS = 5_000;
+
+	private final OcrProvider ocrProvider;
+
+	public InterviewJobDescriptionOcrRecognizer(OcrProvider ocrProvider) {
+		this.ocrProvider = Objects.requireNonNull(ocrProvider, "ocrProvider must not be null");
+	}
+
+	public InterviewJobDescriptionOcrText recognize(List<OcrImage> images) {
+		InterviewJobDescriptionOcrBatch batch = new InterviewJobDescriptionOcrBatch(images);
+		try {
+			if (!ocrProvider.available()) {
+				throw new InterviewException(InterviewErrorCode.SERVICE_UNAVAILABLE);
+			}
+			String recognizedText = ocrProvider.recognizeText(batch.images());
+			String normalizedText = normalizeRecognizedText(recognizedText);
+			return new InterviewJobDescriptionOcrText(normalizedText);
+		}
+		catch (InterviewException exception) {
+			throw exception;
+		}
+		catch (OcrException exception) {
+			throw InterviewInputExceptionMapper.fromOcr(exception);
+		}
+		catch (RuntimeException exception) {
+			throw new InterviewException(InterviewErrorCode.DEPENDENCY_FAILED, exception);
+		}
+	}
+
+	private static String normalizeRecognizedText(String text) {
+		if (text == null || text.isBlank()) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		String normalized = text.replace("\r\n", "\n").replace('\r', '\n').strip();
+		if (normalized.isBlank()
+				|| normalized.codePointCount(0, normalized.length()) > MAX_TEXT_CODE_POINTS) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		return normalized;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrText.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrText.java
@@ -1,0 +1,23 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * Temporary recognized JD text. This type has no persistence representation.
+ */
+public final class InterviewJobDescriptionOcrText {
+
+	private final String text;
+
+	InterviewJobDescriptionOcrText(String text) {
+		this.text = text;
+	}
+
+	public String text() {
+		return text;
+	}
+
+	@Override
+	public String toString() {
+		return "InterviewJobDescriptionOcrText[codePoints="
+				+ text.codePointCount(0, text.length()) + "]";
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewMaterialPreparer.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewMaterialPreparer.java
@@ -1,0 +1,91 @@
+package com.unispeaking.domain.vo.scene;
+
+import com.unispeaking.common.document.DocumentTextExtractor;
+import com.unispeaking.common.exception.document.DocumentException;
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import com.unispeaking.common.exception.interview.InterviewInputExceptionMapper;
+import java.util.Objects;
+
+/**
+ * Validates and normalizes transient Interview creation materials.
+ */
+public final class InterviewMaterialPreparer {
+
+	static final int MAX_JOB_TITLE_CODE_POINTS = 255;
+	static final int MAX_JOB_DESCRIPTION_CODE_POINTS = 5_000;
+	static final int MAX_RESUME_TEXT_CODE_POINTS = 20_000;
+
+	private final DocumentTextExtractor documentTextExtractor;
+
+	public InterviewMaterialPreparer(DocumentTextExtractor documentTextExtractor) {
+		this.documentTextExtractor = Objects.requireNonNull(
+				documentTextExtractor,
+				"documentTextExtractor must not be null");
+	}
+
+	public InterviewPreparedMaterials prepare(
+			String jobTitle,
+			String jobDescription,
+			String resumeText,
+			InterviewResumeFile resumeFile) {
+		String normalizedJobTitle = normalizeOptional(jobTitle);
+		if (normalizedJobTitle == null) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		validateCodePointLength(normalizedJobTitle, MAX_JOB_TITLE_CODE_POINTS);
+
+		String normalizedJobDescription = normalizeOptional(jobDescription);
+		validateCodePointLength(
+				normalizedJobDescription,
+				MAX_JOB_DESCRIPTION_CODE_POINTS);
+
+		String normalizedResumeText = normalizeOptional(resumeText);
+		if (normalizedResumeText != null && resumeFile != null) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+		if (normalizedResumeText != null) {
+			validateCodePointLength(normalizedResumeText, MAX_RESUME_TEXT_CODE_POINTS);
+		}
+		else if (resumeFile != null) {
+			normalizedResumeText = extractResumeText(resumeFile);
+		}
+
+		return new InterviewPreparedMaterials(
+				normalizedJobTitle,
+				normalizedJobDescription,
+				normalizedResumeText);
+	}
+
+	private String extractResumeText(InterviewResumeFile resumeFile) {
+		try {
+			String extractedText = documentTextExtractor.extractText(
+					resumeFile.filename(),
+					resumeFile.mimeType(),
+					resumeFile.content());
+			String normalizedText = normalizeOptional(extractedText);
+			if (normalizedText == null) {
+				throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+			}
+			validateCodePointLength(normalizedText, MAX_RESUME_TEXT_CODE_POINTS);
+			return normalizedText;
+		}
+		catch (DocumentException exception) {
+			throw InterviewInputExceptionMapper.fromDocument(exception);
+		}
+	}
+
+	private static void validateCodePointLength(String value, int maximum) {
+		if (value != null && value.codePointCount(0, value.length()) > maximum) {
+			throw new InterviewException(InterviewErrorCode.INPUT_INVALID);
+		}
+	}
+
+	private static String normalizeOptional(String value) {
+		if (value == null) {
+			return null;
+		}
+		String normalized = value.replace("\r\n", "\n").replace('\r', '\n').strip();
+		return normalized.isBlank() ? null : normalized;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewPlannedQuestion.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewPlannedQuestion.java
@@ -1,0 +1,22 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+public record InterviewPlannedQuestion(
+		int questionNo,
+		String questionText,
+		int maxFollowUps) {
+
+	public InterviewPlannedQuestion {
+		if (questionNo < 1 || questionNo > 5) {
+			throw new IllegalArgumentException("questionNo must be between 1 and 5");
+		}
+		if (questionText == null || questionText.isBlank()) {
+			throw new IllegalArgumentException("questionText must not be blank");
+		}
+		if (maxFollowUps < 0 || maxFollowUps > 2) {
+			throw new IllegalArgumentException("maxFollowUps must be between 0 and 2");
+		}
+		questionText = questionText.trim();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewPreparedMaterials.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewPreparedMaterials.java
@@ -1,0 +1,51 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * Normalized creation materials that exist only while an Interview is being created.
+ */
+public final class InterviewPreparedMaterials {
+
+	private final String jobTitle;
+	private final String jobDescription;
+	private final String resumeText;
+
+	InterviewPreparedMaterials(
+			String jobTitle,
+			String jobDescription,
+			String resumeText) {
+		this.jobTitle = jobTitle;
+		this.jobDescription = jobDescription;
+		this.resumeText = resumeText;
+	}
+
+	public String jobTitle() {
+		return jobTitle;
+	}
+
+	public String jobDescription() {
+		return jobDescription;
+	}
+
+	public String resumeText() {
+		return resumeText;
+	}
+
+	public TargetRoleSummaryGenerationInput targetRoleSummaryInput() {
+		return new TargetRoleSummaryGenerationInput(jobTitle, jobDescription);
+	}
+
+	public InterviewQuestionPlanGenerationInput questionPlanInput(
+			InterviewDifficulty difficulty,
+			TargetRoleSummary roleSummary) {
+		return new InterviewQuestionPlanGenerationInput(
+				difficulty,
+				roleSummary,
+				resumeText);
+	}
+
+	@Override
+	public String toString() {
+		return "InterviewPreparedMaterials[jobTitle=<redacted>, "
+				+ "jobDescription=<redacted>, resumeText=<redacted>]";
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewProgress.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewProgress.java
@@ -1,0 +1,128 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public final class InterviewProgress {
+
+	private final InterviewQuestionPlan plan;
+	private final List<InterviewQuestionPrompt> actualQuestions = new ArrayList<>();
+	private int currentMainQuestionNo = 1;
+	private int followUpCount;
+	private int nextQuestionNo = 1;
+	private boolean currentMainQuestionRecorded;
+	private InterviewEndReason endReason;
+
+	public InterviewProgress(InterviewQuestionPlan plan) {
+		this.plan = Objects.requireNonNull(plan, "plan");
+	}
+
+	public synchronized InterviewQuestionPrompt recordMainQuestion(String questionText) {
+		ensureOpen();
+		if (currentMainQuestionRecorded) {
+			throw new IllegalStateException("current main question is already recorded");
+		}
+		InterviewPlannedQuestion planned = plan.mainQuestion(currentMainQuestionNo);
+		InterviewQuestionPrompt prompt = record(new InterviewQuestionPrompt(
+				nextQuestionNo,
+				InterviewQuestionType.MAIN,
+				questionText == null ? planned.questionText() : questionText));
+		nextQuestionNo++;
+		currentMainQuestionRecorded = true;
+		return prompt;
+	}
+
+	public synchronized InterviewQuestionPrompt recordFollowUp(String questionText) {
+		ensureOpen();
+		if (!currentMainQuestionRecorded) {
+			throw new IllegalStateException("main question must be recorded first");
+		}
+		if (followUpCount >= plan.maxFollowUps()) {
+			throw new IllegalStateException("follow-up limit has been reached");
+		}
+		InterviewQuestionPrompt prompt = record(new InterviewQuestionPrompt(
+				nextQuestionNo,
+				InterviewQuestionType.FOLLOW_UP,
+				questionText));
+		nextQuestionNo++;
+		followUpCount++;
+		return prompt;
+	}
+
+	public synchronized void moveToNextMainQuestion() {
+		ensureOpen();
+		if (!currentMainQuestionRecorded) {
+			throw new IllegalStateException("current main question has not been recorded");
+		}
+		if (currentMainQuestionNo == plan.mainQuestions().size()) {
+			endReason = InterviewEndReason.PLAN_COMPLETED;
+			return;
+		}
+		currentMainQuestionNo++;
+		followUpCount = 0;
+		currentMainQuestionRecorded = false;
+	}
+
+	public synchronized void end(InterviewEndReason reason) {
+		Objects.requireNonNull(reason, "reason");
+		if (reason == InterviewEndReason.PLAN_COMPLETED
+				&& (currentMainQuestionNo != plan.mainQuestions().size()
+						|| !currentMainQuestionRecorded)) {
+			throw new IllegalStateException("question plan is not complete");
+		}
+		if (endReason != null && endReason != reason) {
+			throw new IllegalStateException("interview already has another end reason");
+		}
+		endReason = reason;
+	}
+
+	public synchronized boolean isComplete() {
+		return endReason == InterviewEndReason.PLAN_COMPLETED;
+	}
+
+	public synchronized InterviewQuestionPlan plan() {
+		return plan;
+	}
+
+	public synchronized int currentMainQuestionNo() {
+		return currentMainQuestionNo;
+	}
+
+	public synchronized int followUpCount() {
+		return followUpCount;
+	}
+
+	public synchronized int nextQuestionNo() {
+		return nextQuestionNo;
+	}
+
+	public synchronized boolean currentMainQuestionRecorded() {
+		return currentMainQuestionRecorded;
+	}
+
+	public synchronized int currentQuestionNo() {
+		return endReason == null && currentMainQuestionRecorded && !actualQuestions.isEmpty()
+				? actualQuestions.getLast().questionNo()
+				: -1;
+	}
+
+	public synchronized InterviewEndReason endReason() {
+		return endReason;
+	}
+
+	public synchronized List<InterviewQuestionPrompt> actualQuestions() {
+		return List.copyOf(actualQuestions);
+	}
+
+	private InterviewQuestionPrompt record(InterviewQuestionPrompt prompt) {
+		actualQuestions.add(prompt);
+		return prompt;
+	}
+
+	private void ensureOpen() {
+		if (endReason != null) {
+			throw new IllegalStateException("interview progress is terminal");
+		}
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlan.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlan.java
@@ -1,0 +1,56 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class InterviewQuestionPlan {
+
+	private static final int MAIN_QUESTION_COUNT = 5;
+
+	private final InterviewDifficulty difficulty;
+	private final List<InterviewPlannedQuestion> mainQuestions;
+
+	public InterviewQuestionPlan(
+			InterviewDifficulty difficulty,
+			List<InterviewPlannedQuestion> mainQuestions) {
+		this.difficulty = Objects.requireNonNull(difficulty, "difficulty");
+		if (mainQuestions == null || mainQuestions.size() != MAIN_QUESTION_COUNT) {
+			throw new IllegalArgumentException("Interview must contain exactly five main questions");
+		}
+		List<InterviewPlannedQuestion> copied = List.copyOf(mainQuestions);
+		for (int index = 0; index < copied.size(); index++) {
+			InterviewPlannedQuestion question = copied.get(index);
+			if (question.questionNo() != index + 1) {
+				throw new IllegalArgumentException("main question numbers must be consecutive");
+			}
+			int expectedLimit = expectedFollowUpLimit(difficulty);
+			if (question.maxFollowUps() != expectedLimit) {
+				throw new IllegalArgumentException("follow-up limit does not match difficulty");
+			}
+		}
+		this.mainQuestions = copied;
+	}
+
+	public InterviewDifficulty difficulty() {
+		return difficulty;
+	}
+
+	public List<InterviewPlannedQuestion> mainQuestions() {
+		return mainQuestions;
+	}
+
+	public InterviewPlannedQuestion mainQuestion(int questionNo) {
+		if (questionNo < 1 || questionNo > MAIN_QUESTION_COUNT) {
+			throw new IllegalArgumentException("main question number is out of range");
+		}
+		return mainQuestions.get(questionNo - 1);
+	}
+
+	public int maxFollowUps() {
+		return expectedFollowUpLimit(difficulty);
+	}
+
+	private static int expectedFollowUpLimit(InterviewDifficulty difficulty) {
+		return difficulty == InterviewDifficulty.CHALLENGE ? 2 : 1;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlan.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlan.java
@@ -2,6 +2,7 @@ package com.unispeaking.domain.vo.scene;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.IntStream;
 
 public final class InterviewQuestionPlan {
 
@@ -31,6 +32,24 @@ public final class InterviewQuestionPlan {
 		this.mainQuestions = copied;
 	}
 
+	public static InterviewQuestionPlan fromGeneratedMainQuestions(
+			InterviewDifficulty difficulty,
+			List<String> mainQuestionTexts) {
+		Objects.requireNonNull(difficulty, "difficulty must not be null");
+		if (mainQuestionTexts == null || mainQuestionTexts.size() != MAIN_QUESTION_COUNT) {
+			throw new IllegalArgumentException("Interview must contain exactly five main questions");
+		}
+		int followUpLimit = expectedFollowUpLimit(difficulty);
+		List<InterviewPlannedQuestion> questions = IntStream
+				.range(0, MAIN_QUESTION_COUNT)
+				.mapToObj(index -> new InterviewPlannedQuestion(
+						index + 1,
+						mainQuestionTexts.get(index),
+						followUpLimit))
+				.toList();
+		return new InterviewQuestionPlan(difficulty, questions);
+	}
+
 	public InterviewDifficulty difficulty() {
 		return difficulty;
 	}
@@ -48,6 +67,15 @@ public final class InterviewQuestionPlan {
 
 	public int maxFollowUps() {
 		return expectedFollowUpLimit(difficulty);
+	}
+
+	public InterviewFollowUpFocus followUpFocus() {
+		return switch (difficulty) {
+			case BASIC -> InterviewFollowUpFocus.CLARIFICATION;
+			case STANDARD -> InterviewFollowUpFocus.REASON_ACTION_RESULT;
+			case CHALLENGE ->
+					InterviewFollowUpFocus.TRADE_OFF_REFLECTION_COMPLEX_SCENARIO;
+		};
 	}
 
 	private static int expectedFollowUpLimit(InterviewDifficulty difficulty) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanGenerationInput.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanGenerationInput.java
@@ -1,0 +1,25 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+/**
+ * Transient inputs for generating a question plan.
+ */
+public record InterviewQuestionPlanGenerationInput(
+		InterviewDifficulty difficulty,
+		TargetRoleSummary targetRoleSummary,
+		String resumeText) {
+
+	public InterviewQuestionPlanGenerationInput {
+		difficulty = Objects.requireNonNull(difficulty, "difficulty must not be null");
+		targetRoleSummary = Objects.requireNonNull(
+				targetRoleSummary,
+				"targetRoleSummary must not be null");
+	}
+
+	@Override
+	public String toString() {
+		return "InterviewQuestionPlanGenerationInput[difficulty=" + difficulty
+				+ ", targetRoleSummary=<redacted>, resumeText=<redacted>]";
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanGenerator.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanGenerator.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * Provider-independent question-plan generation boundary.
+ */
+@FunctionalInterface
+public interface InterviewQuestionPlanGenerator {
+
+	InterviewQuestionPlan generate(InterviewQuestionPlanGenerationInput input);
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPrompt.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewQuestionPrompt.java
@@ -1,0 +1,20 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+public record InterviewQuestionPrompt(
+		int questionNo,
+		InterviewQuestionType questionType,
+		String questionText) {
+
+	public InterviewQuestionPrompt {
+		if (questionNo < 1) {
+			throw new IllegalArgumentException("questionNo must be positive");
+		}
+		questionType = Objects.requireNonNull(questionType, "questionType");
+		if (questionText == null || questionText.isBlank()) {
+			throw new IllegalArgumentException("questionText must not be blank");
+		}
+		questionText = questionText.trim();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewReportCalculation.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewReportCalculation.java
@@ -1,0 +1,37 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/**
+ * Complete five-dimension Interview report produced without persistence or
+ * provider calls.
+ */
+public record InterviewReportCalculation(
+		InterviewReportType reportType,
+		BigDecimal overallScore,
+		String overallSummary,
+		InterviewReportDimension fluency,
+		InterviewReportDimension logicCoherence,
+		InterviewReportDimension grammarControl,
+		InterviewReportDimension pronunciationIntelligibility,
+		InterviewReportDimension vocabularyExpression) {
+
+	public InterviewReportCalculation {
+		Objects.requireNonNull(reportType, "reportType must not be null");
+		InterviewReportConstraints.requireScore(overallScore, "overallScore");
+		overallSummary = InterviewReportConstraints.requireText(
+				overallSummary,
+				"overallSummary",
+				InterviewReportConstraints.MAX_SUMMARY_CODE_POINTS);
+		Objects.requireNonNull(fluency, "fluency must not be null");
+		Objects.requireNonNull(logicCoherence, "logicCoherence must not be null");
+		Objects.requireNonNull(grammarControl, "grammarControl must not be null");
+		Objects.requireNonNull(
+				pronunciationIntelligibility,
+				"pronunciationIntelligibility must not be null");
+		Objects.requireNonNull(
+				vocabularyExpression,
+				"vocabularyExpression must not be null");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewReportConstraints.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewReportConstraints.java
@@ -1,0 +1,52 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.math.BigDecimal;
+
+final class InterviewReportConstraints {
+
+	static final int MAX_SUMMARY_CODE_POINTS = 2_000;
+	static final int MAX_FEEDBACK_CODE_POINTS = 1_000;
+
+	private static final BigDecimal MAX_SCORE = new BigDecimal("100");
+	private static final int MIN_SCORE_SCALE = -2;
+	private static final int MAX_SCORE_SCALE = 8;
+	private static final int MAX_SCORE_PRECISION = 11;
+
+	private InterviewReportConstraints() {
+	}
+
+	static BigDecimal requireScore(BigDecimal score, String fieldName) {
+		if (score == null) {
+			throw new IllegalArgumentException(fieldName + " must not be null");
+		}
+		if (score.scale() < MIN_SCORE_SCALE || score.scale() > MAX_SCORE_SCALE) {
+			throw new IllegalArgumentException(
+					fieldName + " scale must be between "
+							+ MIN_SCORE_SCALE + " and " + MAX_SCORE_SCALE);
+		}
+		if (score.precision() > MAX_SCORE_PRECISION) {
+			throw new IllegalArgumentException(
+					fieldName + " precision must not exceed " + MAX_SCORE_PRECISION);
+		}
+		if (score.compareTo(BigDecimal.ZERO) < 0
+				|| score.compareTo(MAX_SCORE) > 0) {
+			throw new IllegalArgumentException(
+					fieldName + " must be between 0 and 100");
+		}
+		return score;
+	}
+
+	static String requireText(
+			String value,
+			String fieldName,
+			int maxCodePoints) {
+		if (value == null || value.isBlank()) {
+			throw new IllegalArgumentException(fieldName + " must not be blank");
+		}
+		if (value.codePointCount(0, value.length()) > maxCodePoints) {
+			throw new IllegalArgumentException(
+					fieldName + " must not exceed " + maxCodePoints + " characters");
+		}
+		return value;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewResumeFile.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewResumeFile.java
@@ -1,0 +1,29 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * In-memory resume upload. The content must never be persisted or logged.
+ */
+public record InterviewResumeFile(
+		String filename,
+		String mimeType,
+		byte[] content) {
+
+	public InterviewResumeFile {
+		content = copy(content);
+	}
+
+	@Override
+	public byte[] content() {
+		return copy(content);
+	}
+
+	@Override
+	public String toString() {
+		return "InterviewResumeFile[filename=<redacted>, mimeType=" + mimeType
+				+ ", contentBytes=" + (content == null ? 0 : content.length) + "]";
+	}
+
+	private static byte[] copy(byte[] content) {
+		return content == null ? null : content.clone();
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewSpeechReportScores.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewSpeechReportScores.java
@@ -1,0 +1,18 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.math.BigDecimal;
+
+/**
+ * Normalized, side-effect-free speech scores used by an Interview report.
+ */
+public record InterviewSpeechReportScores(
+		BigDecimal fluency,
+		BigDecimal pronunciationIntelligibility) {
+
+	public InterviewSpeechReportScores {
+		fluency = InterviewReportConstraints.requireScore(fluency, "fluency");
+		pronunciationIntelligibility = InterviewReportConstraints.requireScore(
+				pronunciationIntelligibility,
+				"pronunciationIntelligibility");
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewStructuredReportAssessment.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewStructuredReportAssessment.java
@@ -1,0 +1,49 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+/**
+ * Provider-independent structured assessment used to assemble an Interview
+ * report.
+ *
+ * <p>Only normalized report fields cross into this domain object. The text is
+ * expected to be Chinese, synthesized and anonymized before construction;
+ * provider payloads and source answers have no representation here.</p>
+ */
+public record InterviewStructuredReportAssessment(
+		String overallSummary,
+		InterviewDimensionFeedback fluency,
+		InterviewReportDimension logicCoherence,
+		InterviewReportDimension grammarControl,
+		InterviewDimensionFeedback pronunciationIntelligibility,
+		InterviewReportDimension vocabularyExpression) {
+
+	public InterviewStructuredReportAssessment {
+		overallSummary = InterviewReportConstraints.requireText(
+				overallSummary,
+				"overallSummary",
+				InterviewReportConstraints.MAX_SUMMARY_CODE_POINTS);
+		Objects.requireNonNull(fluency, "fluency must not be null");
+		validateScoredDimension(logicCoherence, "logicCoherence");
+		validateScoredDimension(grammarControl, "grammarControl");
+		Objects.requireNonNull(
+				pronunciationIntelligibility,
+				"pronunciationIntelligibility must not be null");
+		validateScoredDimension(vocabularyExpression, "vocabularyExpression");
+	}
+
+	private static void validateScoredDimension(
+			InterviewReportDimension dimension,
+			String fieldName) {
+		Objects.requireNonNull(dimension, fieldName + " must not be null");
+		InterviewReportConstraints.requireScore(dimension.score(), fieldName + ".score");
+		InterviewReportConstraints.requireText(
+				dimension.evaluation(),
+				fieldName + ".evaluation",
+				InterviewReportConstraints.MAX_FEEDBACK_CODE_POINTS);
+		InterviewReportConstraints.requireText(
+				dimension.actionSuggestion(),
+				fieldName + ".actionSuggestion",
+				InterviewReportConstraints.MAX_FEEDBACK_CODE_POINTS);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewSubmissionStatus.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewSubmissionStatus.java
@@ -1,0 +1,20 @@
+package com.unispeaking.domain.vo.scene;
+
+public enum InterviewSubmissionStatus {
+
+	ACCEPTED,
+	PROCESSING,
+	COMPLETED,
+	FAILED_RETRYABLE,
+	FAILED_TERMINAL;
+
+	public boolean isInFlight() {
+		return this == ACCEPTED || this == PROCESSING;
+	}
+
+	public boolean isTerminal() {
+		return this == COMPLETED
+				|| this == FAILED_RETRYABLE
+				|| this == FAILED_TERMINAL;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryGenerationInput.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryGenerationInput.java
@@ -1,0 +1,21 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+/**
+ * Source boundary for role-summary generation. Resume content is intentionally absent.
+ */
+public record TargetRoleSummaryGenerationInput(
+		String jobTitle,
+		String jobDescription) {
+
+	public TargetRoleSummaryGenerationInput {
+		jobTitle = Objects.requireNonNull(jobTitle, "jobTitle must not be null");
+	}
+
+	@Override
+	public String toString() {
+		return "TargetRoleSummaryGenerationInput[jobTitle=<redacted>, "
+				+ "jobDescription=<redacted>]";
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryGenerator.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryGenerator.java
@@ -1,0 +1,10 @@
+package com.unispeaking.domain.vo.scene;
+
+/**
+ * Provider-independent role-summary generation boundary.
+ */
+@FunctionalInterface
+public interface TargetRoleSummaryGenerator {
+
+	TargetRoleSummary generate(TargetRoleSummaryGenerationInput input);
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/config/InterviewRuntimeConfig.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/config/InterviewRuntimeConfig.java
@@ -1,7 +1,10 @@
 package com.unispeaking.infrastructure.config;
 
+import com.unispeaking.component.session.InterviewRuntimePolicy;
 import java.time.Clock;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,5 +30,19 @@ public class InterviewRuntimeConfig {
 	@Bean(name = "interviewClock")
 	public Clock interviewClock() {
 		return Clock.systemUTC();
+	}
+
+	@Bean
+	public InterviewRuntimePolicy interviewRuntimePolicy() {
+		return InterviewRuntimePolicy.defaults();
+	}
+
+	@Bean(name = "interviewWatchdogScheduler", destroyMethod = "shutdown")
+	public ScheduledExecutorService interviewWatchdogScheduler() {
+		return Executors.newSingleThreadScheduledExecutor(runnable -> {
+			Thread thread = new Thread(runnable, "interview-watchdog-1");
+			thread.setDaemon(true);
+			return thread;
+		});
 	}
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/config/InterviewRuntimeConfig.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/config/InterviewRuntimeConfig.java
@@ -1,0 +1,31 @@
+package com.unispeaking.infrastructure.config;
+
+import java.time.Clock;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+public class InterviewRuntimeConfig {
+
+	@Bean(name = "interviewTaskExecutor")
+	public Executor interviewTaskExecutor() {
+		ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+		executor.setThreadNamePrefix("interview-task-");
+		executor.setCorePoolSize(2);
+		executor.setMaxPoolSize(8);
+		executor.setQueueCapacity(100);
+		executor.setRejectedExecutionHandler(new ThreadPoolExecutor.AbortPolicy());
+		executor.setWaitForTasksToCompleteOnShutdown(true);
+		executor.setAwaitTerminationSeconds(30);
+		executor.initialize();
+		return executor;
+	}
+
+	@Bean(name = "interviewClock")
+	public Clock interviewClock() {
+		return Clock.systemUTC();
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/document/DocumentTextExtractorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/document/DocumentTextExtractorTest.java
@@ -28,6 +28,7 @@ class DocumentTextExtractorTest {
 	private static final String PDF_MIME_TYPE = "application/pdf";
 	private static final String DOCX_MIME_TYPE =
 			"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+	private static final String SUPPLEMENTARY_CODE_POINT = "\uD83D\uDE80";
 
 	private final DocumentTextExtractor extractor = new DocumentTextExtractor();
 
@@ -120,6 +121,37 @@ class DocumentTextExtractorTest {
 						DOCX_MIME_TYPE,
 						overMaximum,
 						DocumentErrorCode.TEXT_TOO_LARGE));
+	}
+
+	@Test
+	void countsExtractedTextLimitByUnicodeCodePoint() {
+		byte[] maximum = docxWithParagraphs(
+				SUPPLEMENTARY_CODE_POINT.repeat(DocumentTextExtractor.MAX_TEXT_CHARS));
+		byte[] overMaximum = docxWithParagraphs(
+				SUPPLEMENTARY_CODE_POINT.repeat(DocumentTextExtractor.MAX_TEXT_CHARS + 1));
+
+		String extracted = extractor.extractText("resume.docx", DOCX_MIME_TYPE, maximum);
+
+		assertAll(
+				() -> assertEquals(
+						DocumentTextExtractor.MAX_TEXT_CHARS,
+						extracted.codePointCount(0, extracted.length())),
+				() -> assertError(
+						"resume.docx",
+						DOCX_MIME_TYPE,
+						overMaximum,
+						DocumentErrorCode.TEXT_TOO_LARGE));
+	}
+
+	@Test
+	void acceptsValidPdfAtExactFileSizeLimit() {
+		byte[] source = pdfWithText("exact size");
+		byte[] exactLimit = Arrays.copyOf(source, DocumentTextExtractor.MAX_FILE_BYTES);
+		Arrays.fill(exactLimit, source.length, exactLimit.length, (byte) ' ');
+
+		String extracted = extractor.extractText("resume.pdf", PDF_MIME_TYPE, exactLimit);
+
+		assertEquals("exact size", extracted);
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/calculation/InterviewReportAssemblerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/calculation/InterviewReportAssemblerTest.java
@@ -1,0 +1,309 @@
+package com.unispeaking.common.evaluation.calculation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.domain.vo.scene.InterviewDimensionFeedback;
+import com.unispeaking.domain.vo.scene.InterviewReportCalculation;
+import com.unispeaking.domain.vo.scene.InterviewReportDimension;
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import com.unispeaking.domain.vo.scene.InterviewSpeechReportScores;
+import com.unispeaking.domain.vo.scene.InterviewStructuredReportAssessment;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.Test;
+
+class InterviewReportAssemblerTest {
+
+	@Test
+	void assemblesCompleteReportAtInclusiveScoreBoundaries() {
+		InterviewReportCalculation report = assemble(
+				InterviewReportType.FULL,
+				score("0"),
+				score("25"),
+				score("50"),
+				score("75"),
+				score("100"));
+
+		assertAll(
+				() -> assertEquals(InterviewReportType.FULL, report.reportType()),
+				() -> assertEquals(score("50.0"), report.overallScore()),
+				() -> assertEquals("表达整体清楚，五个维度均有可执行的提升空间。",
+						report.overallSummary()),
+				() -> assertDimension(report.fluency(), "0"),
+				() -> assertDimension(report.logicCoherence(), "25"),
+				() -> assertDimension(report.grammarControl(), "50"),
+				() -> assertDimension(
+						report.pronunciationIntelligibility(),
+						"75"),
+				() -> assertDimension(report.vocabularyExpression(), "100"));
+	}
+
+	@Test
+	void appliesEqualWeightToEveryDimension() {
+		for (int raisedDimension = 0; raisedDimension < 5; raisedDimension++) {
+			BigDecimal[] scores = {
+					BigDecimal.ZERO,
+					BigDecimal.ZERO,
+					BigDecimal.ZERO,
+					BigDecimal.ZERO,
+					BigDecimal.ZERO
+			};
+			scores[raisedDimension] = score("100");
+
+			InterviewReportCalculation report = assemble(
+					InterviewReportType.FULL,
+					scores[0],
+					scores[1],
+					scores[2],
+					scores[3],
+					scores[4]);
+
+			assertEquals(score("20.0"), report.overallScore());
+		}
+	}
+
+	@Test
+	void roundsArithmeticMeanHalfUpToOneDecimal() {
+		InterviewReportCalculation report = assemble(
+				InterviewReportType.FULL,
+				score("0"),
+				score("0"),
+				score("0"),
+				score("0"),
+				score("0.25"));
+
+		assertAll(
+				() -> assertEquals(score("0.1"), report.overallScore()),
+				() -> assertEquals(1, report.overallScore().scale()));
+	}
+
+	@Test
+	void fullAndPartialUseTheSameCompleteFiveDimensionAlgorithm() {
+		InterviewReportCalculation full = assemble(
+				InterviewReportType.FULL,
+				score("61"),
+				score("72"),
+				score("83"),
+				score("94"),
+				score("55"));
+		InterviewReportCalculation partial = assemble(
+				InterviewReportType.PARTIAL,
+				score("61"),
+				score("72"),
+				score("83"),
+				score("94"),
+				score("55"));
+
+		assertAll(
+				() -> assertEquals(score("73.0"), full.overallScore()),
+				() -> assertEquals(full.overallScore(), partial.overallScore()),
+				() -> assertEquals(full.overallSummary(), partial.overallSummary()),
+				() -> assertEquals(full.fluency(), partial.fluency()),
+				() -> assertEquals(full.logicCoherence(), partial.logicCoherence()),
+				() -> assertEquals(full.grammarControl(), partial.grammarControl()),
+				() -> assertEquals(
+						full.pronunciationIntelligibility(),
+						partial.pronunciationIntelligibility()),
+				() -> assertEquals(
+						full.vocabularyExpression(),
+						partial.vocabularyExpression()));
+	}
+
+	@Test
+	void rejectsOutOfRangeSpeechAndStructuredScores() {
+		assertAll(
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewSpeechReportScores(
+								score("-0.1"),
+								score("80"))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewSpeechReportScores(
+								score("80"),
+								score("100.1"))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> dimension("-0.1")),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> dimension("100.1")));
+	}
+
+	@Test
+	void rejectsPathologicalBigDecimalShapesBeforeCalculation() {
+		BigDecimal extremePositiveScale = new BigDecimal(
+				BigInteger.ONE,
+				Integer.MAX_VALUE);
+		BigDecimal extremeNegativeScale = new BigDecimal(
+				BigInteger.ZERO,
+				Integer.MIN_VALUE);
+		BigDecimal excessivePrecision = new BigDecimal("9".repeat(1_000));
+		InterviewReportDimension extremeLogic = new InterviewReportDimension(
+				extremePositiveScale,
+				"逻辑结构完整。",
+				"继续练习分点表达。");
+
+		assertAll(
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewSpeechReportScores(
+								extremePositiveScale,
+								score("80"))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewSpeechReportScores(
+								extremeNegativeScale,
+								score("80"))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewSpeechReportScores(
+								excessivePrecision,
+								score("80"))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> assessment(
+								extremeLogic,
+								dimension("80"),
+								dimension("80"))));
+	}
+
+	@Test
+	void rejectsMissingDimensionsAndIncompleteNarratives() {
+		assertAll(
+				() -> assertThrows(
+						NullPointerException.class,
+						() -> InterviewReportAssembler.assemble(
+								null,
+								new InterviewSpeechReportScores(
+										score("80"),
+										score("80")),
+								assessment(
+										dimension("80"),
+										dimension("80"),
+										dimension("80")))),
+				() -> assertThrows(
+						NullPointerException.class,
+						() -> assessment(null, dimension("80"), dimension("80"))),
+				() -> assertThrows(
+						NullPointerException.class,
+						() -> InterviewReportAssembler.assemble(
+								InterviewReportType.PARTIAL,
+								null,
+								assessment(
+										dimension("80"),
+										dimension("80"),
+										dimension("80")))),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewDimensionFeedback(" ", "加强限时表达练习。")),
+				() -> assertThrows(
+						IllegalArgumentException.class,
+						() -> new InterviewDimensionFeedback(
+								"表达较为清楚。",
+								"建".repeat(1_001))));
+	}
+
+	@Test
+	void domainTypesExposeOnlyNormalizedReportFields() {
+		assertAll(
+				() -> assertEquals(
+						Set.of("evaluation", "actionSuggestion"),
+						recordComponents(InterviewDimensionFeedback.class)),
+				() -> assertEquals(
+						Set.of("score", "evaluation", "actionSuggestion"),
+						recordComponents(InterviewReportDimension.class)),
+				() -> assertEquals(
+						Set.of("fluency", "pronunciationIntelligibility"),
+						recordComponents(InterviewSpeechReportScores.class)),
+				() -> assertEquals(
+						Set.of(
+								"overallSummary",
+								"fluency",
+								"logicCoherence",
+								"grammarControl",
+								"pronunciationIntelligibility",
+								"vocabularyExpression"),
+						recordComponents(InterviewStructuredReportAssessment.class)),
+				() -> assertEquals(
+						Set.of(
+								"reportType",
+								"overallScore",
+								"overallSummary",
+								"fluency",
+								"logicCoherence",
+								"grammarControl",
+								"pronunciationIntelligibility",
+								"vocabularyExpression"),
+						recordComponents(InterviewReportCalculation.class)));
+	}
+
+	private InterviewReportCalculation assemble(
+			InterviewReportType reportType,
+			BigDecimal fluency,
+			BigDecimal logicCoherence,
+			BigDecimal grammarControl,
+			BigDecimal pronunciationIntelligibility,
+			BigDecimal vocabularyExpression) {
+		return InterviewReportAssembler.assemble(
+				reportType,
+				new InterviewSpeechReportScores(
+						fluency,
+						pronunciationIntelligibility),
+				assessment(
+						dimension(logicCoherence.toPlainString()),
+						dimension(grammarControl.toPlainString()),
+						dimension(vocabularyExpression.toPlainString())));
+	}
+
+	private InterviewStructuredReportAssessment assessment(
+			InterviewReportDimension logicCoherence,
+			InterviewReportDimension grammarControl,
+			InterviewReportDimension vocabularyExpression) {
+		return new InterviewStructuredReportAssessment(
+				"表达整体清楚，五个维度均有可执行的提升空间。",
+				feedback(),
+				logicCoherence,
+				grammarControl,
+				feedback(),
+				vocabularyExpression);
+	}
+
+	private InterviewDimensionFeedback feedback() {
+		return new InterviewDimensionFeedback(
+				"表达较为清楚，关键信息能够被理解。",
+				"加强限时表达练习，并在练习后复盘。");
+	}
+
+	private InterviewReportDimension dimension(String value) {
+		return new InterviewReportDimension(
+				score(value),
+				"表达较为清楚，关键信息能够被理解。",
+				"加强限时表达练习，并在练习后复盘。");
+	}
+
+	private void assertDimension(
+			InterviewReportDimension dimension,
+			String expectedScore) {
+		assertAll(
+				() -> assertEquals(score(expectedScore), dimension.score()),
+				() -> assertNotNull(dimension.evaluation()),
+				() -> assertNotNull(dimension.actionSuggestion()));
+	}
+
+	private Set<String> recordComponents(Class<?> type) {
+		return Arrays.stream(type.getRecordComponents())
+				.map(component -> component.getName())
+				.collect(Collectors.toSet());
+	}
+
+	private BigDecimal score(String value) {
+		return new BigDecimal(value);
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/GlobalExceptionHandlerTest.java
@@ -2,8 +2,18 @@ package com.unispeaking.common.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import com.unispeaking.domain.dto.scene.CreateInterviewRequest;
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.MethodParameter;
 import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 class GlobalExceptionHandlerTest {
 
@@ -47,5 +57,65 @@ class GlobalExceptionHandlerTest {
 				"acknowledged 必须为 true"));
 
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+	}
+
+	@Test
+	void mapsOnlyInterviewValidationErrorsToUnprocessableEntity() throws Exception {
+		CreateInterviewRequest request = new CreateInterviewRequest(
+				"", InterviewDifficulty.STANDARD, "", null);
+		var interviewError = validationException("acceptInterview", request);
+		var genericError = validationException("acceptGeneric", new Object());
+
+		var interviewResponse = handler.handleValidationException(interviewError);
+		var genericResponse = handler.handleValidationException(genericError);
+
+		assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, interviewResponse.getStatusCode());
+		assertEquals("INTERVIEW_INPUT_INVALID", interviewResponse.getBody().code());
+		assertEquals(HttpStatus.BAD_REQUEST, genericResponse.getStatusCode());
+		assertEquals("VALIDATION_ERROR", genericResponse.getBody().code());
+	}
+
+	@Test
+	void mapsInterviewMultipartFailuresBeforeControllerInvocation() {
+		MockHttpServletRequest interviewRequest = new MockHttpServletRequest(
+				"POST", "/api/interviews");
+		MockHttpServletRequest genericRequest = new MockHttpServletRequest(
+				"POST", "/api/profile/avatar");
+
+		var interviewTooLarge = handler.handleUploadTooLarge(
+				new MaxUploadSizeExceededException(10), interviewRequest);
+		var genericTooLarge = handler.handleUploadTooLarge(
+				new MaxUploadSizeExceededException(10), genericRequest);
+		var interviewMedia = handler.handleUnsupportedMediaType(
+				new HttpMediaTypeNotSupportedException("application/xml"),
+				interviewRequest);
+		var genericMedia = handler.handleUnsupportedMediaType(
+				new HttpMediaTypeNotSupportedException("application/xml"),
+				genericRequest);
+
+		assertEquals(HttpStatus.PAYLOAD_TOO_LARGE, interviewTooLarge.getStatusCode());
+		assertEquals("INTERVIEW_PAYLOAD_TOO_LARGE", interviewTooLarge.getBody().code());
+		assertEquals("PAYLOAD_TOO_LARGE", genericTooLarge.getBody().code());
+		assertEquals(HttpStatus.UNSUPPORTED_MEDIA_TYPE, interviewMedia.getStatusCode());
+		assertEquals("INTERVIEW_MEDIA_TYPE_UNSUPPORTED", interviewMedia.getBody().code());
+		assertEquals("MEDIA_TYPE_UNSUPPORTED", genericMedia.getBody().code());
+	}
+
+	private MethodArgumentNotValidException validationException(
+			String methodName,
+			Object target) throws Exception {
+		Method method = GlobalExceptionHandlerTest.class.getDeclaredMethod(
+				methodName, target.getClass());
+		BeanPropertyBindingResult errors = new BeanPropertyBindingResult(target, "request");
+		errors.addError(new FieldError("request", "field", "is invalid"));
+		return new MethodArgumentNotValidException(new MethodParameter(method, 0), errors);
+	}
+
+	@SuppressWarnings("unused")
+	private void acceptInterview(CreateInterviewRequest request) {
+	}
+
+	@SuppressWarnings("unused")
+	private void acceptGeneric(Object request) {
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/interview/InterviewExceptionTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/interview/InterviewExceptionTest.java
@@ -1,0 +1,22 @@
+package com.unispeaking.common.exception.interview;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.unispeaking.common.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.Test;
+
+class InterviewExceptionTest {
+
+	private final GlobalExceptionHandler handler = new GlobalExceptionHandler();
+
+	@Test
+	void mapsEveryStableInterviewErrorToItsDeclaredHttpStatus() {
+		for (InterviewErrorCode errorCode : InterviewErrorCode.values()) {
+			var response = handler.handleBusinessException(new InterviewException(errorCode));
+
+			assertEquals(errorCode.status(), response.getStatusCode());
+			assertEquals(errorCode.code(), response.getBody().code());
+			assertEquals(errorCode.defaultMessage(), response.getBody().message());
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/interview/InterviewInputExceptionMapperTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/interview/InterviewInputExceptionMapperTest.java
@@ -1,0 +1,64 @@
+package com.unispeaking.common.exception.interview;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import com.unispeaking.common.exception.document.DocumentErrorCode;
+import com.unispeaking.common.exception.document.DocumentException;
+import com.unispeaking.common.exception.ocr.OcrErrorCode;
+import com.unispeaking.common.exception.ocr.OcrException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InterviewInputExceptionMapperTest {
+
+	@Test
+	void mapsEveryDocumentFailureToStableInterviewError() {
+		Map<DocumentErrorCode, InterviewErrorCode> expected = Map.of(
+				DocumentErrorCode.INPUT_REQUIRED, InterviewErrorCode.INPUT_INVALID,
+				DocumentErrorCode.TOO_LARGE, InterviewErrorCode.PAYLOAD_TOO_LARGE,
+				DocumentErrorCode.FORMAT_UNSUPPORTED,
+				InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED,
+				DocumentErrorCode.CONTENT_INVALID, InterviewErrorCode.INPUT_INVALID,
+				DocumentErrorCode.PDF_PAGE_LIMIT_EXCEEDED,
+				InterviewErrorCode.INPUT_INVALID,
+				DocumentErrorCode.TEXT_EMPTY, InterviewErrorCode.INPUT_INVALID,
+				DocumentErrorCode.TEXT_TOO_LARGE, InterviewErrorCode.INPUT_INVALID);
+
+		for (DocumentErrorCode source : DocumentErrorCode.values()) {
+			DocumentException cause = new DocumentException(source);
+			InterviewException mapped = InterviewInputExceptionMapper.fromDocument(cause);
+
+			assertAll(
+					() -> assertSame(expected.get(source), mapped.errorCode()),
+					() -> assertSame(cause, mapped.getCause()));
+		}
+	}
+
+	@Test
+	void mapsEveryOcrFailureToStableInterviewError() {
+		Map<OcrErrorCode, InterviewErrorCode> expected = Map.ofEntries(
+				Map.entry(OcrErrorCode.INPUT_REQUIRED, InterviewErrorCode.INPUT_INVALID),
+				Map.entry(OcrErrorCode.TOO_MANY_IMAGES, InterviewErrorCode.INPUT_INVALID),
+				Map.entry(OcrErrorCode.TOTAL_SIZE_EXCEEDED,
+						InterviewErrorCode.PAYLOAD_TOO_LARGE),
+				Map.entry(OcrErrorCode.FORMAT_UNSUPPORTED,
+						InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED),
+				Map.entry(OcrErrorCode.CONTENT_INVALID, InterviewErrorCode.INPUT_INVALID),
+				Map.entry(OcrErrorCode.PIXEL_LIMIT_EXCEEDED,
+						InterviewErrorCode.INPUT_INVALID),
+				Map.entry(OcrErrorCode.UNAVAILABLE, InterviewErrorCode.SERVICE_UNAVAILABLE),
+				Map.entry(OcrErrorCode.TIMEOUT, InterviewErrorCode.DEPENDENCY_FAILED),
+				Map.entry(OcrErrorCode.PROCESS_FAILED, InterviewErrorCode.DEPENDENCY_FAILED),
+				Map.entry(OcrErrorCode.RESPONSE_INVALID, InterviewErrorCode.DEPENDENCY_FAILED));
+
+		for (OcrErrorCode source : OcrErrorCode.values()) {
+			OcrException cause = new OcrException(source);
+			InterviewException mapped = InterviewInputExceptionMapper.fromOcr(cause);
+
+			assertAll(
+					() -> assertSame(expected.get(source), mapped.errorCode()),
+					() -> assertSame(cause, mapped.getCause()));
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/ActiveSessionRegistryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/ActiveSessionRegistryTest.java
@@ -1,10 +1,21 @@
 package com.unispeaking.component.session;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.unispeaking.domain.po.session.AbstractSceneSession;
 import com.unispeaking.domain.po.session.CustomSceneSession;
+import com.unispeaking.domain.po.session.FreeChatSceneSession;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class ActiveSessionRegistryTest {
@@ -31,5 +42,82 @@ class ActiveSessionRegistryTest {
 		assertSame(registered, registry.findById("session_1").orElseThrow());
 		assertTrue(registry.remove("session_1", registered));
 		assertTrue(registry.findById("session_1").isEmpty());
+	}
+
+	@Test
+	void returnsTypedSessionsWithoutUnsafeCasts() {
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		CustomSceneSession session = new CustomSceneSession("session_1", "user_1");
+		registry.registerIfAbsent(session);
+
+		assertSame(session, registry.findById("session_1", CustomSceneSession.class).orElseThrow());
+		assertTrue(registry.findById("session_1", FreeChatSceneSession.class).isEmpty());
+	}
+
+	@Test
+	void snapshotIsStableAndUnmodifiableDuringConcurrentChanges() throws Exception {
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		CustomSceneSession original = new CustomSceneSession("session_1", "user_1");
+		registry.registerIfAbsent(original);
+		List<AbstractSceneSession> snapshot = registry.snapshot();
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			executor.submit(() -> {
+				await(start);
+				registry.remove("session_1", original);
+			});
+			executor.submit(() -> {
+				await(start);
+				registry.registerIfAbsent(new CustomSceneSession("session_2", "user_2"));
+			});
+			start.countDown();
+			executor.shutdown();
+			assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS));
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertEquals(List.of(original), snapshot);
+		assertThrows(UnsupportedOperationException.class, () -> snapshot.clear());
+		assertEquals(1, registry.snapshot().size());
+	}
+
+	@Test
+	void takesSnapshotsWhileRegistryIsMutating() throws Exception {
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<?> writer = executor.submit(() -> {
+				await(start);
+				for (int index = 0; index < 1000; index++) {
+					String sessionId = "session_" + index;
+					CustomSceneSession session = new CustomSceneSession(sessionId, "user_1");
+					registry.registerIfAbsent(session);
+					if (index % 2 == 0) {
+						registry.remove(sessionId, session);
+					}
+				}
+			});
+			start.countDown();
+			for (int index = 0; index < 100; index++) {
+				assertTrue(registry.snapshot().stream().noneMatch(Objects::isNull));
+			}
+			writer.get(5, TimeUnit.SECONDS);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			if (!latch.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("timed out waiting for concurrent registry test");
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("registry test interrupted", exception);
+		}
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
@@ -1,0 +1,250 @@
+package com.unispeaking.component.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.jupiter.api.Test;
+
+class InterviewExecutionCoordinatorTest {
+
+	@Test
+	void serializesTasksForTheSameInterviewAndTracksQueuedWork() throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(executor);
+		CountDownLatch firstStarted = new CountDownLatch(1);
+		CountDownLatch releaseFirst = new CountDownLatch(1);
+		CountDownLatch finished = new CountDownLatch(2);
+		List<Integer> order = new CopyOnWriteArrayList<>();
+		AtomicInteger concurrentTasks = new AtomicInteger();
+		AtomicInteger maximumConcurrency = new AtomicInteger();
+		try {
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, () -> {
+				trackConcurrency(concurrentTasks, maximumConcurrency);
+				order.add(1);
+				firstStarted.countDown();
+				await(releaseFirst);
+				concurrentTasks.decrementAndGet();
+				finished.countDown();
+			});
+			assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+			coordinator.execute("interview_1", InterviewTaskType.FINALIZING, () -> {
+				trackConcurrency(concurrentTasks, maximumConcurrency);
+				order.add(2);
+				concurrentTasks.decrementAndGet();
+				finished.countDown();
+			});
+
+			InterviewExecutionState queued = coordinator.state("interview_1");
+			assertEquals(1, queued.processingTasks());
+			assertEquals(1, queued.finalizingTasks());
+			assertTrue(queued.busy());
+			releaseFirst.countDown();
+			assertTrue(finished.await(5, TimeUnit.SECONDS));
+			assertEquals(List.of(1, 2), order);
+			assertEquals(1, maximumConcurrency.get());
+			assertFalse(coordinator.isBusy("interview_1"));
+		} finally {
+			releaseFirst.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void allowsDifferentInterviewsToRunInParallel() throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(executor);
+		CountDownLatch bothStarted = new CountDownLatch(2);
+		CountDownLatch release = new CountDownLatch(1);
+		CountDownLatch finished = new CountDownLatch(2);
+		try {
+			Runnable task = () -> {
+				bothStarted.countDown();
+				await(release);
+				finished.countDown();
+			};
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, task);
+			coordinator.execute("interview_2", InterviewTaskType.PROCESSING, task);
+
+			assertTrue(bothStarted.await(5, TimeUnit.SECONDS));
+			release.countDown();
+			assertTrue(finished.await(5, TimeUnit.SECONDS));
+		} finally {
+			release.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void preservesSubmissionOrderForQueuedInterviewTasks() throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(4);
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(executor);
+		List<Integer> order = new CopyOnWriteArrayList<>();
+		CountDownLatch finished = new CountDownLatch(20);
+		try {
+			for (int index = 0; index < 20; index++) {
+				int value = index;
+				coordinator.execute("interview_1", InterviewTaskType.PROCESSING, () -> {
+					order.add(value);
+					finished.countDown();
+				});
+			}
+			assertTrue(finished.await(5, TimeUnit.SECONDS));
+			assertEquals(
+					List.of(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19),
+					order);
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void rollsBackBusyStateWhenExecutorRejectsTask() {
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				task -> { throw new RejectedExecutionException("full"); });
+
+		assertThrows(
+				RejectedExecutionException.class,
+				() -> coordinator.execute(
+						"interview_1", InterviewTaskType.PROCESSING, () -> { }));
+		assertFalse(coordinator.isBusy("interview_1"));
+	}
+
+	@Test
+	void taskFailureDoesNotStrandLaterWorkOrBusyState() throws Exception {
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				task -> executor.submit(task));
+		CountDownLatch firstStarted = new CountDownLatch(1);
+		CountDownLatch releaseFirst = new CountDownLatch(1);
+		CountDownLatch secondFinished = new CountDownLatch(1);
+		try {
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, () -> {
+				firstStarted.countDown();
+				await(releaseFirst);
+				throw new IllegalStateException("provider failed");
+			});
+			assertTrue(firstStarted.await(5, TimeUnit.SECONDS));
+			coordinator.execute(
+					"interview_1", InterviewTaskType.FINALIZING, secondFinished::countDown);
+			releaseFirst.countDown();
+
+			assertTrue(secondFinished.await(5, TimeUnit.SECONDS));
+			assertFalse(coordinator.isBusy("interview_1"));
+		} finally {
+			releaseFirst.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void synchronousLockUsesTheSamePerInterviewBoundary() throws Exception {
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(executor);
+		CountDownLatch locked = new CountDownLatch(1);
+		CountDownLatch release = new CountDownLatch(1);
+		CountDownLatch asyncFinished = new CountDownLatch(1);
+		Thread holder = new Thread(() -> coordinator.withLock("interview_1", () -> {
+			locked.countDown();
+			await(release);
+		}));
+		try {
+			holder.start();
+			assertTrue(locked.await(5, TimeUnit.SECONDS));
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, asyncFinished::countDown);
+			assertFalse(asyncFinished.await(100, TimeUnit.MILLISECONDS));
+			release.countDown();
+			assertTrue(asyncFinished.await(5, TimeUnit.SECONDS));
+			holder.join(5000);
+			assertFalse(holder.isAlive());
+		} finally {
+			release.countDown();
+			holder.join(5000);
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void busyQueryKeepsItsSlotAcrossReleaseAndNewTaskAcceptance() throws Exception {
+		ExecutorService taskExecutor = Executors.newFixedThreadPool(2);
+		ExecutorService queryExecutor = Executors.newSingleThreadExecutor();
+		CountDownLatch firstTaskStarted = new CountDownLatch(1);
+		CountDownLatch releaseFirstTask = new CountDownLatch(1);
+		CountDownLatch firstDrainFinished = new CountDownLatch(1);
+		CountDownLatch stateRetainedSlot = new CountDownLatch(1);
+		CountDownLatch releaseStateRead = new CountDownLatch(1);
+		AtomicBoolean blockStateRead = new AtomicBoolean();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				task -> taskExecutor.submit(() -> {
+					try {
+						task.run();
+					} finally {
+						firstDrainFinished.countDown();
+					}
+				}),
+				() -> {
+					if (blockStateRead.compareAndSet(true, false)) {
+						stateRetainedSlot.countDown();
+						await(releaseStateRead);
+					}
+				});
+		CountDownLatch secondTaskStarted = new CountDownLatch(1);
+		CountDownLatch releaseSecondTask = new CountDownLatch(1);
+		try {
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, () -> {
+				firstTaskStarted.countDown();
+				await(releaseFirstTask);
+			});
+			assertTrue(firstTaskStarted.await(5, TimeUnit.SECONDS));
+
+			blockStateRead.set(true);
+			Future<Boolean> state = queryExecutor.submit(() -> coordinator.isBusy("interview_1"));
+			assertTrue(stateRetainedSlot.await(5, TimeUnit.SECONDS));
+			releaseFirstTask.countDown();
+			assertTrue(firstDrainFinished.await(5, TimeUnit.SECONDS));
+
+			coordinator.execute("interview_1", InterviewTaskType.PROCESSING, () -> {
+				secondTaskStarted.countDown();
+				await(releaseSecondTask);
+			});
+			assertTrue(secondTaskStarted.await(5, TimeUnit.SECONDS));
+			releaseStateRead.countDown();
+			assertTrue(state.get(5, TimeUnit.SECONDS));
+		} finally {
+			releaseFirstTask.countDown();
+			releaseSecondTask.countDown();
+			releaseStateRead.countDown();
+			taskExecutor.shutdownNow();
+			queryExecutor.shutdownNow();
+		}
+	}
+
+	private static void trackConcurrency(
+			AtomicInteger concurrentTasks,
+			AtomicInteger maximumConcurrency) {
+		int current = concurrentTasks.incrementAndGet();
+		maximumConcurrency.accumulateAndGet(current, Math::max);
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			if (!latch.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("timed out waiting for coordinator test");
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("coordinator test interrupted", exception);
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
@@ -5,6 +5,13 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.unispeaking.domain.po.session.InterviewSubmission;
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
@@ -13,8 +20,10 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 
 class InterviewExecutionCoordinatorTest {
@@ -230,6 +239,230 @@ class InterviewExecutionCoordinatorTest {
 		}
 	}
 
+	@Test
+	void watchdogCapsDeadlineAndReleasesBusyStateWhileProviderIsBlocked() throws Exception {
+		MutableClock clock = new MutableClock(Instant.parse("2030-01-01T00:00:00Z"));
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				executor, clock, () -> { });
+		CountDownLatch providerStarted = new CountDownLatch(1);
+		CountDownLatch releaseProvider = new CountDownLatch(1);
+		CountDownLatch providerFinished = new CountDownLatch(1);
+		AtomicInteger timeouts = new AtomicInteger();
+		try {
+			coordinator.executeUntil(
+					"interview_1",
+					InterviewTaskType.PROCESSING,
+					clock.instant(),
+					Duration.ofHours(1),
+					lease -> {
+						try {
+							providerStarted.countDown();
+							await(releaseProvider);
+						} finally {
+							providerFinished.countDown();
+						}
+					},
+					timeouts::incrementAndGet);
+			assertTrue(providerStarted.await(5, TimeUnit.SECONDS));
+
+			clock.advance(Duration.ofMinutes(10).minusMillis(1));
+			assertEquals(0, coordinator.expireTasks(clock.instant()));
+			assertTrue(coordinator.isBusy("interview_1"));
+
+			clock.advance(Duration.ofMillis(1));
+			assertEquals(1, coordinator.expireTasks(clock.instant()));
+			assertEquals(1, timeouts.get());
+			assertFalse(coordinator.isBusy("interview_1"));
+		} finally {
+			releaseProvider.countDown();
+			assertTrue(providerFinished.await(5, TimeUnit.SECONDS));
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void runningSubmissionTimeoutFencesLateCommitAndDefersCleanupUntilTaskStops()
+			throws Exception {
+		MutableClock clock = new MutableClock(Instant.parse("2030-01-01T00:00:00Z"));
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				executor, clock, () -> { });
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		CountDownLatch providerStarted = new CountDownLatch(1);
+		CountDownLatch releaseProvider = new CountDownLatch(1);
+		CountDownLatch cleanupFinished = new CountDownLatch(1);
+		AtomicBoolean lateCommitAccepted = new AtomicBoolean(true);
+		AtomicInteger lateMutations = new AtomicInteger();
+		AtomicInteger temporaryCleanups = new AtomicInteger();
+		try {
+			coordinator.executeSubmission(
+					"interview_1",
+					submission,
+					lease -> {
+						providerStarted.countDown();
+						await(releaseProvider);
+						lateCommitAccepted.set(lease.commitIfActive(
+								lateMutations::incrementAndGet));
+					},
+					() -> {
+						temporaryCleanups.incrementAndGet();
+						cleanupFinished.countDown();
+					});
+			assertTrue(providerStarted.await(5, TimeUnit.SECONDS));
+
+			clock.advance(InterviewRuntimePolicy.MAXIMUM_TASK_TIMEOUT);
+			assertEquals(1, coordinator.expireTasks(clock.instant()));
+			assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, submission.status());
+			assertFalse(coordinator.isBusy("interview_1"));
+			assertFalse(coordinator.runIfIdle("interview_1", () -> { }));
+			assertEquals(0, temporaryCleanups.get());
+
+			releaseProvider.countDown();
+			assertTrue(cleanupFinished.await(5, TimeUnit.SECONDS));
+			assertFalse(lateCommitAccepted.get());
+			assertEquals(0, lateMutations.get());
+			assertEquals(1, temporaryCleanups.get());
+			assertTrue(coordinator.runIfIdle("interview_1", () -> { }));
+		} finally {
+			releaseProvider.countDown();
+			executor.shutdownNow();
+		}
+	}
+
+	@Test
+	void timeoutCallbackFailureDoesNotBlockOtherExpiredTasks() {
+		MutableClock clock = new MutableClock(Instant.parse("2030-01-01T00:00:00Z"));
+		List<Runnable> drains = new CopyOnWriteArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		AtomicInteger successfulCallbacks = new AtomicInteger();
+
+		coordinator.executeUntil(
+				"interview_1",
+				InterviewTaskType.PROCESSING,
+				clock.instant(),
+				Duration.ofMinutes(1),
+					lease -> { },
+				() -> { throw new IllegalStateException("cleanup failed"); });
+		coordinator.executeUntil(
+				"interview_2",
+				InterviewTaskType.FINALIZING,
+				clock.instant(),
+				Duration.ofMinutes(1),
+					lease -> { },
+				successfulCallbacks::incrementAndGet);
+
+		clock.advance(Duration.ofMinutes(1));
+		assertEquals(2, coordinator.expireTasks(clock.instant()));
+		assertEquals(1, successfulCallbacks.get());
+		assertFalse(coordinator.isBusy("interview_1"));
+		assertFalse(coordinator.isBusy("interview_2"));
+		drains.forEach(Runnable::run);
+	}
+
+	@Test
+	void failedTimeoutCallbackIsRetriedWithoutRestoringBusyState() {
+		MutableClock clock = new MutableClock(Instant.parse("2030-01-01T00:00:00Z"));
+		List<Runnable> drains = new CopyOnWriteArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		AtomicInteger attempts = new AtomicInteger();
+		coordinator.executeUntil(
+				"interview_1",
+				InterviewTaskType.PROCESSING,
+				clock.instant(),
+				Duration.ofMinutes(1),
+					lease -> { },
+				() -> {
+					if (attempts.incrementAndGet() == 1) {
+						throw new IllegalStateException("cleanup failed");
+					}
+				});
+
+		clock.advance(Duration.ofMinutes(1));
+		assertEquals(1, coordinator.expireTasks(clock.instant()));
+		assertEquals(1, attempts.get());
+		assertFalse(coordinator.isBusy("interview_1"));
+		assertTrue(coordinator.hasPendingTimeoutCallback("interview_1"));
+
+		assertEquals(0, coordinator.expireTasks(clock.instant()));
+		assertEquals(2, attempts.get());
+		assertFalse(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertFalse(coordinator.isBusy("interview_1"));
+	}
+
+	@Test
+	void timeoutCallbackErrorIsRetriedWithoutBlockingOtherInterviews() {
+		MutableClock clock = new MutableClock(Instant.parse("2030-01-01T00:00:00Z"));
+		List<Runnable> drains = new CopyOnWriteArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		AtomicInteger errorAttempts = new AtomicInteger();
+		AtomicInteger otherCallbacks = new AtomicInteger();
+		coordinator.executeUntil(
+				"interview_1",
+				InterviewTaskType.PROCESSING,
+				clock.instant(),
+				Duration.ofMinutes(1),
+					lease -> { },
+				() -> {
+					if (errorAttempts.incrementAndGet() == 1) {
+						throw new AssertionError("cleanup error");
+					}
+				});
+		coordinator.executeUntil(
+				"interview_2",
+				InterviewTaskType.FINALIZING,
+				clock.instant(),
+				Duration.ofMinutes(1),
+					lease -> { },
+				otherCallbacks::incrementAndGet);
+
+		clock.advance(Duration.ofMinutes(1));
+		assertEquals(2, coordinator.expireTasks(clock.instant()));
+		assertEquals(1, errorAttempts.get());
+		assertEquals(1, otherCallbacks.get());
+		assertTrue(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertFalse(coordinator.isBusy("interview_1"));
+		assertFalse(coordinator.isBusy("interview_2"));
+
+		assertEquals(0, coordinator.expireTasks(clock.instant()));
+		assertEquals(2, errorAttempts.get());
+		assertFalse(coordinator.hasPendingTimeoutCallback("interview_1"));
+	}
+
+	@Test
+	void idleMaintenanceFencesConcurrentTaskAcceptanceWithoutUsingProviderLock() throws Exception {
+		List<Runnable> drains = new CopyOnWriteArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(drains::add);
+		ExecutorService callers = Executors.newFixedThreadPool(2);
+		CountDownLatch maintenanceStarted = new CountDownLatch(1);
+		CountDownLatch releaseMaintenance = new CountDownLatch(1);
+		try {
+			Future<Boolean> maintenance = callers.submit(() -> coordinator.runIfIdle(
+					"interview_1",
+					() -> {
+						maintenanceStarted.countDown();
+						await(releaseMaintenance);
+					}));
+			assertTrue(maintenanceStarted.await(5, TimeUnit.SECONDS));
+			Future<?> acceptance = callers.submit(() -> coordinator.execute(
+					"interview_1", InterviewTaskType.PROCESSING, () -> { }));
+
+			assertThrows(TimeoutException.class, () -> acceptance.get(100, TimeUnit.MILLISECONDS));
+			assertTrue(drains.isEmpty());
+			releaseMaintenance.countDown();
+			assertTrue(maintenance.get(5, TimeUnit.SECONDS));
+			acceptance.get(5, TimeUnit.SECONDS);
+			assertEquals(1, drains.size());
+		} finally {
+			releaseMaintenance.countDown();
+			callers.shutdownNow();
+		}
+	}
+
 	private static void trackConcurrency(
 			AtomicInteger concurrentTasks,
 			AtomicInteger maximumConcurrency) {
@@ -246,5 +479,29 @@ class InterviewExecutionCoordinatorTest {
 			Thread.currentThread().interrupt();
 			throw new IllegalStateException("coordinator test interrupted", exception);
 		}
+	}
+
+	private static final class MutableClock extends Clock {
+
+		private final AtomicReference<Instant> now;
+
+		private MutableClock(Instant now) {
+			this.now = new AtomicReference<>(now);
+		}
+
+		private void advance(Duration duration) {
+			now.updateAndGet(current -> current.plus(duration));
+		}
+
+		@Override
+		public ZoneId getZone() { return ZoneOffset.UTC; }
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return zone.equals(ZoneOffset.UTC) ? this : Clock.fixed(instant(), zone);
+		}
+
+		@Override
+		public Instant instant() { return now.get(); }
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewExecutionCoordinatorTest.java
@@ -31,7 +31,15 @@ class InterviewExecutionCoordinatorTest {
 	@Test
 	void serializesTasksForTheSameInterviewAndTracksQueuedWork() throws Exception {
 		ExecutorService executor = Executors.newFixedThreadPool(2);
-		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(executor);
+		CountDownLatch drainFinished = new CountDownLatch(1);
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				task -> executor.submit(() -> {
+					try {
+						task.run();
+					} finally {
+						drainFinished.countDown();
+					}
+				}));
 		CountDownLatch firstStarted = new CountDownLatch(1);
 		CountDownLatch releaseFirst = new CountDownLatch(1);
 		CountDownLatch finished = new CountDownLatch(2);
@@ -61,6 +69,7 @@ class InterviewExecutionCoordinatorTest {
 			assertTrue(queued.busy());
 			releaseFirst.countDown();
 			assertTrue(finished.await(5, TimeUnit.SECONDS));
+			assertTrue(drainFinished.await(5, TimeUnit.SECONDS));
 			assertEquals(List.of(1, 2), order);
 			assertEquals(1, maximumConcurrency.get());
 			assertFalse(coordinator.isBusy("interview_1"));
@@ -133,8 +142,15 @@ class InterviewExecutionCoordinatorTest {
 	@Test
 	void taskFailureDoesNotStrandLaterWorkOrBusyState() throws Exception {
 		ExecutorService executor = Executors.newSingleThreadExecutor();
+		CountDownLatch drainFinished = new CountDownLatch(1);
 		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
-				task -> executor.submit(task));
+				task -> executor.submit(() -> {
+					try {
+						task.run();
+					} finally {
+						drainFinished.countDown();
+					}
+				}));
 		CountDownLatch firstStarted = new CountDownLatch(1);
 		CountDownLatch releaseFirst = new CountDownLatch(1);
 		CountDownLatch secondFinished = new CountDownLatch(1);
@@ -150,6 +166,7 @@ class InterviewExecutionCoordinatorTest {
 			releaseFirst.countDown();
 
 			assertTrue(secondFinished.await(5, TimeUnit.SECONDS));
+			assertTrue(drainFinished.await(5, TimeUnit.SECONDS));
 			assertFalse(coordinator.isBusy("interview_1"));
 		} finally {
 			releaseFirst.countDown();

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewRuntimeSupervisorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/InterviewRuntimeSupervisorTest.java
@@ -1,0 +1,574 @@
+package com.unispeaking.component.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.domain.po.session.InterviewSession;
+import com.unispeaking.domain.po.session.InterviewSubmission;
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.InterviewPlannedQuestion;
+import com.unispeaking.domain.vo.scene.InterviewQuestionPlan;
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+class InterviewRuntimeSupervisorTest {
+
+	private static final Instant START = Instant.parse("2030-01-01T00:00:00Z");
+	private static final InterviewRuntimePolicy POLICY = InterviewRuntimePolicy.defaults();
+
+	@Test
+	void stateHeartbeatAndBusinessActivityRefreshLastSeenAndResumeWithoutChangingProgress() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("First question");
+		var questions = session.actualQuestions();
+		registry.save(session);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, directCoordinator(clock), clock, List.of());
+
+		clock.advance(POLICY.idleTimeout());
+		assertEquals(1, supervisor.scan());
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+
+		clock.advance(Duration.ofMinutes(1));
+		assertSame(session, supervisor.recordStateQuery("session_1").orElseThrow());
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+		assertEquals(clock.instant(), session.lastSeen());
+		assertEquals(questions, session.actualQuestions());
+
+		clock.advance(Duration.ofSeconds(1));
+		assertTrue(supervisor.recordHeartbeat("interview_1").isPresent());
+		assertEquals(clock.instant(), session.lastSeen());
+		clock.advance(Duration.ofSeconds(1));
+		assertTrue(supervisor.recordBusinessActivity("session_1").isPresent());
+		assertEquals(clock.instant(), session.lastSeen());
+		assertEquals(questions, session.actualQuestions());
+	}
+
+	@Test
+	void acceptedProcessingAndFinalizingSessionsAreExcludedFromIdleCleanup() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		List<Runnable> drains = new CopyOnWriteArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		InterviewSession accepted = activeSession("session_a", "interview_a", clock);
+		accepted.recordMainQuestion("Question");
+		accepted.registerSubmission(new InterviewSubmission(
+				"submission_a", 1, "digest_a", clock.instant()));
+		InterviewSession processing = activeSession("session_p", "interview_p", clock);
+		InterviewSession finalizing = activeSession("session_f", "interview_f", clock);
+		registry.save(accepted);
+		registry.save(processing);
+		registry.save(finalizing);
+		coordinator.execute("interview_p", InterviewTaskType.PROCESSING, () -> { });
+		coordinator.execute("interview_f", InterviewTaskType.FINALIZING, () -> { });
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, coordinator, clock, List.of());
+
+		clock.advance(Duration.ofMinutes(9));
+		assertEquals(0, supervisor.scan());
+		assertEquals(SessionStatus.ACTIVE, accepted.getStatus());
+		assertEquals(SessionStatus.ACTIVE, processing.getStatus());
+		assertEquals(SessionStatus.ACTIVE, finalizing.getStatus());
+		assertEquals(3, registry.snapshot().size());
+	}
+
+	@Test
+	void watchdogFailsQueuedSubmissionCleansTemporaryDataAndReleasesRuntime() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		List<Runnable> drains = new ArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("Question");
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		session.registerSubmission(submission);
+		registry.save(session);
+		AtomicInteger providerCalls = new AtomicInteger();
+		AtomicInteger temporaryCleanups = new AtomicInteger();
+		List<ExpiredInterviewCleanupRequest> cleanups = new ArrayList<>();
+		coordinator.executeSubmission(
+				"interview_1",
+				submission,
+					lease -> providerCalls.incrementAndGet(),
+				temporaryCleanups::incrementAndGet);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, coordinator, clock, List.of(cleanups::add));
+
+		clock.advance(POLICY.taskTimeout());
+		assertEquals(2, supervisor.scan());
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, submission.status());
+		assertEquals("INTERVIEW_SUBMISSION_TIMEOUT", submission.errorCode());
+		assertEquals(1, temporaryCleanups.get());
+		assertFalse(coordinator.isBusy("interview_1"));
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+		assertTrue(registry.findById("session_1").isPresent());
+		assertTrue(cleanups.isEmpty());
+
+		clock.advance(POLICY.recoveryWindow());
+		assertEquals(1, supervisor.scan());
+		assertTrue(registry.findById("session_1").isEmpty());
+		assertEquals("interview_1", cleanups.getFirst().interviewId());
+
+		drains.forEach(Runnable::run);
+		assertEquals(0, providerCalls.get());
+	}
+
+	@Test
+	void orphanedAcceptedSubmissionExpiresFromItsAcceptanceTime() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("Question");
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		session.registerSubmission(submission);
+		registry.save(session);
+		List<ExpiredInterviewSubmissionCleanupRequest> submissionCleanups =
+				new ArrayList<>();
+		AtomicReference<InterviewSubmissionStatus> statusAtCleanup = new AtomicReference<>();
+		List<ExpiredInterviewCleanupRequest> interviewCleanups = new ArrayList<>();
+		InterviewRuntimeSupervisor supervisor = new InterviewRuntimeSupervisor(
+				registry,
+				directCoordinator(clock),
+				clock,
+				POLICY,
+				mock(ScheduledExecutorService.class),
+				List.of(interviewCleanups::add),
+				List.of(request -> {
+					statusAtCleanup.set(submission.status());
+					submissionCleanups.add(request);
+				}));
+
+		clock.advance(POLICY.taskTimeout());
+		assertEquals(2, supervisor.scan());
+
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, submission.status());
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, statusAtCleanup.get());
+		assertEquals(1, submissionCleanups.size());
+		assertEquals("submission_1", submissionCleanups.getFirst().submissionId());
+		assertEquals(START.plus(POLICY.taskTimeout()),
+				submissionCleanups.getFirst().deadline());
+		assertTrue(interviewCleanups.isEmpty());
+		assertTrue(registry.findById("session_1").isPresent());
+
+		clock.advance(POLICY.recoveryWindow());
+		assertEquals(1, supervisor.scan());
+		assertEquals(1, interviewCleanups.size());
+		assertTrue(registry.findById("session_1").isEmpty());
+	}
+
+	@Test
+	void failedOrphanedSubmissionCleanupIsRetriedBeforeSessionCanExpire() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("Question");
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		session.registerSubmission(submission);
+		registry.save(session);
+		AtomicInteger cleanupAttempts = new AtomicInteger();
+		InterviewRuntimeSupervisor supervisor = new InterviewRuntimeSupervisor(
+				registry,
+				directCoordinator(clock),
+				clock,
+				POLICY,
+				mock(ScheduledExecutorService.class),
+				List.of(),
+				List.of(request -> {
+					if (cleanupAttempts.incrementAndGet() == 1) {
+						throw new IllegalStateException("temporary cleanup unavailable");
+					}
+				}));
+
+		clock.advance(POLICY.taskTimeout());
+		assertEquals(1, supervisor.scan());
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, submission.status());
+		assertEquals(1, cleanupAttempts.get());
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+		assertTrue(registry.findById("session_1").isPresent());
+
+		assertEquals(1, supervisor.scan());
+		assertEquals(2, cleanupAttempts.get());
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+		assertTrue(registry.findById("session_1").isPresent());
+	}
+
+	@Test
+	void failedSubmissionTimeoutCleanupIsRetriedBeforeRuntimeCanExpire() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		List<Runnable> drains = new ArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("Question");
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		session.registerSubmission(submission);
+		registry.save(session);
+		AtomicInteger cleanupAttempts = new AtomicInteger();
+		coordinator.executeSubmission(
+				"interview_1",
+				submission,
+					lease -> { },
+				() -> {
+					if (cleanupAttempts.incrementAndGet() == 1) {
+						throw new IllegalStateException("temporary cleanup unavailable");
+					}
+				});
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, coordinator, clock, List.of());
+
+		clock.advance(POLICY.taskTimeout());
+		assertEquals(1, supervisor.scan());
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, submission.status());
+		assertFalse(coordinator.isBusy("interview_1"));
+		assertTrue(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertTrue(registry.findById("session_1").isPresent());
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+
+		assertEquals(1, supervisor.scan());
+		assertEquals(2, cleanupAttempts.get());
+		assertFalse(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+		assertTrue(registry.findById("session_1").isPresent());
+	}
+
+	@Test
+	void runningCleanupRetryRemainsVisibleToConcurrentScans() throws Exception {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		List<Runnable> drains = new ArrayList<>();
+		InterviewExecutionCoordinator coordinator = new InterviewExecutionCoordinator(
+				drains::add, clock, () -> { });
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		session.recordMainQuestion("Question");
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", clock.instant());
+		session.registerSubmission(submission);
+		registry.save(session);
+		AtomicInteger cleanupAttempts = new AtomicInteger();
+		CountDownLatch retryStarted = new CountDownLatch(1);
+		CountDownLatch releaseRetry = new CountDownLatch(1);
+		coordinator.executeSubmission(
+				"interview_1",
+				submission,
+					lease -> { },
+				() -> {
+					int attempt = cleanupAttempts.incrementAndGet();
+					if (attempt == 1) {
+						throw new IllegalStateException("temporary cleanup unavailable");
+					}
+					if (attempt == 2) {
+						retryStarted.countDown();
+						await(releaseRetry);
+						throw new AssertionError("temporary cleanup still unavailable");
+					}
+				});
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, coordinator, clock, List.of());
+		clock.advance(POLICY.taskTimeout());
+		assertEquals(1, supervisor.scan());
+
+		ExecutorService retryExecutor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Integer> retryScan = retryExecutor.submit(supervisor::scan);
+			assertTrue(retryStarted.await(5, TimeUnit.SECONDS));
+			assertTrue(coordinator.hasPendingTimeoutCallback("interview_1"));
+
+			assertEquals(0, supervisor.scan());
+			assertEquals(SessionStatus.ACTIVE, session.getStatus());
+			assertTrue(registry.findById("session_1").isPresent());
+
+			releaseRetry.countDown();
+			assertEquals(0, retryScan.get(5, TimeUnit.SECONDS));
+		} finally {
+			releaseRetry.countDown();
+			retryExecutor.shutdownNow();
+		}
+
+		assertTrue(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertEquals(1, supervisor.scan());
+		assertFalse(coordinator.hasPendingTimeoutCallback("interview_1"));
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+		assertTrue(registry.findById("session_1").isPresent());
+	}
+
+	@Test
+	void cleanupFailureIsIsolatedAndRetriedSessionRemainsRegistered() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession failedCleanup = activeSession("session_1", "interview_1", clock);
+		InterviewSession successfulCleanup = activeSession("session_2", "interview_2", clock);
+		registry.save(failedCleanup);
+		registry.save(successfulCleanup);
+		List<String> attempted = new CopyOnWriteArrayList<>();
+		ExpiredInterviewCleanup cleanup = request -> {
+			attempted.add(request.sessionId());
+			if (request.sessionId().equals("session_1")) {
+				throw new IllegalStateException("downstream unavailable");
+			}
+		};
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, directCoordinator(clock), clock, List.of(cleanup));
+
+		clock.advance(POLICY.idleTimeout());
+		supervisor.scan();
+		clock.advance(POLICY.recoveryWindow());
+		supervisor.scan();
+
+		assertEquals(2, attempted.size());
+		assertTrue(registry.findById("session_1").isPresent());
+		assertTrue(registry.findById("session_2").isEmpty());
+		assertEquals(SessionStatus.INTERRUPTED, failedCleanup.getStatus());
+	}
+
+	@Test
+	void recoveryWindowBoundaryExpiresInsteadOfResuming() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		registry.save(session);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, directCoordinator(clock), clock, List.of());
+
+		clock.advance(POLICY.idleTimeout());
+		supervisor.scan();
+		clock.advance(POLICY.recoveryWindow());
+
+		assertTrue(supervisor.recordHeartbeat("session_1").isEmpty());
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+	}
+
+	@Test
+	void interruptedSessionCanRecoverForTheFullRecoveryWindow() {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		registry.save(session);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, directCoordinator(clock), clock, List.of());
+
+		clock.advance(POLICY.idleTimeout());
+		supervisor.scan();
+		Instant interruptedAt = clock.instant();
+		clock.advance(POLICY.recoveryWindow().minusMillis(1));
+
+		assertSame(session, supervisor.recordHeartbeat("session_1").orElseThrow());
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+		assertTrue(session.interruptedAt().isEmpty());
+		assertEquals(interruptedAt.plus(POLICY.recoveryWindow()).minusMillis(1),
+				session.lastSeen());
+	}
+
+	@Test
+	void concurrentIdleScanAndHeartbeatCannotLeaveTouchedSessionInterrupted() throws Exception {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		registry.save(session);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry, directCoordinator(clock), clock, List.of());
+		clock.advance(POLICY.idleTimeout());
+		CountDownLatch start = new CountDownLatch(1);
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			Future<?> scan = executor.submit(() -> {
+				await(start);
+				supervisor.scan();
+			});
+			Future<?> heartbeat = executor.submit(() -> {
+				await(start);
+				supervisor.recordHeartbeat("session_1");
+			});
+			start.countDown();
+			scan.get(5, TimeUnit.SECONDS);
+			heartbeat.get(5, TimeUnit.SECONDS);
+		} finally {
+			executor.shutdownNow();
+		}
+
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+		assertEquals(clock.instant(), session.lastSeen());
+		assertSame(session, registry.findById("session_1").orElseThrow());
+	}
+
+	@Test
+	void heartbeatCannotReviveSessionAfterExpirationCleanupIsClaimed() throws Exception {
+		MutableClock clock = new MutableClock(START);
+		ActiveSessionRegistry registry = new ActiveSessionRegistry();
+		InterviewSession session = activeSession("session_1", "interview_1", clock);
+		registry.save(session);
+		CountDownLatch cleanupStarted = new CountDownLatch(1);
+		CountDownLatch releaseCleanup = new CountDownLatch(1);
+		InterviewRuntimeSupervisor supervisor = supervisor(
+				registry,
+				directCoordinator(clock),
+				clock,
+				List.of(request -> {
+					cleanupStarted.countDown();
+					await(releaseCleanup);
+				}));
+		clock.advance(POLICY.idleTimeout());
+		assertEquals(1, supervisor.scan());
+		clock.advance(POLICY.recoveryWindow());
+
+		ExecutorService executor = Executors.newSingleThreadExecutor();
+		try {
+			Future<Integer> cleanup = executor.submit(supervisor::scan);
+			assertTrue(cleanupStarted.await(5, TimeUnit.SECONDS));
+			assertTrue(session.expirationCleanupClaimed());
+			assertTrue(supervisor.recordHeartbeat("session_1").isEmpty());
+
+			releaseCleanup.countDown();
+			assertEquals(1, cleanup.get(5, TimeUnit.SECONDS));
+		} finally {
+			releaseCleanup.countDown();
+			executor.shutdownNow();
+		}
+
+		assertTrue(registry.findById("session_1").isEmpty());
+		assertEquals(SessionStatus.INTERRUPTED, session.getStatus());
+	}
+
+	@Test
+	void scheduledScanStartsOnceAndCloseCancelsItsFuture() {
+		MutableClock clock = new MutableClock(START);
+		ScheduledExecutorService scheduler = mock(ScheduledExecutorService.class);
+		@SuppressWarnings("unchecked")
+		ScheduledFuture<Object> future = mock(ScheduledFuture.class);
+		AtomicReference<Runnable> scheduledScan = new AtomicReference<>();
+		when(future.isCancelled()).thenReturn(false);
+		when(scheduler.scheduleAtFixedRate(
+				any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class)))
+				.thenAnswer(invocation -> {
+					scheduledScan.set(invocation.getArgument(0));
+					return future;
+				});
+		InterviewRuntimeSupervisor supervisor = new InterviewRuntimeSupervisor(
+				new ActiveSessionRegistry(),
+				directCoordinator(clock),
+				clock,
+				POLICY,
+				scheduler,
+				List.of(),
+				List.of());
+
+		supervisor.start();
+		supervisor.start();
+		assertTrue(supervisor.isRunning());
+		scheduledScan.get().run();
+		verify(scheduler, times(1)).scheduleAtFixedRate(
+				any(Runnable.class), anyLong(), anyLong(), any(TimeUnit.class));
+
+		supervisor.close();
+		verify(future).cancel(false);
+		assertFalse(supervisor.isRunning());
+	}
+
+	private static InterviewRuntimeSupervisor supervisor(
+			ActiveSessionRegistry registry,
+			InterviewExecutionCoordinator coordinator,
+			Clock clock,
+			List<ExpiredInterviewCleanup> cleanups) {
+		return new InterviewRuntimeSupervisor(
+				registry,
+				coordinator,
+				clock,
+				POLICY,
+				mock(ScheduledExecutorService.class),
+				cleanups,
+				List.of());
+	}
+
+	private static InterviewExecutionCoordinator directCoordinator(Clock clock) {
+		return new InterviewExecutionCoordinator(Runnable::run, clock, () -> { });
+	}
+
+	private static InterviewSession activeSession(
+			String sessionId,
+			String interviewId,
+			MutableClock clock) {
+		InterviewSession session = new InterviewSession(
+				sessionId, "user_1", interviewId, plan());
+		session.activate();
+		session.touch(clock.instant());
+		return session;
+	}
+
+	private static InterviewQuestionPlan plan() {
+		return new InterviewQuestionPlan(
+				InterviewDifficulty.STANDARD,
+				IntStream.rangeClosed(1, 5)
+						.mapToObj(no -> new InterviewPlannedQuestion(no, "Main " + no, 1))
+						.toList());
+	}
+
+	private static void await(CountDownLatch latch) {
+		try {
+			if (!latch.await(5, TimeUnit.SECONDS)) {
+				throw new IllegalStateException("timed out waiting for runtime test");
+			}
+		} catch (InterruptedException exception) {
+			Thread.currentThread().interrupt();
+			throw new IllegalStateException("runtime test interrupted", exception);
+		}
+	}
+
+	private static final class MutableClock extends Clock {
+
+		private final AtomicReference<Instant> now;
+
+		private MutableClock(Instant now) {
+			this.now = new AtomicReference<>(now);
+		}
+
+		private void advance(Duration duration) {
+			now.updateAndGet(current -> current.plus(duration));
+		}
+
+		@Override
+		public ZoneId getZone() { return ZoneOffset.UTC; }
+
+		@Override
+		public Clock withZone(ZoneId zone) {
+			return zone.equals(ZoneOffset.UTC) ? this : Clock.fixed(instant(), zone);
+		}
+
+		@Override
+		public Instant instant() { return now.get(); }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/dto/scene/InterviewApiContractTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/dto/scene/InterviewApiContractTest.java
@@ -1,0 +1,385 @@
+package com.unispeaking.domain.dto.scene;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.InterviewQuestionType;
+import com.unispeaking.domain.vo.scene.InterviewReportType;
+import com.unispeaking.domain.vo.scene.TargetRoleSummary;
+import java.lang.reflect.RecordComponent;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+
+class InterviewApiContractTest {
+
+	@Test
+	void freezesAnswerAndStatePollingFields() {
+		assertArrayEquals(
+				new String[] {"submissionId", "questionNo"},
+				fields(InterviewAnswerRequest.class));
+		assertArrayEquals(
+				new String[] {"submission", "statePath"},
+				fields(InterviewAnswerAcceptedResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"submissionId", "questionNo", "processingStatus", "retryable",
+					"errorCode", "message", "updatedAt"
+				},
+				fields(InterviewSubmissionResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "sessionId", "status", "errorCode", "message",
+					"retryable", "currentQuestionNo",
+					"acceptingSubmissions", "endRequested", "confirmationRequired",
+					"actualWords", "minimumWords", "lastSeen", "latestSubmission",
+					"nextQuestion"
+				},
+				fields(InterviewStateResponse.class));
+		assertArrayEquals(
+				new InterviewProcessingStatus[] {
+					InterviewProcessingStatus.ACCEPTED,
+					InterviewProcessingStatus.PROCESSING,
+					InterviewProcessingStatus.COMPLETED,
+					InterviewProcessingStatus.FAILED
+				},
+				InterviewProcessingStatus.values());
+	}
+
+	@Test
+	void freezesEndConfirmationAndWaitingContract() {
+		assertArrayEquals(
+				new String[] {"confirmInsufficientData"},
+				fields(EndInterviewRequest.class));
+		assertArrayEquals(
+				new InterviewEndStatus[] {
+					InterviewEndStatus.WAITING_FOR_SUBMISSIONS,
+					InterviewEndStatus.CONFIRMATION_REQUIRED,
+					InterviewEndStatus.FINALIZING,
+					InterviewEndStatus.COMPLETED,
+					InterviewEndStatus.FAILED
+				},
+				InterviewEndStatus.values());
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "processingStatus", "reportType",
+					"confirmationRequired", "actualWords", "minimumWords"
+				},
+				fields(EndInterviewResponse.class));
+	}
+
+	@Test
+	void freezesAllTwelveEndpointMappingsAndReuseDecisions() {
+		List<InterviewEndpointContract> endpoints = InterviewApiContractCatalog.endpoints();
+
+		assertEquals(12, endpoints.size());
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews/job-description/ocr",
+				HttpStatus.OK, Void.class, InterviewJobDescriptionOcrResponse.class);
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews",
+				HttpStatus.CREATED, CreateInterviewRequest.class, CreateInterviewResponse.class);
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews/{id}/answers",
+				HttpStatus.ACCEPTED, InterviewAnswerRequest.class,
+				InterviewAnswerAcceptedResponse.class);
+		assertEndpoint(endpoints, HttpMethod.GET, "/api/interviews/{id}/state",
+				HttpStatus.OK, Void.class, InterviewStateResponse.class);
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews/{id}/heartbeat",
+				HttpStatus.OK, Void.class, InterviewHeartbeatResponse.class);
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews/{id}/end",
+				HttpStatus.ACCEPTED, EndInterviewRequest.class, EndInterviewResponse.class);
+		assertEndpoint(endpoints, HttpMethod.GET, "/api/interviews",
+				HttpStatus.OK, Void.class, InterviewHistoryResponse.class);
+		assertEndpoint(endpoints, HttpMethod.GET, "/api/interviews/{id}",
+				HttpStatus.OK, Void.class, InterviewDetailResponse.class);
+		assertEndpoint(endpoints, HttpMethod.GET, "/api/interviews/{id}/recording",
+				HttpStatus.OK, Void.class, InterviewRecordingResponse.class);
+		assertEndpoint(endpoints, HttpMethod.GET, "/api/interviews/trends",
+				HttpStatus.OK, Void.class, InterviewTrendResponse.class);
+		assertEndpoint(endpoints, HttpMethod.POST, "/api/interviews/{sourceId}/repractice",
+				HttpStatus.CREATED, Void.class, CreateInterviewResponse.class);
+		assertEndpoint(endpoints, HttpMethod.DELETE, "/api/interviews/{id}",
+				HttpStatus.OK, Void.class, DeleteInterviewResponse.class);
+		assertThrows(
+				UnsupportedOperationException.class,
+				() -> InterviewApiContractCatalog.endpoints().clear());
+	}
+
+	@Test
+	void freezesRemainingPublicResponseFields() {
+		assertArrayEquals(
+				new String[] {"jobTitle", "difficulty", "jobDescription", "resumeText"},
+				fields(CreateInterviewRequest.class));
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "sessionId", "difficulty", "status", "roleSummary",
+					"firstQuestion"
+				},
+				fields(CreateInterviewResponse.class));
+		assertArrayEquals(new String[] {"text"}, fields(InterviewJobDescriptionOcrResponse.class));
+		assertArrayEquals(
+				new String[] {"interviewId", "status", "lastSeen"},
+				fields(InterviewHeartbeatResponse.class));
+		assertArrayEquals(new String[] {"interviews"}, fields(InterviewHistoryResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "jobTitle", "difficulty", "reportType", "overallScore",
+					"recordingDurationSeconds", "completedAt"
+				},
+				fields(InterviewHistoryItemResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "jobTitle", "difficulty", "roleSummary", "questions",
+					"report", "recording", "completedAt"
+				},
+				fields(InterviewDetailResponse.class));
+		assertArrayEquals(
+				new String[] {"url", "expiresAt"},
+				fields(InterviewRecordingResponse.class));
+		assertArrayEquals(
+				new String[] {"difficulty", "points"},
+				fields(InterviewTrendResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"interviewId", "reportType", "completedAt", "overallScore", "fluency",
+					"logicCoherence", "grammarControl", "pronunciationIntelligibility",
+					"vocabularyExpression"
+				},
+				fields(InterviewTrendPointResponse.class));
+		assertArrayEquals(
+				new String[] {"interviewId", "deleted"},
+				fields(DeleteInterviewResponse.class));
+		assertArrayEquals(
+				new String[] {
+					"overview", "responsibilities", "requiredSkills",
+					"qualificationRequirements"
+				},
+				fields(TargetRoleSummary.class));
+	}
+
+	@Test
+	void aiQuestionUsesBase64WithAnExplicitMimeType() {
+		InterviewAudioResponse audio = new InterviewAudioResponse(
+				"audio/wav", "UklGRg==");
+		InterviewAiQuestionResponse question = new InterviewAiQuestionResponse(
+				1, InterviewQuestionType.MAIN, "Tell me about yourself.", audio);
+
+		assertArrayEquals(
+				new String[] {"mimeType", "base64"},
+				fields(InterviewAudioResponse.class));
+		assertEquals("UklGRg==", question.audio().base64());
+		assertFalse(Arrays.stream(InterviewAudioResponse.class.getRecordComponents())
+				.anyMatch(component -> component.getType() == byte[].class));
+	}
+
+	@Test
+	void reportAlwaysContainsAllFiveDimensions() {
+		assertArrayEquals(
+				new String[] {
+					"reportType", "overallScore", "overallSummary", "fluency",
+					"logicCoherence", "grammarControl", "pronunciationIntelligibility",
+					"vocabularyExpression"
+				},
+				fields(InterviewReportResponse.class));
+
+		InterviewReportDimensionResponse dimension = new InterviewReportDimensionResponse(
+				new BigDecimal("80.0"), "评价", "建议");
+		InterviewReportResponse report = new InterviewReportResponse(
+				InterviewReportType.PARTIAL,
+				new BigDecimal("80.0"),
+				"总结",
+				dimension,
+				dimension,
+				dimension,
+				dimension,
+				dimension);
+		assertEquals(InterviewReportType.PARTIAL, report.reportType());
+	}
+
+	@Test
+	void publicCollectionsAreImmutableSnapshots() {
+		List<InterviewHistoryItemResponse> historySource = new ArrayList<>();
+		historySource.add(historyItem());
+		InterviewHistoryResponse history = new InterviewHistoryResponse(historySource);
+		historySource.clear();
+
+		assertEquals(1, history.interviews().size());
+		assertThrows(UnsupportedOperationException.class, () -> history.interviews().clear());
+
+		List<InterviewQuestionResponse> questions = new ArrayList<>(List.of(
+				new InterviewQuestionResponse(1, InterviewQuestionType.MAIN, "Question")));
+		InterviewDetailResponse detail = new InterviewDetailResponse(
+				"interview_1",
+				"Engineer",
+				InterviewDifficulty.STANDARD,
+				roleSummary(),
+				questions,
+				report(),
+				new InterviewRecordingMetadataResponse(60),
+				OffsetDateTime.parse("2026-08-05T08:00:00Z"));
+		questions.clear();
+		assertEquals(1, detail.questions().size());
+		assertThrows(UnsupportedOperationException.class, () -> detail.questions().clear());
+	}
+
+	@Test
+	void responseContractsDoNotExposePrivateRuntimeOrSourceMaterial() {
+		List<Class<?>> responseTypes = List.of(
+				CreateInterviewResponse.class,
+				InterviewJobDescriptionOcrResponse.class,
+				InterviewAiQuestionResponse.class,
+				InterviewAudioResponse.class,
+				InterviewAnswerAcceptedResponse.class,
+				InterviewSubmissionResponse.class,
+				InterviewStateResponse.class,
+				InterviewHeartbeatResponse.class,
+				EndInterviewResponse.class,
+				InterviewHistoryItemResponse.class,
+				InterviewHistoryResponse.class,
+				InterviewDetailResponse.class,
+				InterviewQuestionResponse.class,
+				InterviewRecordingMetadataResponse.class,
+				InterviewRecordingResponse.class,
+				InterviewReportDimensionResponse.class,
+				InterviewReportResponse.class,
+				InterviewTrendPointResponse.class,
+				InterviewTrendResponse.class,
+				DeleteInterviewResponse.class,
+				TargetRoleSummary.class);
+		List<String> forbidden = List.of(
+				"transcript", "asr", "provider", "payload", "digest", "objectkey",
+				"jobdescription", "resumetext", "resumecontent", "rawmaterial",
+				"speechevaluation", "speechscore", "turnscore", "phoneme", "accuracy",
+				"answeraudio", "audiobytes");
+
+		for (Class<?> responseType : responseTypes) {
+			for (String field : fields(responseType)) {
+				String normalized = field.toLowerCase(Locale.ROOT);
+				assertFalse(
+						forbidden.stream().anyMatch(normalized::contains),
+						() -> responseType.getSimpleName() + " exposes " + field);
+			}
+		}
+	}
+
+	@Test
+	void detailRejectsIncompleteCompletedAssets() {
+		OffsetDateTime completedAt = OffsetDateTime.parse("2026-08-05T08:00:00Z");
+		assertThrows(NullPointerException.class, () -> new InterviewDetailResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD, roleSummary(),
+				questions(), null, new InterviewRecordingMetadataResponse(60), completedAt));
+		assertThrows(NullPointerException.class, () -> new InterviewDetailResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD, roleSummary(),
+				questions(), report(), null, completedAt));
+		assertThrows(NullPointerException.class, () -> new InterviewDetailResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD, roleSummary(),
+				questions(), report(), new InterviewRecordingMetadataResponse(60), null));
+		assertThrows(IllegalArgumentException.class, () -> new InterviewDetailResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD, roleSummary(),
+				List.of(), report(), new InterviewRecordingMetadataResponse(60), completedAt));
+		assertThrows(NullPointerException.class, () -> new InterviewDetailResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD, null,
+				questions(), report(), new InterviewRecordingMetadataResponse(60), completedAt));
+	}
+
+	@Test
+	void historyAndTrendsRejectIncompleteOrPartialAssets() {
+		OffsetDateTime completedAt = OffsetDateTime.parse("2026-08-05T08:00:00Z");
+		assertThrows(NullPointerException.class, () -> new InterviewHistoryItemResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD,
+				InterviewReportType.FULL, null, 60, completedAt));
+		assertThrows(NullPointerException.class, () -> new InterviewHistoryItemResponse(
+				"interview_1", "Engineer", InterviewDifficulty.STANDARD,
+				InterviewReportType.FULL, new BigDecimal("80.0"), 60, null));
+
+		assertThrows(IllegalArgumentException.class, () -> trendPoint(
+				InterviewReportType.PARTIAL, completedAt));
+		assertThrows(NullPointerException.class, () -> trendPoint(
+				InterviewReportType.FULL, null));
+		assertEquals(
+				InterviewReportType.FULL,
+				trendPoint(InterviewReportType.FULL, completedAt).reportType());
+	}
+
+	private static InterviewHistoryItemResponse historyItem() {
+		return new InterviewHistoryItemResponse(
+				"interview_1",
+				"Engineer",
+				InterviewDifficulty.STANDARD,
+				InterviewReportType.FULL,
+				new BigDecimal("80.0"),
+				60,
+				OffsetDateTime.parse("2026-08-05T08:00:00Z"));
+	}
+
+	private static TargetRoleSummary roleSummary() {
+		return new TargetRoleSummary(
+				"Backend engineer",
+				List.of("Build services"),
+				List.of("Java"),
+				List.of("Experience"));
+	}
+
+	private static InterviewReportResponse report() {
+		InterviewReportDimensionResponse dimension = new InterviewReportDimensionResponse(
+				new BigDecimal("80.0"), "评价", "建议");
+		return new InterviewReportResponse(
+				InterviewReportType.FULL,
+				new BigDecimal("80.0"),
+				"总结",
+				dimension,
+				dimension,
+				dimension,
+				dimension,
+				dimension);
+	}
+
+	private static List<InterviewQuestionResponse> questions() {
+		return List.of(new InterviewQuestionResponse(
+				1, InterviewQuestionType.MAIN, "Question"));
+	}
+
+	private static InterviewTrendPointResponse trendPoint(
+			InterviewReportType reportType,
+			OffsetDateTime completedAt) {
+		return new InterviewTrendPointResponse(
+				"interview_1",
+				reportType,
+				completedAt,
+				new BigDecimal("80.0"),
+				new BigDecimal("80.0"),
+				new BigDecimal("80.0"),
+				new BigDecimal("80.0"),
+				new BigDecimal("80.0"),
+				new BigDecimal("80.0"));
+	}
+
+	private static void assertEndpoint(
+			List<InterviewEndpointContract> endpoints,
+			HttpMethod method,
+			String path,
+			HttpStatus status,
+			Class<?> requestType,
+			Class<?> responseType) {
+		assertEquals(
+				1,
+				endpoints.stream().filter(endpoint -> endpoint.method() == method
+						&& endpoint.path().equals(path)
+						&& endpoint.successStatus() == status
+						&& endpoint.requestType() == requestType
+						&& endpoint.responseType() == responseType).count());
+	}
+
+	private static String[] fields(Class<?> type) {
+		return Arrays.stream(type.getRecordComponents())
+				.map(RecordComponent::getName)
+				.toArray(String[]::new);
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/dto/scene/InterviewApiContractTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/dto/scene/InterviewApiContractTest.java
@@ -9,6 +9,7 @@ import com.unispeaking.domain.vo.scene.InterviewDifficulty;
 import com.unispeaking.domain.vo.scene.InterviewQuestionType;
 import com.unispeaking.domain.vo.scene.InterviewReportType;
 import com.unispeaking.domain.vo.scene.TargetRoleSummary;
+import jakarta.validation.constraints.Size;
 import java.lang.reflect.RecordComponent;
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
@@ -162,6 +163,14 @@ class InterviewApiContractTest {
 					"qualificationRequirements"
 				},
 				fields(TargetRoleSummary.class));
+	}
+
+	@Test
+	void leavesFinalJdAndResumeCodePointLimitsToMaterialBoundary() {
+		RecordComponent[] components = CreateInterviewRequest.class.getRecordComponents();
+
+		assertFalse(hasSizeConstraint(components[2]));
+		assertFalse(hasSizeConstraint(components[3]));
 	}
 
 	@Test
@@ -381,5 +390,10 @@ class InterviewApiContractTest {
 		return Arrays.stream(type.getRecordComponents())
 				.map(RecordComponent::getName)
 				.toArray(String[]::new);
+	}
+
+	private static boolean hasSizeConstraint(RecordComponent component) {
+		return component.getAccessor().isAnnotationPresent(Size.class)
+				|| component.getAnnotatedType().isAnnotationPresent(Size.class);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSessionTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSessionTest.java
@@ -1,0 +1,231 @@
+package com.unispeaking.domain.po.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.InterviewEndReason;
+import com.unispeaking.domain.vo.scene.InterviewPlannedQuestion;
+import com.unispeaking.domain.vo.scene.InterviewQuestionPlan;
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.Test;
+
+class InterviewSessionTest {
+
+	private static final Instant NOW = Instant.parse("2026-08-05T04:00:00Z");
+
+	@Test
+	void ownsInterviewRuntimeAndProtectsSnapshots() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.recordMainQuestion(null);
+		Instant touchTime = session.getCreatedAt().plusSeconds(10);
+		session.touch(touchTime);
+
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		session.registerSubmission(submission);
+
+		assertEquals("interview_1", session.getSceneId());
+		assertEquals(SessionStatus.CREATED, session.getStatus());
+		assertEquals(touchTime, session.lastSeen());
+		assertEquals(1, session.turns().size());
+		assertEquals(1, session.submissions().size());
+		assertTrue(session.hasInFlightSubmissions());
+		submission.markProcessing(NOW.plusSeconds(1));
+		submission.markCompleted(NOW.plusSeconds(2));
+		assertFalse(session.hasInFlightSubmissions());
+	}
+
+	@Test
+	void endRequestStopsNewSubmissionsUntilInsufficientDataIsConfirmedOrCleared() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.requestEnd();
+		assertTrue(session.endRequested());
+		assertFalse(session.acceptingSubmissions());
+
+		session.requireConfirmation();
+		assertTrue(session.confirmationRequired());
+		assertFalse(session.endRequested());
+		assertTrue(session.acceptingSubmissions());
+
+		session.requestEnd();
+		session.confirmInsufficientData();
+		assertFalse(session.acceptingSubmissions());
+		assertTrue(session.insufficientDataConfirmed());
+		assertThrows(IllegalStateException.class, session::clearEndRequest);
+}
+
+	@Test
+	void terminalStateTransitionsRemainSynchronizedAndFlowCleanupIsIndependent() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.activate();
+		session.complete(NOW);
+		session.markFlowCleanupPending();
+
+		assertEquals(SessionStatus.COMPLETED, session.getStatus());
+		assertTrue(session.flowCleanupPending());
+		session.clearFlowCleanupPending();
+		assertFalse(session.flowCleanupPending());
+		session.end(InterviewEndReason.USER_ENDED);
+	}
+
+	@Test
+	void rejectsSubmissionAfterEndAndOnlyAcceptsCurrentRecordedQuestion() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.recordMainQuestion(null);
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		session.registerSubmission(submission);
+		assertThrows(
+				IllegalStateException.class,
+				() -> session.registerSubmission(new InterviewSubmission(
+						"submission_1", 1, "digest_2", NOW)));
+
+		InterviewSession secondSession = new InterviewSession(
+				"session_2", "user_1", "interview_2", plan());
+		secondSession.recordMainQuestion(null);
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> secondSession.registerSubmission(new InterviewSubmission(
+						"submission_3", 99, "digest_3", NOW)));
+		secondSession.recordFollowUp("Follow up");
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> secondSession.registerSubmission(new InterviewSubmission(
+						"submission_old", 1, "digest_old", NOW)));
+		secondSession.requestEnd();
+		assertThrows(
+				IllegalStateException.class,
+				() -> secondSession.registerSubmission(new InterviewSubmission(
+						"submission_4", 1, "digest_4", NOW)));
+	}
+
+	@Test
+	void endClosesSubmissionsAndTouchNeverMovesLastSeenBackwards() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.recordMainQuestion(null);
+		Instant touchTime = session.getCreatedAt().plusSeconds(10);
+		session.touch(touchTime);
+		session.touch(NOW);
+		session.end(InterviewEndReason.USER_ENDED);
+
+		assertEquals(touchTime, session.lastSeen());
+		assertThrows(
+				IllegalStateException.class,
+				() -> session.registerSubmission(new InterviewSubmission(
+						"submission_1", 1, "digest_1", NOW.plusSeconds(11))));
+	}
+
+	@Test
+	void allowsOnlyOneConcurrentSubmissionForTheCurrentQuestion() throws Exception {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		session.recordMainQuestion(null);
+		CountDownLatch ready = new CountDownLatch(2);
+		CountDownLatch start = new CountDownLatch(1);
+		AtomicInteger accepted = new AtomicInteger();
+		ExecutorService executor = Executors.newFixedThreadPool(2);
+		try {
+			for (int index = 1; index <= 2; index++) {
+				int submissionNo = index;
+				executor.submit(() -> {
+					ready.countDown();
+					try {
+						start.await();
+						session.registerSubmission(new InterviewSubmission(
+								"submission_" + submissionNo,
+								1,
+								"digest_" + submissionNo,
+								Instant.now()));
+						accepted.incrementAndGet();
+					}
+					catch (InterruptedException exception) {
+						Thread.currentThread().interrupt();
+					}
+					catch (RuntimeException ignored) {
+						// The second reservation is expected to lose the session lock.
+					}
+				});
+			}
+			ready.await();
+			start.countDown();
+		}
+		finally {
+			executor.shutdown();
+		}
+		while (!executor.isTerminated()) {
+			Thread.yield();
+		}
+		assertEquals(1, accepted.get());
+		assertEquals(1, session.submissions().size());
+	}
+
+	@Test
+	void naturalPlanCompletionClosesTheSubmissionGate() {
+		InterviewSession session = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		for (int mainNo = 1; mainNo <= 5; mainNo++) {
+			session.recordMainQuestion("Main " + mainNo);
+			if (mainNo < 5) {
+				session.moveToNextMainQuestion();
+			}
+		}
+		session.moveToNextMainQuestion();
+
+		assertFalse(session.acceptingSubmissions());
+		assertThrows(
+				IllegalStateException.class,
+				() -> session.registerSubmission(new InterviewSubmission(
+						"submission_1", 5, "digest_1", NOW.plusSeconds(1))));
+	}
+
+	@Test
+	void retryableFailureBlocksANewSubmissionIdButTerminalFailureAllowsIt() {
+		InterviewSession retryableSession = new InterviewSession(
+				"session_1", "user_1", "interview_1", plan());
+		retryableSession.recordMainQuestion(null);
+		InterviewSubmission retryable = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		retryableSession.registerSubmission(retryable);
+		retryable.markProcessing(NOW.plusSeconds(1));
+		retryable.markFailed(true, "ASR_TIMEOUT", "超时", NOW.plusSeconds(2));
+		assertThrows(
+				IllegalStateException.class,
+				() -> retryableSession.registerSubmission(new InterviewSubmission(
+						"submission_2", 1, "digest_2", NOW.plusSeconds(3))));
+
+		InterviewSession terminalSession = new InterviewSession(
+				"session_2", "user_1", "interview_2", plan());
+		terminalSession.recordMainQuestion(null);
+		InterviewSubmission terminal = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		terminalSession.registerSubmission(terminal);
+		terminal.markProcessing(NOW.plusSeconds(1));
+		terminal.markFailed(false, "AUDIO_INVALID", "无效", NOW.plusSeconds(2));
+		terminalSession.registerSubmission(new InterviewSubmission(
+				"submission_2", 1, "digest_2", NOW.plusSeconds(3)));
+		assertEquals(2, terminalSession.submissions().size());
+	}
+
+	private static InterviewQuestionPlan plan() {
+		return new InterviewQuestionPlan(
+				InterviewDifficulty.STANDARD,
+				java.util.stream.IntStream.rangeClosed(1, 5)
+						.mapToObj(no -> new InterviewPlannedQuestion(no, "Main " + no, 1))
+						.toList());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSubmissionTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSubmissionTest.java
@@ -1,0 +1,70 @@
+package com.unispeaking.domain.po.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class InterviewSubmissionTest {
+
+	private static final Instant NOW = Instant.parse("2026-08-05T04:00:00Z");
+
+	@Test
+	void followsProcessingAndRetryableFailureLifecycle() {
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+
+		submission.markProcessing(NOW.plusSeconds(1));
+		submission.markFailed(
+				true,
+				"ASR_TIMEOUT",
+				"语音识别暂时超时",
+				NOW.plusSeconds(2));
+		submission.retry(NOW.plusSeconds(3));
+		submission.markProcessing(NOW.plusSeconds(4));
+		submission.markCompleted(NOW.plusSeconds(5));
+
+		assertEquals(InterviewSubmissionStatus.COMPLETED, submission.status());
+		assertEquals(NOW.plusSeconds(5), submission.updatedAt());
+		assertEquals(null, submission.errorCode());
+	}
+
+	@Test
+	void terminalFailureCannotBeRetriedOrCompleted() {
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		submission.markProcessing(NOW.plusSeconds(1));
+		submission.markFailed(
+				false,
+				"AUDIO_INVALID",
+				"音频格式无效",
+				NOW.plusSeconds(2));
+
+		assertEquals(InterviewSubmissionStatus.FAILED_TERMINAL, submission.status());
+		assertThrows(
+				IllegalStateException.class,
+				() -> submission.retry(NOW.plusSeconds(3)));
+		assertThrows(
+				IllegalStateException.class,
+				() -> submission.markCompleted(NOW.plusSeconds(3)));
+	}
+
+	@Test
+	void invalidFailureDoesNotMutateStateAndTimeCannotMoveBackwards() {
+		InterviewSubmission submission = new InterviewSubmission(
+				"submission_1", 1, "digest_1", NOW);
+		submission.markProcessing(NOW.plusSeconds(1));
+
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> submission.markFailed(
+						true, " ", "message", NOW.plusSeconds(2)));
+		assertEquals(InterviewSubmissionStatus.PROCESSING, submission.status());
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> submission.markCompleted(NOW));
+		assertEquals(InterviewSubmissionStatus.PROCESSING, submission.status());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSubmissionTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/po/session/InterviewSubmissionTest.java
@@ -1,7 +1,9 @@
 package com.unispeaking.domain.po.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.unispeaking.domain.vo.scene.InterviewSubmissionStatus;
 import java.time.Instant;
@@ -66,5 +68,28 @@ class InterviewSubmissionTest {
 				IllegalArgumentException.class,
 				() -> submission.markCompleted(NOW));
 		assertEquals(InterviewSubmissionStatus.PROCESSING, submission.status());
+	}
+
+	@Test
+	void timeoutCanFailAcceptedOrProcessingSubmissionButNotCompletedSubmission() {
+		InterviewSubmission accepted = new InterviewSubmission(
+				"submission_accepted", 1, "digest_1", NOW);
+		InterviewSubmission processing = new InterviewSubmission(
+				"submission_processing", 1, "digest_2", NOW);
+		processing.markProcessing(NOW.plusSeconds(1));
+		InterviewSubmission completed = new InterviewSubmission(
+				"submission_completed", 1, "digest_3", NOW);
+		completed.markProcessing(NOW.plusSeconds(1));
+		completed.markCompleted(NOW.plusSeconds(2));
+
+		assertTrue(accepted.markTimedOut(
+				true, "TIMEOUT", "timeout", NOW.plusSeconds(3)));
+		assertTrue(processing.markTimedOut(
+				false, "TIMEOUT", "timeout", NOW.plusSeconds(3)));
+		assertFalse(completed.markTimedOut(
+				true, "TIMEOUT", "timeout", NOW.plusSeconds(3)));
+		assertEquals(InterviewSubmissionStatus.FAILED_RETRYABLE, accepted.status());
+		assertEquals(InterviewSubmissionStatus.FAILED_TERMINAL, processing.status());
+		assertEquals(InterviewSubmissionStatus.COMPLETED, completed.status());
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewGenerationBoundaryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewGenerationBoundaryTest.java
@@ -1,0 +1,50 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterviewGenerationBoundaryTest {
+
+	@Test
+	void excludesResumeFromTargetRoleSummaryGenerationInput() {
+		assertArrayEquals(
+				new String[] {"jobTitle", "jobDescription"},
+				Arrays.stream(TargetRoleSummaryGenerationInput.class.getRecordComponents())
+						.map(component -> component.getName())
+						.toArray(String[]::new));
+	}
+
+	@Test
+	void separatesSummaryAndQuestionPlanGenerationContracts() {
+		InterviewPreparedMaterials materials = new InterviewPreparedMaterials(
+				"Secret role",
+				"Secret JD",
+				"Secret resume");
+		TargetRoleSummary summary = new TargetRoleSummary(
+				"Overview",
+				List.of("Responsibility"),
+				List.of("Skill"),
+				List.of("Qualification"));
+
+		TargetRoleSummaryGenerationInput summaryInput = materials.targetRoleSummaryInput();
+		InterviewQuestionPlanGenerationInput planInput = materials.questionPlanInput(
+				InterviewDifficulty.STANDARD,
+				summary);
+		TargetRoleSummaryGenerator summaryGenerator = input -> summary;
+		InterviewQuestionPlanGenerator planGenerator = input ->
+				InterviewQuestionPlan.fromGeneratedMainQuestions(
+						input.difficulty(),
+						List.of("Q1", "Q2", "Q3", "Q4", "Q5"));
+
+		assertEquals(summary, summaryGenerator.generate(summaryInput));
+		assertEquals("Secret resume", planInput.resumeText());
+		assertEquals(5, planGenerator.generate(planInput).mainQuestions().size());
+		assertFalse(summaryInput.toString().contains("Secret"));
+		assertFalse(planInput.toString().contains("Secret"));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrBatchTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrBatchTest.java
@@ -1,0 +1,74 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import com.unispeaking.domain.dto.ocr.OcrImage;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterviewJobDescriptionOcrBatchTest {
+
+	@Test
+	void acceptsFiveImagesAtExactTotalSizeAndKeepsAnImmutableSnapshot() {
+		byte[] content = new byte[InterviewJobDescriptionOcrBatch.MAX_TOTAL_BYTES / 5];
+		content[0] = 1;
+		List<OcrImage> images = new ArrayList<>();
+		for (int index = 0; index < InterviewJobDescriptionOcrBatch.MAX_IMAGE_COUNT; index++) {
+			images.add(new OcrImage(content));
+		}
+
+		InterviewJobDescriptionOcrBatch batch = new InterviewJobDescriptionOcrBatch(images);
+		content[0] = 9;
+		images.clear();
+
+		assertAll(
+				() -> assertEquals(5, batch.images().size()),
+				() -> assertEquals(
+						InterviewJobDescriptionOcrBatch.MAX_TOTAL_BYTES,
+						batch.totalBytes()),
+				() -> assertEquals(1, batch.images().getFirst().content()[0]),
+				() -> assertThrows(
+						UnsupportedOperationException.class,
+						() -> batch.images().clear()),
+				() -> assertFalse(batch.toString().contains("[B@")));
+	}
+
+	@Test
+	void rejectsMissingImagesAndImagesOverBatchLimits() {
+		List<OcrImage> sixImages = java.util.stream.IntStream.range(0, 6)
+				.mapToObj(index -> new OcrImage(new byte[] {1}))
+				.toList();
+		byte[] overLimit = new byte[InterviewJobDescriptionOcrBatch.MAX_TOTAL_BYTES + 1];
+
+		assertAll(
+				() -> assertError(null, InterviewErrorCode.INPUT_INVALID),
+				() -> assertError(List.of(), InterviewErrorCode.INPUT_INVALID),
+				() -> assertError(
+						Arrays.asList(new OcrImage(new byte[] {1}), null),
+						InterviewErrorCode.INPUT_INVALID),
+				() -> assertError(
+						List.of(new OcrImage(new byte[0])),
+						InterviewErrorCode.INPUT_INVALID),
+				() -> assertError(sixImages, InterviewErrorCode.INPUT_INVALID),
+				() -> assertError(
+						List.of(new OcrImage(overLimit)),
+						InterviewErrorCode.PAYLOAD_TOO_LARGE));
+	}
+
+	private static void assertError(
+			List<OcrImage> images,
+			InterviewErrorCode expected) {
+		InterviewException exception = assertThrows(
+				InterviewException.class,
+				() -> new InterviewJobDescriptionOcrBatch(images));
+		assertSame(expected, exception.errorCode());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrRecognizerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewJobDescriptionOcrRecognizerTest.java
@@ -1,0 +1,182 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import com.unispeaking.common.exception.ocr.OcrErrorCode;
+import com.unispeaking.common.exception.ocr.OcrException;
+import com.unispeaking.domain.dto.ocr.OcrImage;
+import com.unispeaking.provider.OcrProvider;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterviewJobDescriptionOcrRecognizerTest {
+
+	private static final String SUPPLEMENTARY_CODE_POINT = "\uD83D\uDE80";
+
+	@Test
+	void validatesBatchAndCallsProviderOnceInInputOrder() {
+		StubOcrProvider provider = new StubOcrProvider();
+		provider.response = "\u2003First line\r\nSecond line\u2003";
+		InterviewJobDescriptionOcrRecognizer recognizer =
+				new InterviewJobDescriptionOcrRecognizer(provider);
+
+		InterviewJobDescriptionOcrText result = recognizer.recognize(List.of(
+				new OcrImage(new byte[] {3}),
+				new OcrImage(new byte[] {1}),
+				new OcrImage(new byte[] {2})));
+
+		assertAll(
+				() -> assertEquals("First line\nSecond line", result.text()),
+				() -> assertEquals(List.of(3, 1, 2), provider.firstBytes),
+				() -> assertEquals(1, provider.recognitionCalls),
+				() -> assertFalse(result.toString().contains("First line")));
+	}
+
+	@Test
+	void rejectsInvalidBatchBeforeCheckingOrCallingProvider() {
+		StubOcrProvider provider = new StubOcrProvider();
+		InterviewJobDescriptionOcrRecognizer recognizer =
+				new InterviewJobDescriptionOcrRecognizer(provider);
+		List<OcrImage> sixImages = java.util.stream.IntStream.range(0, 6)
+				.mapToObj(index -> new OcrImage(new byte[] {1}))
+				.toList();
+
+		assertError(
+				InterviewErrorCode.INPUT_INVALID,
+				() -> recognizer.recognize(sixImages));
+		assertAll(
+				() -> assertEquals(0, provider.availabilityChecks),
+				() -> assertEquals(0, provider.recognitionCalls));
+	}
+
+	@Test
+	void mapsUnavailableProviderWithoutCallingRecognition() {
+		StubOcrProvider provider = new StubOcrProvider();
+		provider.available = false;
+		InterviewJobDescriptionOcrRecognizer recognizer =
+				new InterviewJobDescriptionOcrRecognizer(provider);
+
+		assertError(
+				InterviewErrorCode.SERVICE_UNAVAILABLE,
+				() -> recognizer.recognize(oneImage()));
+		assertEquals(0, provider.recognitionCalls);
+	}
+
+	@Test
+	void mapsProviderFormatPixelAvailabilityAndProcessFailures() {
+		assertProviderError(OcrErrorCode.FORMAT_UNSUPPORTED,
+				InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED);
+		assertProviderError(OcrErrorCode.PIXEL_LIMIT_EXCEEDED,
+				InterviewErrorCode.INPUT_INVALID);
+		assertProviderError(OcrErrorCode.UNAVAILABLE,
+				InterviewErrorCode.SERVICE_UNAVAILABLE);
+		assertProviderError(OcrErrorCode.PROCESS_FAILED,
+				InterviewErrorCode.DEPENDENCY_FAILED);
+	}
+
+	@Test
+	void mapsUnexpectedProviderFailureToDependencyFailed() {
+		StubOcrProvider provider = new StubOcrProvider();
+		provider.failure = new IllegalStateException("provider diagnostic");
+
+		assertError(
+				InterviewErrorCode.DEPENDENCY_FAILED,
+				() -> new InterviewJobDescriptionOcrRecognizer(provider).recognize(oneImage()));
+	}
+
+	@Test
+	void rejectsNullAndUnicodeBlankRecognitionResults() {
+		StubOcrProvider nullProvider = new StubOcrProvider();
+		nullProvider.response = null;
+		StubOcrProvider blankProvider = new StubOcrProvider();
+		blankProvider.response = "\u2003\n\u2003";
+
+		assertAll(
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> new InterviewJobDescriptionOcrRecognizer(nullProvider)
+								.recognize(oneImage())),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> new InterviewJobDescriptionOcrRecognizer(blankProvider)
+								.recognize(oneImage())));
+	}
+
+	@Test
+	void countsRecognizedTextByUnicodeCodePoint() {
+		StubOcrProvider maximumProvider = new StubOcrProvider();
+		maximumProvider.response = SUPPLEMENTARY_CODE_POINT.repeat(
+				InterviewJobDescriptionOcrRecognizer.MAX_TEXT_CODE_POINTS);
+		StubOcrProvider overProvider = new StubOcrProvider();
+		overProvider.response = SUPPLEMENTARY_CODE_POINT.repeat(
+				InterviewJobDescriptionOcrRecognizer.MAX_TEXT_CODE_POINTS + 1);
+
+		InterviewJobDescriptionOcrText result =
+				new InterviewJobDescriptionOcrRecognizer(maximumProvider).recognize(oneImage());
+
+		assertAll(
+				() -> assertEquals(
+						InterviewJobDescriptionOcrRecognizer.MAX_TEXT_CODE_POINTS,
+						result.text().codePointCount(0, result.text().length())),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> new InterviewJobDescriptionOcrRecognizer(overProvider)
+								.recognize(oneImage())));
+	}
+
+	private static List<OcrImage> oneImage() {
+		return List.of(new OcrImage(new byte[] {1}));
+	}
+
+	private static void assertProviderError(
+			OcrErrorCode source,
+			InterviewErrorCode expected) {
+		StubOcrProvider provider = new StubOcrProvider();
+		provider.failure = new OcrException(source);
+		assertError(
+				expected,
+				() -> new InterviewJobDescriptionOcrRecognizer(provider).recognize(oneImage()));
+	}
+
+	private static void assertError(
+			InterviewErrorCode expected,
+			org.junit.jupiter.api.function.Executable action) {
+		InterviewException exception = assertThrows(InterviewException.class, action);
+		assertSame(expected, exception.errorCode());
+	}
+
+	private static final class StubOcrProvider implements OcrProvider {
+
+		private boolean available = true;
+		private String response = "recognized";
+		private RuntimeException failure;
+		private int availabilityChecks;
+		private int recognitionCalls;
+		private List<Integer> firstBytes = new ArrayList<>();
+
+		@Override
+		public String recognizeText(List<OcrImage> images) {
+			recognitionCalls++;
+			firstBytes = images.stream()
+					.map(image -> Byte.toUnsignedInt(image.content()[0]))
+					.toList();
+			if (failure != null) {
+				throw failure;
+			}
+			return response;
+		}
+
+		@Override
+		public boolean available() {
+			availabilityChecks++;
+			return available;
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewMaterialPreparerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewMaterialPreparerTest.java
@@ -1,0 +1,209 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.common.document.DocumentTextExtractor;
+import com.unispeaking.common.exception.interview.InterviewErrorCode;
+import com.unispeaking.common.exception.interview.InterviewException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import org.apache.poi.xwpf.usermodel.XWPFDocument;
+import org.junit.jupiter.api.Test;
+
+class InterviewMaterialPreparerTest {
+
+	private static final String DOCX_MIME_TYPE =
+			"application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+	private static final String SUPPLEMENTARY_CODE_POINT = "\uD83D\uDE80";
+
+	private final InterviewMaterialPreparer preparer =
+			new InterviewMaterialPreparer(new DocumentTextExtractor());
+
+	@Test
+	void requiresJobTitleAndAllowsBothOptionalResumeSourcesToBeAbsent() {
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"  Backend Engineer  ",
+				"  Build APIs\r\nSafely  ",
+				"  ",
+				null);
+
+		assertAll(
+				() -> assertEquals("Backend Engineer", prepared.jobTitle()),
+				() -> assertEquals("Build APIs\nSafely", prepared.jobDescription()),
+				() -> assertNull(prepared.resumeText()),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare(" ", null, null, null)),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare("\u2003", null, null, null)));
+	}
+
+	@Test
+	void acceptsFinalTextLimitsAndRejectsOneCharacterMore() {
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"Engineer",
+				"j".repeat(InterviewMaterialPreparer.MAX_JOB_DESCRIPTION_CODE_POINTS),
+				"r".repeat(InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS),
+				null);
+
+		assertAll(
+				() -> assertEquals(
+						InterviewMaterialPreparer.MAX_JOB_DESCRIPTION_CODE_POINTS,
+						prepared.jobDescription().length()),
+				() -> assertEquals(
+						InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS,
+						prepared.resumeText().length()),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare(
+								"Engineer",
+								"j".repeat(
+										InterviewMaterialPreparer.MAX_JOB_DESCRIPTION_CODE_POINTS + 1),
+								null,
+								null)),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare(
+								"Engineer",
+								null,
+								"r".repeat(
+										InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS + 1),
+								null)));
+	}
+
+	@Test
+	void countsJobDescriptionAndResumeByUnicodeCodePoint() {
+		String maximumJobDescription = SUPPLEMENTARY_CODE_POINT.repeat(
+				InterviewMaterialPreparer.MAX_JOB_DESCRIPTION_CODE_POINTS);
+		String maximumResume = SUPPLEMENTARY_CODE_POINT.repeat(
+				InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS);
+
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"Engineer",
+				maximumJobDescription,
+				maximumResume,
+				null);
+
+		assertAll(
+				() -> assertEquals(
+						InterviewMaterialPreparer.MAX_JOB_DESCRIPTION_CODE_POINTS,
+						prepared.jobDescription().codePointCount(
+								0, prepared.jobDescription().length())),
+				() -> assertEquals(
+						InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS,
+						prepared.resumeText().codePointCount(0, prepared.resumeText().length())),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare(
+								"Engineer",
+								maximumJobDescription + SUPPLEMENTARY_CODE_POINT,
+								null,
+								null)),
+				() -> assertError(
+						InterviewErrorCode.INPUT_INVALID,
+						() -> preparer.prepare(
+								"Engineer",
+								null,
+								maximumResume + SUPPLEMENTARY_CODE_POINT,
+								null)));
+	}
+
+	@Test
+	void acceptsSupplementaryResumeAtFileTextLimit() {
+		String maximumResume = SUPPLEMENTARY_CODE_POINT.repeat(
+				InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS);
+
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"Engineer",
+				null,
+				null,
+				new InterviewResumeFile(
+						"resume.docx",
+						DOCX_MIME_TYPE,
+						docx(maximumResume)));
+
+		assertEquals(
+				InterviewMaterialPreparer.MAX_RESUME_TEXT_CODE_POINTS,
+				prepared.resumeText().codePointCount(0, prepared.resumeText().length()));
+	}
+
+	@Test
+	void rejectsResumeTextAndFileTogether() {
+		InterviewResumeFile file = new InterviewResumeFile(
+				"resume.docx",
+				DOCX_MIME_TYPE,
+				docx("file resume"));
+
+		assertError(
+				InterviewErrorCode.INPUT_INVALID,
+				() -> preparer.prepare("Engineer", null, "text resume", file));
+	}
+
+	@Test
+	void extractsDocxAndMapsUnsupportedFilesToInterviewError() {
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"Engineer",
+				null,
+				null,
+				new InterviewResumeFile("resume.docx", DOCX_MIME_TYPE, docx("Java developer")));
+
+		assertAll(
+				() -> assertEquals("Java developer", prepared.resumeText()),
+				() -> assertError(
+						InterviewErrorCode.MEDIA_TYPE_UNSUPPORTED,
+						() -> preparer.prepare(
+								"Engineer",
+								null,
+								null,
+								new InterviewResumeFile(
+										"resume.doc",
+										"application/msword",
+										new byte[] {1, 2, 3}))));
+	}
+
+	@Test
+	void keepsResumeBytesDefensiveAndRedactsMaterialText() {
+		byte[] content = new byte[] {1, 2, 3};
+		InterviewResumeFile file = new InterviewResumeFile("resume.pdf", "application/pdf", content);
+		content[0] = 9;
+		byte[] returned = file.content();
+		returned[1] = 9;
+		InterviewPreparedMaterials prepared = preparer.prepare(
+				"Secret role",
+				"Secret JD",
+				"Secret resume",
+				null);
+
+		assertAll(
+				() -> assertEquals(1, file.content()[0]),
+				() -> assertEquals(2, file.content()[1]),
+				() -> assertFalse(prepared.toString().contains("Secret")),
+				() -> assertFalse(file.toString().contains("resume.pdf")),
+				() -> assertFalse(file.toString().contains("[B@")));
+	}
+
+	private static byte[] docx(String text) {
+		try (XWPFDocument document = new XWPFDocument();
+				ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+			document.createParagraph().createRun().setText(text);
+			document.write(output);
+			return output.toByteArray();
+		}
+		catch (IOException exception) {
+			throw new IllegalStateException(exception);
+		}
+	}
+
+	private static void assertError(
+			InterviewErrorCode expected,
+			org.junit.jupiter.api.function.Executable action) {
+		InterviewException exception = assertThrows(InterviewException.class, action);
+		assertSame(expected, exception.errorCode());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewProgressTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewProgressTest.java
@@ -1,0 +1,106 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterviewProgressTest {
+
+	@Test
+	void recordsActualQuestionSequenceAndResetsFollowUps() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.STANDARD));
+
+		InterviewQuestionPrompt main = progress.recordMainQuestion(null);
+		InterviewQuestionPrompt followUp = progress.recordFollowUp("Why?");
+		progress.moveToNextMainQuestion();
+		InterviewQuestionPrompt next = progress.recordMainQuestion(null);
+
+		assertEquals(1, main.questionNo());
+		assertEquals(InterviewQuestionType.MAIN, main.questionType());
+		assertEquals(2, followUp.questionNo());
+		assertEquals(3, next.questionNo());
+		assertEquals(0, progress.followUpCount());
+		assertEquals(List.of(main, followUp, next), progress.actualQuestions());
+	}
+
+	@Test
+	void enforcesLimitAndCompletesOnlyAfterTheFifthMainQuestion() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.BASIC));
+		for (int mainNo = 1; mainNo <= 5; mainNo++) {
+			progress.recordMainQuestion("Main " + mainNo);
+			if (mainNo < 5) {
+				progress.moveToNextMainQuestion();
+			}
+		}
+
+		progress.recordFollowUp("final follow-up");
+		assertThrows(
+				IllegalStateException.class,
+				() -> progress.recordFollowUp("too late"));
+		progress.moveToNextMainQuestion();
+		assertEquals(InterviewEndReason.PLAN_COMPLETED, progress.endReason());
+		assertThrows(
+				IllegalStateException.class,
+				() -> progress.recordMainQuestion("after completion"));
+	}
+
+	@Test
+	void rejectsEndingPlanBeforeFifthQuestion() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.STANDARD));
+		assertThrows(
+				IllegalStateException.class,
+				() -> progress.end(InterviewEndReason.PLAN_COMPLETED));
+		progress.end(InterviewEndReason.USER_ENDED);
+		assertEquals(InterviewEndReason.USER_ENDED, progress.endReason());
+	}
+
+	@Test
+	void rejectsSkippingOrRepeatingTheCurrentMainQuestion() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.STANDARD));
+		assertThrows(
+				IllegalStateException.class,
+				progress::moveToNextMainQuestion);
+		progress.recordMainQuestion("Main 1");
+		assertThrows(
+				IllegalStateException.class,
+				() -> progress.recordMainQuestion("Duplicate"));
+	}
+
+	@Test
+	void cannotCompleteThePlanBeforeTheFifthQuestionIsActuallyPresented() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.STANDARD));
+		for (int mainNo = 1; mainNo < 5; mainNo++) {
+			progress.recordMainQuestion("Main " + mainNo);
+			progress.moveToNextMainQuestion();
+		}
+		assertThrows(
+				IllegalStateException.class,
+				() -> progress.end(InterviewEndReason.PLAN_COMPLETED));
+		progress.recordMainQuestion("Main 5");
+		progress.end(InterviewEndReason.PLAN_COMPLETED);
+		assertEquals(InterviewEndReason.PLAN_COMPLETED, progress.endReason());
+	}
+
+	@Test
+	void invalidQuestionTextDoesNotConsumeQuestionNumbersOrFollowUpQuota() {
+		InterviewProgress progress = new InterviewProgress(plan(InterviewDifficulty.STANDARD));
+		InterviewQuestionPrompt main = progress.recordMainQuestion("Main 1");
+		assertEquals(1, main.questionNo());
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> progress.recordFollowUp(" "));
+		assertEquals(0, progress.followUpCount());
+		assertEquals(2, progress.nextQuestionNo());
+	}
+
+	private static InterviewQuestionPlan plan(InterviewDifficulty difficulty) {
+		int limit = difficulty == InterviewDifficulty.CHALLENGE ? 2 : 1;
+		return new InterviewQuestionPlan(
+				difficulty,
+				java.util.stream.IntStream.rangeClosed(1, 5)
+						.mapToObj(no -> new InterviewPlannedQuestion(no, "Main " + no, limit))
+						.toList());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanTest.java
@@ -1,0 +1,55 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class InterviewQuestionPlanTest {
+
+	@Test
+	void fixesFiveQuestionsAndDifficultyFollowUpLimit() {
+		InterviewQuestionPlan plan = plan(InterviewDifficulty.CHALLENGE);
+
+		assertEquals(5, plan.mainQuestions().size());
+		assertEquals(2, plan.maxFollowUps());
+		assertThrows(
+				UnsupportedOperationException.class,
+				() -> plan.mainQuestions().clear());
+	}
+
+	@Test
+	void rejectsWrongCountSequenceOrDifficultyLimit() {
+		List<InterviewPlannedQuestion> questions = new ArrayList<>(List.of(
+				new InterviewPlannedQuestion(1, "One", 1)));
+
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> new InterviewQuestionPlan(InterviewDifficulty.BASIC, questions));
+
+		List<InterviewPlannedQuestion> wrongSequence = questions(5, 1);
+		wrongSequence.set(2, new InterviewPlannedQuestion(4, "Four", 1));
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> new InterviewQuestionPlan(InterviewDifficulty.STANDARD, wrongSequence));
+
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> new InterviewQuestionPlan(
+						InterviewDifficulty.BASIC,
+						questions(5, 2)));
+	}
+
+	private static InterviewQuestionPlan plan(InterviewDifficulty difficulty) {
+		return new InterviewQuestionPlan(difficulty, questions(5,
+				difficulty == InterviewDifficulty.CHALLENGE ? 2 : 1));
+	}
+
+	private static List<InterviewPlannedQuestion> questions(int count, int limit) {
+		return java.util.stream.IntStream.rangeClosed(1, count)
+				.mapToObj(no -> new InterviewPlannedQuestion(no, "Question " + no, limit))
+				.collect(java.util.stream.Collectors.toCollection(ArrayList::new));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/InterviewQuestionPlanTest.java
@@ -15,9 +15,44 @@ class InterviewQuestionPlanTest {
 
 		assertEquals(5, plan.mainQuestions().size());
 		assertEquals(2, plan.maxFollowUps());
+		assertEquals(
+				InterviewFollowUpFocus.TRADE_OFF_REFLECTION_COMPLEX_SCENARIO,
+				plan.followUpFocus());
 		assertThrows(
 				UnsupportedOperationException.class,
 				() -> plan.mainQuestions().clear());
+	}
+
+	@Test
+	void createsFiveQuestionPlanFromProviderIndependentTextsForEveryDifficulty() {
+		InterviewQuestionPlan basic = generated(InterviewDifficulty.BASIC);
+		InterviewQuestionPlan standard = generated(InterviewDifficulty.STANDARD);
+		InterviewQuestionPlan challenge = generated(InterviewDifficulty.CHALLENGE);
+
+		assertEquals(InterviewFollowUpFocus.CLARIFICATION, basic.followUpFocus());
+		assertEquals(1, basic.mainQuestion(5).maxFollowUps());
+		assertEquals(
+				InterviewFollowUpFocus.REASON_ACTION_RESULT,
+				standard.followUpFocus());
+		assertEquals(1, standard.mainQuestion(5).maxFollowUps());
+		assertEquals(
+				InterviewFollowUpFocus.TRADE_OFF_REFLECTION_COMPLEX_SCENARIO,
+				challenge.followUpFocus());
+		assertEquals(2, challenge.mainQuestion(5).maxFollowUps());
+	}
+
+	@Test
+	void rejectsGeneratedQuestionListsThatAreNotExactlyFiveNonBlankTexts() {
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> InterviewQuestionPlan.fromGeneratedMainQuestions(
+						InterviewDifficulty.BASIC,
+						List.of("Q1")));
+		assertThrows(
+				IllegalArgumentException.class,
+				() -> InterviewQuestionPlan.fromGeneratedMainQuestions(
+						InterviewDifficulty.STANDARD,
+						List.of("Q1", "Q2", " ", "Q4", "Q5")));
 	}
 
 	@Test
@@ -45,6 +80,12 @@ class InterviewQuestionPlanTest {
 	private static InterviewQuestionPlan plan(InterviewDifficulty difficulty) {
 		return new InterviewQuestionPlan(difficulty, questions(5,
 				difficulty == InterviewDifficulty.CHALLENGE ? 2 : 1));
+	}
+
+	private static InterviewQuestionPlan generated(InterviewDifficulty difficulty) {
+		return InterviewQuestionPlan.fromGeneratedMainQuestions(
+				difficulty,
+				List.of("Q1", "Q2", "Q3", "Q4", "Q5"));
 	}
 
 	private static List<InterviewPlannedQuestion> questions(int count, int limit) {

--- a/docs/interview-foundation-architecture.md
+++ b/docs/interview-foundation-architecture.md
@@ -2,214 +2,326 @@
 
 ## 1. 目的与范围
 
-英文模拟面试让已登录用户用简历、目标岗位说明和训练时长准备一个面试场景，完成实时
-英语问答，并获得只针对本次口语表现的报告。
+英文模拟面试是现有 Scene 业务的特化场景。用户围绕目标岗位完成固定五个主问题及有限
+追问，在面试结束后获得完整录音和五维英语口语报告。系统不评价岗位匹配度、胜任度或
+录用概率。
 
-本文是 Interview foundation 的维护入口，只记录公共能力边界、接口语义、关键决策、
-失败补偿和核心流程。Interview 与 IELTS 都是现有 Scene 的特化，不是顶层后端模块。
+本阶段实现 Issue #33 定义、Issue #38 交付的后端闭环：
 
-本阶段范围：
+- 岗位名称、可选 JD 和可选简历输入；简历支持文本、文本型 PDF 和 DOCX。
+- 本地 PaddleOCR 识别最多五张 JD 截图，创建时只接收用户确认后的最终 JD 文本。
+- BASIC、STANDARD、CHALLENGE 三档难度，所有难度固定五个主问题。
+- `ASR -> LLM -> TTS` 的分段式逐题问答，不使用 Realtime API。
+- `submissionId` 幂等、十分钟进程内恢复、FULL/PARTIAL 五维报告和完整 MP3 录音。
+- 历史、录音播放、FULL 趋势、快速复练和物理删除。
 
-- 准备 `INTERVIEW_SCENE` 的材料快照、问题计划、流程定义和 Prompt。
-- 复用公共 Scene Flow、Session、Evaluation 和 Provider 能力完成训练闭环。
-- 明确幂等、授权、失败状态、可重试边界和敏感材料最小化规则。
+本阶段不实现前端 API 接入、时长选择、自动结束、用户回答字幕、DOC/图片/扫描版简历、
+重启恢复、多实例共享、Redis、MQ、Outbox、SSE、业务 WebSocket、向量检索或第二套 Scene
+Flow。原始简历、JD 截图、用户转写和分题回答音频不长期保存。
 
-本阶段不包含招聘决策、岗位匹配、录用建议、长期保存原始简历、计费权益、消息队列或
-新的 AI/存储供应商。本文不承诺具体厂商，也不以空接口预留未确认能力。
+## 2. 模块与职责
 
-## 2. 领域原语与职责边界
-
-| 原语 | 核心职责 | 输入 | 输出 | 不负责 |
-|---|---|---|---|---|
-| Interview Scene | 把用户材料转成一次可训练的面试场景 | 当前用户、简历、岗位说明、时长 | 岗位快照、问题计划、流程定义、Prompt | 会话连接、逐轮消息、评分、招聘判断 |
-| Scene Flow | 记录并校验场景当前步骤 | Scene、期望步骤、动作标识 | 当前步骤、下一步骤、是否完成 | 材料解析、问题生成、实时传输、评分 |
-| Session | 记录一次用户训练事实及完整对话 | 当前用户、就绪 Scene、完整消息、结束原因 | Session ID、生命周期状态、对话记录 | 面试规则、问题选择、评分算法 |
-| Evaluation | 从已授权训练事实生成口语反馈 | Session、完整对话、可选音频、评分上下文 | 单轮结果、整场报告或明确的处理中/失败状态 | 推进流程、改变会话状态、岗位胜任判断 |
-
-变化方向测试：面试材料和问题策略会独立于 IELTS 题库演进，分别留在各自的 Scene
-特化；会话授权、生命周期、消息完整性和口语评分语义需要跨 Scene 一致，保留为公共
-原语。前端页面可以独立演进，但不据此拆出 `service/interview`。
-
-## 3. 代码组织约束
+代码继续位于现有模块：
 
 ```text
+controller/InterviewController.java
 service/scene/InterviewSceneService.java
 service/scene/impl/InterviewSceneServiceImpl.java
-service/scene/SceneFlowService.java
-service/session/SessionService.java
-service/evaluation/EvaluationService.java
 domain/dto/scene/...
-domain/dto/session/...
-domain/dto/evaluation/...
-infrastructure/persistence/{entity,mapper,repository}/...
-src/main/resources/db/migration/V{version}__{description}.sql
+domain/vo/scene/...
+domain/po/session/InterviewSession.java
+component/session/ActiveSessionRegistry.java
+infrastructure/persistence/{entity,mapper,repository}/scene/...
 ```
 
-Interview 的 HTTP 入口可以使用独立业务路由和 `InterviewSceneController`，但内部仍按
-上述边界编排。供应商 Adapter 继续位于 `infrastructure`，数据库访问继续通过公共
-Repository；不得出现 Interview 私有 Mapper、Session、Evaluation 或 Provider 包。
+不得新增 `service/interview`、`domain/dto/interview`、Interview 私有 Provider、第二套
+Session Service 或 `interview_session` 表。
 
-兼容基线：复用现有 `SceneType.INTERVIEW_SCENE`、`interview_` ID 前缀、公共 Session
-状态机和已有评分持久化；后续实现只为缺失的 Interview Scene 事实新增 Flyway 迁移，
-不复制公共表，也不改写已发布迁移。
+职责边界：
 
-## 4. 接口契约
+- `InterviewController` 只做 HTTP 协议适配、认证入口和 DTO 转换，只依赖
+  `InterviewSceneService`。
+- `InterviewSceneService` 拥有材料准备、创建、逐题回答、追问裁决、恢复、结束、报告、
+  完整录音和学习资产的完整用例编排。
+- `SceneFlowService` 只管理外层 `DIALOGUE -> COMPLETED` 流程。题目和追问切换不推进
+  Flow，成功或最终失败时释放 Flow。
+- `SessionService` 只注册 Scene 特化创建的 Session、创建 `practice_session`、校验归属并
+  写入 `COMPLETED`/`FAILED` 终态。不得编排 Interview 的 ASR、LLM、TTS、追问或报告。
+- `EvaluationService.evaluateSpeech` 只提供无持久化副作用的语音评分，不查询 Scene 或
+  Session，不保存转写和逐轮评分。
+- ASR、LLM、TTS、评分、OCR、对象存储继续通过现有 Provider 或通用组件调用。
 
-以下是稳定的业务语义，不固定尚未实现的 Java DTO 形状。
+## 3. 运行态与持久化边界
 
-### 4.1 `InterviewSceneService`
+`InterviewSession` 继承 `AbstractSceneSession`，由 `ActiveSessionRegistry` 管理。它只存在于
+当前后端进程，组合：
 
-| 操作 | 输入 | 输出 | 前置与后置条件 | 幂等与错误 |
-|---|---|---|---|---|
-| 准备面试场景 | 当前用户、PDF/DOC/DOCX 简历、岗位说明、10/15/20 分钟、幂等键 | `sceneId`、准备状态、材料摘要、问题数 | 用户已认证；文件不超过 10 MB；岗位说明 30–5000 字；成功后 Scene 类型为 `INTERVIEW_SCENE` 且归属当前用户 | 同一用户和幂等键返回同一结果；格式无效为 400，材料不可解析为 422，供应商暂时失败为 503 |
-| 查询准备结果 | 当前用户、`sceneId` | 准备中、已就绪或失败及安全错误码 | 只返回当前用户的 Scene；已就绪结果包含可启动 Session 所需的稳定快照 | 不存在为 404，不归属为 403；不返回原始 Prompt 或简历全文 |
+- `InterviewQuestionPlan`：五个主问题和每题追问上限。
+- `InterviewProgress`：当前主问题、追问次数、实际问题和结束原因。
+- `InterviewTurn`：AI 问题音频、用户回答临时音频、临时转写和临时语音评分。
+- 最近活动时间、当前 submission、结束请求和不足数据确认状态。
 
-该 Service 可以编排材料提取、LLM Provider 和 Scene Repository，但不得创建 Session、
-推进对话步骤或调用 Evaluation。
+不建立 `interview_session`、`interview_turn` 或任务表。数据库继续使用三张 Interview 表和
+`practice_session`：
 
-### 4.2 `SceneFlowService`
+- `interview` 保存身份、岗位摘要、难度和完成录音元数据；`completed_at IS NOT NULL` 才是
+  可见资产。
+- `interview_question` 只保存实际提出的 AI 问题。
+- `interview_report` 保存 FULL/PARTIAL 的完整五维报告。
+- `practice_session` 表达公共训练事实和最终状态，由公共 Session 能力唯一创建。
 
-| 操作 | 输入 | 输出 | 契约 |
-|---|---|---|---|
-| 创建流程 | `sceneId`、Scene 特化给出的流程定义 | 初始步骤和流程版本 | Scene 已就绪；同一 Scene/版本重复调用不产生第二条流程 |
-| 推进流程 | `sceneId`、期望当前步骤、动作标识 | 新的当前步骤、完成标志 | 比较并推进；动作标识去重；过期步骤返回 409 并附当前状态 |
-| 完成流程 | `sceneId`、结束原因 | 完成状态 | 已完成时重复调用仍成功；不能倒退到历史步骤 |
+原始材料、用户转写、分题回答音频和逐轮评分仅在进程内或受控临时存储中存在，最终化或
+失败后清理。
 
-Interview 的问题计划决定“下一题是什么”，`SceneFlowService` 只保证顺序、并发安全和
-可恢复状态，不理解简历或岗位语义。
+## 4. 材料与问题计划
 
-### 4.3 公共 `SessionService`
+输入约束：
 
-| 操作 | 输入 | 输出 | 契约 |
-|---|---|---|---|
-| 开始 Scene Session | 当前用户、已就绪 `sceneId`、模型/声音等会话选项、幂等键 | `sessionId`、`sceneType`、连接信息、状态 | 校验 Scene 归属并绑定 `INTERVIEW_SCENE`；公共状态机负责 `CREATED` 到 `ACTIVE` |
-| 追加完整消息 | 当前用户、`sessionId`、轮次/消息标识、角色、完整文本 | 确认后的消息序号 | 只保存 final 消息，不保存流式 delta；同一消息标识重复提交不重复写入 |
-| 结束 Session | 当前用户、`sessionId`、结束原因 | 最终状态和结束时间 | 先持久化结束事实，再触发可重试的报告生成；重复结束不改写首次有效结束时间 |
-| 查询 Session | 当前用户、`sessionId` | 状态、去敏对话和报告状态 | 每次读取都校验归属；不得返回临时凭证、内部 Prompt 或原始供应商错误 |
+- `jobTitle` 必填；最终 JD 文本不超过 5,000 字符。
+- `resumeText` 与 `resumeFile` 互斥且都可不提供。
+- 简历文件仅允许文本型 PDF 和 DOCX，单文件不超过 10 MB，PDF 不超过 10 页，最终提取
+  文本不超过 20,000 字符。
+- 不支持 DOC、Markdown 文件、图片简历、扫描件和扫描版 PDF。
+- JD OCR 最多接收五张图片，合计不超过 10 MB；只返回识别文字，不创建 Interview，也不
+  保存截图。
 
-公共 Session 是实时训练用例的编排者：可以协调 `SceneFlowService`，并在结束事实落库
-后把报告任务交给 `EvaluationService`；它不决定面试下一题、不解析材料、不计算评分。
-Controller 只做协议适配，不串联这三个 Service。暂停、恢复和打断的实时协议仍由客户
-端 DataChannel 处理；只有影响业务事实的状态才持久化。
+`TargetRoleSummary` 固定包含 `overview`、`responsibilities`、`requiredSkills`、
+`qualificationRequirements` 四个字段。简历只临时影响问题计划，不进入岗位摘要。
 
-### 4.4 公共 `EvaluationService`
+所有难度固定五个主问题：
 
-| 操作 | 输入 | 输出 | 契约 |
-|---|---|---|---|
-| 记录单轮评价 | 已授权 `sessionId`、轮次、完整文本、可选音频 | 单轮口语结果 | `(sessionId, turnNo, evaluatorVersion)` 幂等；不改变 Flow 或 Session 状态 |
-| 生成整场报告 | 已完成 `sessionId`、完整对话、Interview 评分上下文 | 报告或处理中状态 | 可重复执行并覆盖同版本未完成结果；缺失维度明确标记，不以 0 分代替 |
-| 查询评价 | 当前用户、`sessionId` | 完整、部分、处理中或失败 | 校验 Session 归属；报告只评价英语表达，不推断岗位匹配或录用概率 |
+- BASIC：每个主问题最多一个澄清型追问。
+- STANDARD：每个主问题最多一个原因、行动或结果型追问。
+- CHALLENGE：每个主问题最多两个权衡、反思或复杂场景型追问。
 
-评分上下文由 Interview Scene 提供，算法与供应商实现归公共 Evaluation/Provider。
+LLM 每轮只可建议 `ASK_FOLLOW_UP` 或 `MOVE_TO_NEXT_MAIN`，最终由
+`InterviewProgress` 强制执行追问上限。用户英语等级只影响措辞复杂度，不改变问题难度、
+评分量尺或数据库结构。
 
-## 5. 关键 ADR
-
-### ADR-001：Interview 与 IELTS 作为 Scene 特化
-
-- 背景：两者有不同材料和流程规则，但都需要 Scene、Session、Evaluation 和 Provider。
-- 决策：特化放在 `service/scene` 和 `domain/dto/scene`，不建立顶层 Interview/IELTS 包。
-- 原因：业务差异留在变化更快的 Scene 策略，跨场景事实只维护一份。
-- 代价：公共契约必须容纳不同流程，不能把自定义场景的固定学习阶段写死为全局规则。
-- 替代：独立 Interview 模块会复制 Session/评分并形成双向依赖，因此不采用。
-
-### ADR-002：结束事实与报告生成解耦
-
-- 背景：外部评分可能超时，不能因此丢失已经完成的训练。
-- 决策：Session 结束先持久化；报告按 Session 和评分版本幂等生成，可返回处理中、部分或
-  失败状态。
-- 原因：用户可以离开页面，重试不会重复会话或报告。
-- 代价：读取方必须展示非终态，并需要后台重试或后续补偿入口。
-- 替代：结束请求内强制同步生成报告会扩大超时和重复提交风险，因此不采用。
-
-### ADR-003：原始面试材料最小化和短期保留
-
-- 背景：简历与岗位说明包含个人和商业敏感信息。
-- 决策：原始文件仅在受控临时存储中保留到提取完成或短 TTL 到期；业务库只保存训练所需
-  的最小快照和对象 Key，不保存长期签名 URL，不在日志中记录全文。派生快照仍按敏感
-  数据处理，不跨用户复用，并受明确保留期和删除策略约束。
-- 原因：降低泄漏面，同时保留可重复训练所需的稳定业务上下文。
-- 代价：失败排查依赖脱敏摘要、错误码和关联 ID，不能依赖原文日志。
-- 替代：长期保存原始简历便于重跑但超出 foundation 的必要范围，因此不采用。
-
-### ADR-004：数据库演进只认 Flyway 版本迁移
-
-- 背景：项目已配置 `classpath:db/migration` 且关闭 Spring SQL init，多份 DDL 来源会
-  造成执行顺序和环境状态不一致。
-- 决策：版本化 DDL 只放 `src/main/resources/db/migration`；运维脚本不能替代或重复
-  Flyway 迁移。
-- 原因：所有环境共享可验证、可追踪的迁移历史。
-- 代价：已发布迁移不可直接修改，修正必须新增后续版本。
-- 替代：同时维护 `schema.sql` 或手工部署 DDL 容易漂移，因此不采用。
-
-## 6. 失败补偿与隐私
-
-| 失败点 | 已持久化事实 | 补偿与重试 | 用户可见状态 |
-|---|---|---|---|
-| 文件校验/提取失败 | 最多只有准备请求与脱敏错误码 | 删除临时对象；同一幂等键修正输入后需新请求 | 材料无效或无法解析 |
-| 问题计划/Prompt 生成失败 | Scene 保持准备中或失败，不可启动 | 按退避策略重试；达到上限后标记失败并清理临时材料 | 准备失败，可重试 |
-| 流程创建失败 | 已就绪 Scene 仍存在 | 对 Scene/流程版本幂等重放 | 暂不可开始 |
-| 实时连接失败 | Session 已创建但未激活 | 将 Session 记为 `FAILED` 或按策略重连；临时凭证自然过期 | 连接失败，可重新开始 |
-| 消息重复/乱序 | 已确认的完整消息 | 按消息标识去重；缺口保持待补，不猜测文本 | 对话同步中 |
-| 结束时评分失败 | Session 已完成、结束时间不可回退 | 按 Session/评分版本重试；保留已有单轮结果 | 报告处理中、部分或失败 |
-| 临时材料删除失败 | 仅保存对象 Key 和清理状态 | 有界重试并告警；下载链接保持短 TTL | 不暴露基础设施细节 |
-
-所有入口从认证上下文取得 `userId`，对 `sceneId`、`sessionId`、报告和对象 Key 逐次校验
-归属。日志只记录关联 ID、状态、耗时、文件类型/大小和脱敏错误码；禁止记录简历正文、
-岗位说明全文、Prompt、JWT、临时凭证、完整 SDP、音频 Base64 或供应商原始响应。材料
-摘要和问题计划也按敏感数据授权与清理，不得用于其他用户或模型训练。
-
-## 7. 核心场景伪代码
-
-### 7.1 准备面试 Scene
+## 5. 创建流程
 
 ```text
-准备面试场景(当前用户, 简历, 岗位说明, 时长, 幂等键):
-    校验用户、文件类型与大小、岗位说明长度、允许时长
-    如果存在同用户同幂等键的请求:
-        返回已有准备结果
-
-    临时对象 = 安全保存简历(短期保留)
-    尝试:
-        材料摘要 = 提取训练所需最小信息(临时对象, 岗位说明)
-        问题计划 = 生成面试问题计划(材料摘要, 时长)
-        场景 = 保存 Interview Scene(当前用户, 材料摘要, 问题计划)
-        创建流程(场景, 问题计划的流程定义)
-        标记场景已就绪
-        安排删除临时对象
-        返回场景标识和已就绪状态
-    失败:
-        标记准备失败并保存安全错误码
-        安排删除临时对象
-        返回可重试或需修正材料的状态
+分配 interviewId 和 sessionId
+-> 构造 InterviewSession
+-> 校验并解析材料
+-> 生成 role_summary
+-> 生成五题计划
+-> 生成第一题 TTS
+-> 创建 interview
+-> SceneFlowService.createFlow(interviewId)，初始阶段为 DIALOGUE
+-> SessionService.registerSceneSession(session)
+-> 返回第一题文本和 Base64 音频
 ```
 
-### 7.2 公共 Session 完成面试并交付报告
+`registerSceneSession` 是 `practice_session` 的唯一创建入口，并以一个可补偿的注册命令
+完成 registry 注册和数据库创建：任一步骤失败都必须移除已注册运行态并删除已创建的
+`practice_session`。创建失败时再按逆序释放 Flow、删除未完成 Interview 和清理临时材料。
+创建流程不拆分 prepare/start，不创建 Realtime 连接。
+
+## 6. 回答协议与幂等
 
 ```text
-公共 Session 完成面试(当前用户, 场景标识, 会话标识, 结束原因):
-    校验场景和会话都归属当前用户且相互绑定
-    幂等完成 Scene Flow
-    幂等结束公共 Session 并固定结束时间
+POST /api/interviews/{interviewId}/answers
+Content-Type: multipart/form-data
 
-    尝试:
-        完整对话 = 读取已确认的 final 消息
-        评分上下文 = 读取 Interview Scene 的评分快照
-        报告 = 幂等生成口语报告(会话标识, 完整对话, 评分上下文)
-        返回已完成报告
-    暂时失败:
-        保留已完成 Session 和已有单轮结果
-        安排按会话和评分版本重试
-        返回报告处理中或部分结果
-    永久失败:
-        保存安全错误码，不覆盖已有结果
-        返回报告失败并允许用户查看完整对话
+questionNo
+submissionId
+audio
 ```
 
-## 8. 实现验收约束
+音频必须为 16 kHz、单声道、16-bit PCM WAV，单轮最长 210 秒。210 秒是适配默认 Qwen
+ASR 7 MiB 输入上限的技术安全边界，不是面试结束原因，也不提供面试总时长选择。公共
+`PcmWavValidator` 的默认五分钟能力保持兼容，Interview 通过参数化上限使用 210 秒。
 
-- 任何 Interview 生产代码都落在现有 Scene、Session、Evaluation、Provider 或
-  Infrastructure 边界内，没有顶层 `service/interview`、`domain/dto/interview`。
-- 并发创建、推进、消息追加、结束和报告生成都有业务幂等键及冲突测试。
-- 认证、资源归属、文件限制、短 TTL、日志脱敏和删除补偿有自动化测试。
-- 新 DDL 只通过新的 Flyway 版本迁移交付；不修改已发布迁移，不提交 `schema.sql` 副本。
-- 单元、容器集成和覆盖率门禁遵循 `CLAUDE.md`；本文档本身不替代实现测试。
+回答接口在复制临时 WAV、原子预占 submission 并成功提交 executor 后返回
+`202 Accepted`。状态机为：
+
+```text
+ACCEPTED -> PROCESSING -> COMPLETED
+                         -> FAILED_RETRYABLE
+                         -> FAILED_TERMINAL
+```
+
+幂等规则：
+
+- 相同 `submissionId`、题号和音频摘要在 PROCESSING/COMPLETED 时返回已有状态，不重复
+  推进问题。
+- FAILED_RETRYABLE 可使用同一 ID 和摘要重试；优先复用原临时文件。
+- FAILED_TERMINAL 返回原错误；当前题仍可继续时允许使用新的 submission ID 重新录制。
+- 同一 ID 对应不同内容、当前题使用其他未完成 ID、旧题迟到提交均返回 409。
+- 所有预占失败和 executor 拒绝都删除本次新临时文件并回滚未生效的 reservation。
+
+处理顺序固定为：
+
+```text
+WAV 校验 -> ASR -> 有效英文词统计 -> (有效词 >= 4 时 evaluateSpeech，否则记录不可评分)
+-> LLM 决定追问或下一主问题 -> InterviewProgress 裁决 -> 下一题 TTS
+```
+
+只有全部步骤成功才推进问题。API 和日志不得返回或记录用户转写、逐轮评分或 Provider 原始
+响应。AI 问题文本和短音频可通过运行态 JSON 返回，音频字段使用 Base64 和明确 MIME。
+
+## 7. 中断恢复
+
+状态查询、心跳和业务请求都更新 `lastSeen`。非处理态会话失联后进入 `INTERRUPTED`；后端
+每分钟扫描一次，十分钟内恢复时返回 ACTIVE，不重建 Flow，也不改变问题进度。
+
+正在处理回答、等待已接收回答结束或最终化的 Session 不参与基于 lastSeen 的空闲清理，
+但每个 submission 和 finalizer 都必须带有硬截止时间（从接收/开始最终化起不超过十分钟）。
+超过截止时间时，watchdog 将卡死任务标记为 FAILED_RETRYABLE 或 FAILED_TERMINAL，删除其
+临时数据并解除占用；随后由普通十分钟清理处理已无活动的 Session。这样 Provider 阻塞、
+executor 丢失回调和 finalizer 停滞都不会永久占用运行态。
+
+超过会话恢复窗口后：
+
+- 运行态和 `practice_session` 标记 FAILED。
+- 调用 `completeFlow(interviewId, false)`。
+- 删除未完成 Interview 和临时数据。
+- 移除运行态，不进入历史、训练时长或趋势。
+
+不支持后端进程重启后的未完成面试恢复。
+
+## 8. 结束与最低数据
+
+单个回答至少四个有效英文词才参与评分；所有可评分回答合计至少二十个有效英文词才允许
+形成资产。有效词统计复用 `EnglishWordCounter`。二十词资产门槛与公共三十秒训练时长
+门槛互不替代。
+
+```text
+POST /api/interviews/{interviewId}/end
+{ "confirmInsufficientData": false }
+```
+
+结束请求不调用会过早完成 `practice_session` 的通用 `endSession`。它只阻止新的回答预占，
+并等待已经 ACCEPTED/PROCESSING 的回答结束；锁内只观察和切换状态，不阻塞 processor。
+
+- 有 pending submission 时返回 `202 WAITING_FOR_SUBMISSIONS`。
+- pending 完成后若不足二十词，运行态设置 `confirmationRequired=true`，恢复 ACTIVE 和新
+  回答接收；`state` 返回实际词数和最低词数。
+- 数据已确定不足且 `confirmInsufficientData=false` 时返回
+  `409 INTERVIEW_DATA_CONFIRMATION_REQUIRED`，保持 ACTIVE 并更新 `lastSeen`。
+- 确认结束后，运行态和 `practice_session` 标记 FAILED，释放 Flow，删除未完成 Interview
+  和临时数据，不生成报告或录音。
+- 数据足够的用户提前结束生成 PARTIAL；五题计划自然完成生成 FULL。
+
+## 9. 五维报告
+
+FULL 和 PARTIAL 都是字段完整、同量尺的报告。五个维度为：
+
+- 流利度。
+- 逻辑与连贯性。
+- 语法控制。
+- 发音可理解度。
+- 词汇与面试表达。
+
+流利度和发音复用无副作用语音评分结果，逻辑、语法和词汇由一次结构化 LLM 调用生成。
+五维均为 0-100 分且等权，总分保留一位小数。不得复用包含其他维度或不等权规则的
+`ConversationScoreCalculator`。
+
+报告使用中文，包含每个维度的评价和行动建议；不逐字引用用户回答，不输出姓名、公司、
+项目等身份实体，不评价岗位匹配、胜任度或录用概率。LLM 结构非法时只修复一次，再次
+失败则最终化失败。
+
+## 10. 完整录音与完成闸门
+
+完整录音按实际问答顺序包含：
+
+```text
+AI 问题音频 -> 用户回答 -> 下一 AI 问题音频 -> 下一用户回答 -> ...
+```
+
+所有分段统一为 16 kHz 单声道 PCM，拼接后编码为 64 kbps MP3，通过现有
+`ObjectStorageProvider` 上传确定性对象 Key。数据库不保存公开或长期签名 URL。
+
+Interview 只有在完整报告和完整录音都成功后才算完成。成功顺序：
+
+```text
+确定 FULL/PARTIAL
+-> 生成完整报告
+-> 拼接并编码完整录音
+-> 上传录音对象
+-> 单个数据库事务：保存实际问题、报告、录音元数据、completed_at、practice_session COMPLETED
+-> 事务提交后更新运行态
+-> SceneFlowService.advanceStage(interviewId, DIALOGUE)
+-> SceneFlowService.completeFlow(interviewId, true)
+-> 清理临时数据和运行态
+```
+
+最终化按 `interviewId` 幂等。已提交资产不会因后续 Flow 清理失败降级：
+
+- `advanceStage` 和 `completeFlow(true)` 都必须幂等。
+- 提交后 Flow 操作失败时保留运行态中的 `flowCleanupPending`，以有界退避重试；重试任务
+  只做 Flow 收敛，不修改已提交资产和 `practice_session`。
+- 重试耗尽只记录脱敏告警，资产仍保持可见，后续状态查询不得把它降级为 FAILED。
+
+报告、录音、对象上传或最终数据库事务任一最终化步骤失败时统一执行：
+
+- 运行态和 `practice_session` 标记 FAILED。
+- 不向 Interview 表写不存在的 FAILED 状态。
+- 删除未完成 Interview、问题和报告。
+- 回滚或删除已写入但未提交的数据库事实。
+- 对已上传对象执行补偿删除；对象不存在视为幂等成功。
+- `completeFlow(interviewId, false)` 并清理临时数据。
+- 不产生可见学习资产。
+
+## 11. 学习资产、趋势与删除
+
+FULL 和 PARTIAL 都进入历史并可查看岗位摘要、实际 AI 问题、完整五维报告和完整录音。
+只有 FULL 进入最近成绩和能力趋势，趋势按难度分组并动态计算。录音播放接口每次校验用户
+归属并生成短期签名 URL。
+
+快速复练创建新的 Interview，带入岗位名称、难度和岗位摘要；只读取用户指定来源的上一场
+相同岗位 Interview 的实际问题作为避免重复提示。不查询全历史，不做向量或语义相似度
+检索，不持久化 `sourceInterviewId`，也不承诺绝对不重复。
+
+删除顺序：
+
+```text
+删除录音对象
+-> 数据库事务删除 interview_report
+-> 删除 interview_question
+-> 删除 interview
+```
+
+对象不存在视为幂等成功。对象已删但数据库事务失败时，数据库 Interview 记录就是重试
+依据；第二次请求继续数据库删除。删除不得删除或回写 `practice_session`，已产生的训练
+时长不回退。
+
+## 12. HTTP 与隐私约束
+
+公开路由：
+
+```text
+POST   /api/interviews/job-description/ocr
+POST   /api/interviews
+POST   /api/interviews/{id}/answers
+GET    /api/interviews/{id}/state
+POST   /api/interviews/{id}/heartbeat
+POST   /api/interviews/{id}/end
+GET    /api/interviews
+GET    /api/interviews/{id}
+GET    /api/interviews/{id}/recording
+GET    /api/interviews/trends?difficulty=...
+POST   /api/interviews/{sourceId}/repractice
+DELETE /api/interviews/{id}
+```
+
+主要状态映射：202 表示已接收异步工作；404 表示资源不存在或不归属；409 表示题号、提交
+或确认冲突；422 表示可识别但无效的材料、音频或业务状态；502 表示同步外部依赖失败；
+503 表示 executor 或服务暂不可用。异步失败通过 `state` 返回稳定业务错误码、可重试标志，
+不改变已经结束的 HTTP 响应。
+
+日志只记录关联 ID、题号、状态、耗时、文件类型和大小、脱敏错误码。禁止记录 JWT、简历
+正文、JD 全文、Prompt、转写、音频 Base64、长期签名 URL、供应商请求或原始错误体。
+
+## 13. 验收约束
+
+- Controller 只依赖 `InterviewSceneService`。
+- 五题计划、追问上限、submission 幂等和题号推进均有单元与并发测试。
+- 210 秒音频边界测试不改变公共 300 秒行为。
+- 状态查询、恢复、结束确认和十分钟清理使用 fake clock/executor/latch 测试。
+- FULL/PARTIAL 五维完整性、等权总分和趋势口径有自动化测试。
+- 报告或录音任一失败都不能形成可见资产。
+- 对象删除成功但数据库失败后的第二次重试可以完成删除。
+- 原始材料、用户转写和分题音频不入库、不进入公开 API 和日志。
+- 所有 Java 测试放在 `backend/unispeaking-server/src/test/java` 对应包目录。


### PR DESCRIPTION


## 关联 Issue

- Issue #38
- Issue #33

本 PR 是 Interview 后端第一阶段基础能力，不关闭上述 Issue。

## 变更说明

- 明确分段式逐题面试的模块职责、隐私边界、失败补偿和完成闸门。
- 建立固定五个主问题、分难度追问上限、实际问题进度和结束确认等运行态领域模型。
- 增加按 `interviewId` 串行、不同面试并行的 FIFO 执行协调器。
- 定义创建、OCR、回答、状态、心跳、结束、历史、详情、录音、趋势和删除接口契约。
- 增加稳定的 Interview 错误码及 404、409、413、415、422、502、503 映射。
- 建立 JD、简历和 OCR 批次的材料校验与脱敏边界。
- 固化 BASIC、STANDARD、CHALLENGE 三档五题计划及追问限制。
- 增加 FULL/PARTIAL 通用的五维等权报告组装能力。
- 增加十分钟中断恢复、任务硬截止、过期租约和失败清理重试基础。
- 修复任务迟到提交、心跳与过期清理竞争、孤儿 submission 清理顺序等并发问题。

## 关键约束

- 所有难度固定五个主问题。
- BASIC、STANDARD 每题最多一次追问，CHALLENGE 每题最多两次。
- Interview 单轮 PCM WAV 上限按 210 秒设计，公共默认能力仍保持 300 秒。
- AI 问题音频通过 JSON Base64 和 MIME 返回。
- 不保存或公开用户转写、Provider 原始字段、原始 JD/简历、音频摘要和对象存储 Key。
- FULL/PARTIAL 报告均包含完整五维，等权计算并保留一位小数。
- 不新增 Redis、MQ、Outbox、SSE、业务 WebSocket、Interview 私有表或第二套 Scene Flow。

## 本 PR 不包含

- `InterviewController` 和 `InterviewSceneService` 的完整业务接线。
- ASR、语音评分、追问裁决和下一题 TTS 编排。
- 临时回答音频存储及完整 MP3 最终化。
- 历史、趋势、快速复练和物理删除的业务实现。
- 前端真实 API 接入。

这些内容将在后续较小 PR 中继续实现。

## 验证

- 材料、OCR、问题计划相关测试：102 项通过。
- 报告组装及契约相关测试：22 项通过。
- 会话恢复与超时清理门禁：44 项通过。
- Spring Application Context 测试通过。
- `git diff --check` 通过。
- 所有新增 Java 测试均位于 `src/test/java` 对应包目录。

## 审计

- 各提交均执行了独立代码审计。
- 已完成的早期提交按照原流程完成两轮审计。
- 最新运行态提交按照调整后的流程完成一轮审计。
- 该轮审计发现 2 个高危和 1 个中危并发问题，均已修复并补充回归测试。

## Reviewer 关注点

- `InterviewExecutionCoordinator` 的 FIFO、过期租约及迟到提交隔离。
- `InterviewRuntimeSupervisor` 的恢复窗口、清理认领和失败重试。
- Interview 验证错误使用 422 时，其他模块仍保持原有 400 行为。
- DTO 字段白名单是否满足隐私约束。
- FULL/PARTIAL 五维报告是否保持同量尺和等权计算。