### PR TITLE
feat: adapt mobile free chat and scene practice

### DIFF
--- a/frontend/mobile/app.json
+++ b/frontend/mobile/app.json
@@ -12,6 +12,12 @@
     },
     "android": {
       "package": "com.unispeaking.mobile",
+      "permissions": [
+        "android.permission.RECORD_AUDIO",
+        "android.permission.ACCESS_NETWORK_STATE",
+        "android.permission.CHANGE_NETWORK_STATE",
+        "android.permission.MODIFY_AUDIO_SETTINGS"
+      ],
       "adaptiveIcon": {
         "backgroundColor": "#F4F4F1",
         "foregroundImage": "./assets/images/android-icon-foreground.png",
@@ -33,7 +39,10 @@
           "image": "./assets/images/unispeaking/brand-mark.jpg",
           "imageWidth": 92
         }
-      ]
+      ],
+      "expo-secure-store",
+      "expo-audio",
+      "@siteed/audio-studio"
     ],
     "experiments": {
       "typedRoutes": true,

--- a/frontend/mobile/jest.setup.ts
+++ b/frontend/mobile/jest.setup.ts
@@ -1,0 +1,4 @@
+jest.mock(
+  '@react-native-async-storage/async-storage',
+  () => require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);

--- a/frontend/mobile/package-lock.json
+++ b/frontend/mobile/package-lock.json
@@ -11,15 +11,19 @@
         "@expo/ui": "~57.0.7",
         "@expo/vector-icons": "^15.0.2",
         "@react-native-async-storage/async-storage": "2.2.0",
+        "@siteed/audio-studio": "^3.2.1",
         "expo": "~57.0.8",
+        "expo-audio": "~57.0.3",
         "expo-constants": "~57.0.7",
         "expo-device": "~57.0.1",
+        "expo-file-system": "~57.0.1",
         "expo-font": "~57.0.1",
         "expo-glass-effect": "~57.0.1",
         "expo-image": "~57.0.1",
         "expo-linear-gradient": "~57.0.1",
         "expo-linking": "~57.0.4",
         "expo-router": "~57.0.8",
+        "expo-secure-store": "~57.0.1",
         "expo-splash-screen": "~57.0.5",
         "expo-status-bar": "~57.0.1",
         "expo-symbols": "~57.0.1",
@@ -35,12 +39,19 @@
         "react-native-screens": "~4.26.0",
         "react-native-svg": "15.15.4",
         "react-native-web": "~0.21.0",
+        "react-native-webrtc": "^124.0.8",
         "react-native-worklets": "0.10.0"
       },
       "devDependencies": {
+        "@react-native/jest-preset": "^0.86.0",
+        "@testing-library/react-native": "^14.0.1",
+        "@types/jest": "^29.5.14",
         "@types/react": "~19.2.2",
         "eslint": "^9.0.0",
         "eslint-config-expo": "~57.0.1",
+        "jest": "^29.7.0",
+        "jest-expo": "^57.0.2",
+        "test-renderer": "^1.2.0",
         "typescript": "~6.0.3"
       }
     },
@@ -458,6 +469,61 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-async-generators": {
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
+      "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-bigint": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
+      "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-properties": {
+      "version": "7.12.13",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
+      "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.12.13"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-class-static-block": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
+      "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-decorators": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.29.7.tgz",
@@ -515,6 +581,48 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-import-attributes": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.29.7.tgz",
+      "integrity": "sha512-zGYcYfq/WmZ4V+kBIXQon9dSSc8ircGZqw9ZaNhhGj9nZkeBu1jHLBDQqYYi5WA9uawvA2sIMbry2nCFhf5Djg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-import-meta": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
+      "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-json-strings": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
+      "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-jsx": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.29.7.tgz",
@@ -525,6 +633,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
+      "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -542,6 +663,45 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/plugin-syntax-numeric-separator": {
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
+      "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.10.4"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-object-rest-spread": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
+      "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-optional-catch-binding": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
+      "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
     "node_modules/@babel/plugin-syntax-optional-chaining": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
@@ -549,6 +709,38 @@
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.8.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-private-property-in-object": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
+      "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-syntax-top-level-await": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
+      "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
@@ -1187,6 +1379,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/@egjs/hammerjs": {
       "version": "2.0.17",
@@ -1987,6 +2186,429 @@
         "node": ">=12"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
+      "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "find-up": "^4.1.0",
+        "get-package-type": "^0.1.0",
+        "js-yaml": "^3.13.1",
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/camelcase": {
+      "version": "5.3.1",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+      "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+      "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/console": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/console/-/console-29.7.0.tgz",
+      "integrity": "sha512-5Ni4CU7XHQi32IJ398EEP4RrB8eV09sXP2ROqD4bksHrnTree52PsxvX8tpL8LvTZ3pFzXyPbNQReSN41CAhOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/core": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/core/-/core-29.7.0.tgz",
+      "integrity": "sha512-n7aeXWKMnGtDA48y8TLWJPJmLmmZ642Ceo78cYWEpiD7FzDgmNDV/GCVRorPABdXLJZ/9wzzgZAlHjXjxDHGsg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/reporters": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-changed-files": "^29.7.0",
+        "jest-config": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-resolve-dependencies": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/core/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jest/create-cache-key-function": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
+      "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/diff-sequences": {
+      "version": "30.4.0",
+      "resolved": "https://registry.npmjs.org/@jest/diff-sequences/-/diff-sequences-30.4.0.tgz",
+      "integrity": "sha512-zOpzlfUs45l6u7jm39qr87JCHUDsaeCtvL+kQe/Vn9jSnRB4/5IPXISm0h9I1vZW/o00Kn4UTJ2MOlhnUGwv3g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/environment": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
+      "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-8uMeAMycttpva3P1lBHB8VciS9V0XAr3GymPpipdyQXbBcuhkLQOSe8E/p92RyAdToS6ZD1tFkX+CkhoECE0dQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.7.0",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/expect-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-29.7.0.tgz",
+      "integrity": "sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/fake-timers": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
+      "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@sinonjs/fake-timers": "^10.0.2",
+        "@types/node": "*",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/get-type": {
+      "version": "30.1.0",
+      "resolved": "https://registry.npmjs.org/@jest/get-type/-/get-type-30.1.0.tgz",
+      "integrity": "sha512-eMbZE2hUnx1WV0pmURZY9XoXPkUYjpc55mb0CrhtdWLtzMQPFvu/rZkTLZFTsdaVQa+Tr4eWAteqcUzoawq/uA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@jest/globals": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/globals/-/globals-29.7.0.tgz",
+      "integrity": "sha512-mpiz3dutLbkW2MNFubUGUEVLkTGiqW6yLVTA+JbP6fI6J5iL9Y0Nlg8k95pcF8ctKwCS7WVxteBs29hhfAotzQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "jest-mock": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/reporters": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/reporters/-/reporters-29.7.0.tgz",
+      "integrity": "sha512-DApq0KJbJOEzAFYjHADNNxAE3KbhxQB1y5Kplb5Waqw6zVbuWatSnMjE5gs8FUgEPmNsnZA3NCWl9NG0ia04Pg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@bcoe/v8-coverage": "^0.2.3",
+        "@jest/console": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "exit": "^0.1.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "istanbul-lib-coverage": "^3.0.0",
+        "istanbul-lib-instrument": "^6.0.0",
+        "istanbul-lib-report": "^3.0.0",
+        "istanbul-lib-source-maps": "^4.0.0",
+        "istanbul-reports": "^3.1.3",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "slash": "^3.0.0",
+        "string-length": "^4.0.1",
+        "strip-ansi": "^6.0.0",
+        "v8-to-istanbul": "^9.0.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@jest/reporters/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/istanbul-lib-instrument": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-6.0.3.tgz",
+      "integrity": "sha512-Vtgk7L/R2JHyyGW07spoFlB8/lpjiOLTjMdms6AFMraYt3BaJauod/NGrfnVG/y4Ix1JEuMRPDPEj2ua+zz1/Q==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.23.9",
+        "@babel/parser": "^7.23.9",
+        "@istanbuljs/schema": "^0.1.3",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^7.5.4"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@jest/reporters/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1994,6 +2616,80 @@
       "license": "MIT",
       "dependencies": {
         "@sinclair/typebox": "^0.27.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/source-map": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/@jest/source-map/-/source-map-29.6.3.tgz",
+      "integrity": "sha512-MHjT95QuipcPrpLM+8JMSzFx6eHp5Bm+4XeFDJlwsvVBjmKNiIAvasGK2fxz2WbGRlnvqehFbh07MMa7n3YJnw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "callsites": "^3.0.0",
+        "graceful-fs": "^4.2.9"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-result": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-result/-/test-result-29.7.0.tgz",
+      "integrity": "sha512-Fdx+tv6x1zlkJPcWXmMDAG2HBnaR9XPSd5aDWQVsfrZmLVT3lU1cwyxLgRmXR9yrq4NBoEm9BMsfgFzTQAbJYA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/istanbul-lib-coverage": "^2.0.0",
+        "collect-v8-coverage": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/test-sequencer": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/test-sequencer/-/test-sequencer-29.7.0.tgz",
+      "integrity": "sha512-GQwJ5WZVrKnOJuiYiAF52UNUJXgTZx1NHjFSEB0qEMmSZKAkdMoIzw/Cj6x6NF4AvV23AUqDpFzQkN/eYCYTxw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/@jest/transform": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
+      "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/types": "^29.6.3",
+        "@jridgewell/trace-mapping": "^0.3.18",
+        "babel-plugin-istanbul": "^6.1.1",
+        "chalk": "^4.0.0",
+        "convert-source-map": "^2.0.0",
+        "fast-json-stable-stringify": "^2.1.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "pirates": "^4.0.4",
+        "slash": "^3.0.0",
+        "write-file-atomic": "^4.0.2"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2734,6 +3430,26 @@
         "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
       }
     },
+    "node_modules/@react-native/jest-preset": {
+      "version": "0.86.0",
+      "resolved": "https://registry.npmjs.org/@react-native/jest-preset/-/jest-preset-0.86.0.tgz",
+      "integrity": "sha512-KA+xpIP3DvJy7PQJ9c6ZdEKkOPChl+Rk/rV2MhQACEAzfhWU84407KZQv4ccyO3B4caD0gPrFjE96a4P993nsQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.7.0",
+        "@react-native/js-polyfills": "0.86.0",
+        "babel-jest": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "regenerator-runtime": "^0.13.2"
+      },
+      "engines": {
+        "node": ">= 20.19.4"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
+      }
+    },
     "node_modules/@react-native/js-polyfills": {
       "version": "0.86.0",
       "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.86.0.tgz",
@@ -2820,6 +3536,38 @@
       "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "license": "MIT"
     },
+    "node_modules/@sinonjs/commons": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "node_modules/@sinonjs/fake-timers": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@sinonjs/commons": "^3.0.0"
+      }
+    },
+    "node_modules/@siteed/audio-studio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@siteed/audio-studio/-/audio-studio-3.2.1.tgz",
+      "integrity": "sha512-H566BMZYD5p60vrc22S2C50CXNwW39ppdMBr2hE8/m1JHsBTtoxYt1e8WjP1bgztsUjpuevSrKZuUMSFo+GgqQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@expo/config-plugins": ">=7.0.0",
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
@@ -2900,6 +3648,82 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "license": "MIT"
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-14.0.1.tgz",
+      "integrity": "sha512-2r2e2y8SkUNRWKRXlUGqDYunB+AkbdXUPn49Bs5rpv9oxRb0K3USBVugbPbAKJjfj4w5Ba91NJ8LcQCZyopUZA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-matcher-utils": "^30.4.1",
+        "picocolors": "^1.1.1",
+        "pretty-format": "^30.4.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=19.0.0",
+        "react-native": ">=0.78",
+        "test-renderer": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react-native/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/react-native/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
     "node_modules/@testing-library/user-event": {
       "version": "14.6.1",
       "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
@@ -2911,6 +3735,16 @@
       },
       "peerDependencies": {
         "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+      "integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -2931,12 +3765,67 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/graceful-fs": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
+      "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/hammerjs": {
       "version": "2.0.46",
@@ -2966,6 +3855,29 @@
       "license": "MIT",
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.14",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.14.tgz",
+      "integrity": "sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
+      }
+    },
+    "node_modules/@types/jsdom": {
+      "version": "20.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-20.0.1.tgz",
+      "integrity": "sha512-d0r18sZPmMQr1eG35u12FZfhIXNrnsPU/g5wvRKCUf/tOGilKKwYMYGqh33BNR6ba+2gkHw1EUiHoN3mn7E5IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "parse5": "^7.0.0"
       }
     },
     "node_modules/@types/json-schema": {
@@ -3000,6 +3912,16 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-HZOXsKT0tGI9LlUw2LuedXsVeB88wFa536vVL0M6vE8zN63nI+sSr1ByxmPToP5K5bukaVscyeCJcF9guVNJ1g==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-test-renderer": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-19.1.0.tgz",
@@ -3008,6 +3930,20 @@
       "dependencies": {
         "@types/react": "*"
       }
+    },
+    "node_modules/@types/stack-utils": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
+      "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/yargs": {
       "version": "17.0.35",
@@ -3595,6 +4531,14 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/abab": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
+      "integrity": "sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==",
+      "deprecated": "Use your platform's native atob() and btoa() methods instead",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -3632,6 +4576,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/acorn-globals": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-globals/-/acorn-globals-7.0.1.tgz",
+      "integrity": "sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.1.0",
+        "acorn-walk": "^8.0.2"
+      }
+    },
     "node_modules/acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
@@ -3640,6 +4595,19 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/agent-base": {
@@ -3735,6 +4703,33 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/anymatch/node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/arg": {
@@ -3946,6 +4941,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -3960,6 +4962,61 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/babel-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
+      "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/transform": "^29.7.0",
+        "@types/babel__core": "^7.1.14",
+        "babel-plugin-istanbul": "^6.1.1",
+        "babel-preset-jest": "^29.6.3",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.8.0"
+      }
+    },
+    "node_modules/babel-plugin-istanbul": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
+      "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.0.0",
+        "@istanbuljs/load-nyc-config": "^1.0.0",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-instrument": "^5.0.4",
+        "test-exclude": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/babel-plugin-jest-hoist": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
+      "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.3.3",
+        "@babel/types": "^7.3.3",
+        "@types/babel__core": "^7.1.14",
+        "@types/babel__traverse": "^7.0.6"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/babel-plugin-polyfill-corejs2": {
@@ -4043,6 +5100,33 @@
         "@babel/plugin-syntax-flow": "^7.12.1"
       }
     },
+    "node_modules/babel-preset-current-node-syntax": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
+      "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/plugin-syntax-async-generators": "^7.8.4",
+        "@babel/plugin-syntax-bigint": "^7.8.3",
+        "@babel/plugin-syntax-class-properties": "^7.12.13",
+        "@babel/plugin-syntax-class-static-block": "^7.14.5",
+        "@babel/plugin-syntax-import-attributes": "^7.24.7",
+        "@babel/plugin-syntax-import-meta": "^7.10.4",
+        "@babel/plugin-syntax-json-strings": "^7.8.3",
+        "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+        "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+        "@babel/plugin-syntax-numeric-separator": "^7.10.4",
+        "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+        "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+        "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+        "@babel/plugin-syntax-top-level-await": "^7.14.5"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0 || ^8.0.0-0"
+      }
+    },
     "node_modules/babel-preset-expo": {
       "version": "57.0.4",
       "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-57.0.4.tgz",
@@ -4108,6 +5192,23 @@
         "expo-widgets": {
           "optional": true
         }
+      }
+    },
+    "node_modules/babel-preset-jest": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
+      "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "babel-plugin-jest-hoist": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/balanced-match": {
@@ -4322,7 +5423,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4376,6 +5477,16 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/char-regex": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
+      "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/chrome-launcher": {
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/chrome-launcher/-/chrome-launcher-0.15.2.tgz",
@@ -4411,6 +5522,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
       "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+      "license": "MIT"
+    },
+    "node_modules/cjs-module-lexer": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.4.3.tgz",
+      "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/cli-cursor": {
@@ -4466,6 +5584,24 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/co": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "iojs": ">= 1.0.0",
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/collect-v8-coverage": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/collect-v8-coverage/-/collect-v8-coverage-1.0.3.tgz",
+      "integrity": "sha512-1L5aqIkwPfiodaMgQunkF1zRhNqifHBmtbbbxcr6yVxxBnliw4TDOW6NxpO8DJLgJ16OT+Y4ztZqP6p/FtXnAw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/color": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
@@ -4505,6 +5641,19 @@
       "dependencies": {
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/commander": {
@@ -4574,7 +5723,7 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/connect": {
@@ -4624,6 +5773,28 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/create-jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/create-jest/-/create-jest-29.7.0.tgz",
+      "integrity": "sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "exit": "^0.1.2",
+        "graceful-fs": "^4.2.9",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "prompts": "^2.0.1"
+      },
+      "bin": {
+        "create-jest": "bin/create-jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/cross-fetch": {
@@ -4714,11 +5885,90 @@
       "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
       "license": "MIT"
     },
+    "node_modules/cssom": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.5.0.tgz",
+      "integrity": "sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssom": "~0.3.6"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cssstyle/node_modules/cssom": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-3.0.2.tgz",
+      "integrity": "sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -4791,6 +6041,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
@@ -4798,6 +6055,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/dedent": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-1.7.2.tgz",
+      "integrity": "sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==",
+      "devOptional": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "babel-plugin-macros": "^3.1.0"
+      },
+      "peerDependenciesMeta": {
+        "babel-plugin-macros": {
+          "optional": true
+        }
       }
     },
     "node_modules/deep-is": {
@@ -4864,6 +6136,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -4901,11 +6183,31 @@
         "node": ">=8"
       }
     },
+    "node_modules/detect-newline": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
+      "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/diff-sequences": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-29.6.3.tgz",
+      "integrity": "sha512-EjePK1srD3P08o2j4f0ExnylqRs5B9tJjcp9t1krH2qRi8CCdsYfwe9JgSLurFBWwq4uOlipzfk5fHNvwFKr8Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
     },
     "node_modules/dnssd-advertise": {
       "version": "1.1.6",
@@ -4958,6 +6260,30 @@
         }
       ],
       "license": "BSD-2-Clause"
+    },
+    "node_modules/domexception": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/domexception/-/domexception-4.0.0.tgz",
+      "integrity": "sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/domexception/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/domhandler": {
       "version": "5.0.3",
@@ -5015,6 +6341,19 @@
       "integrity": "sha512-khGTy9U9x02KEtsKM8vx5A62BsRmcOsIgDpWr1ImE32Ax8GxHGPHZf+Eu9H8zOOyHJnB0jTbseyTHbq2XCT8yw==",
       "license": "ISC"
     },
+    "node_modules/emittery": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/emittery/-/emittery-0.13.1.tgz",
+      "integrity": "sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/emittery?sponsor=1"
+      }
+    },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -5041,6 +6380,23 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+      "integrity": "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/error-ex/node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
+      "devOptional": true,
+      "license": "MIT"
     },
     "node_modules/error-stack-parser": {
       "version": "2.1.4",
@@ -5274,6 +6630,39 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/escodegen": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
+      "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "esprima": "^4.0.1",
+        "estraverse": "^5.2.0",
+        "esutils": "^2.0.2"
+      },
+      "bin": {
+        "escodegen": "bin/escodegen.js",
+        "esgenerate": "bin/esgenerate.js"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "optionalDependencies": {
+        "source-map": "~0.6.1"
+      }
+    },
+    "node_modules/escodegen/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/eslint": {
@@ -5795,6 +7184,20 @@
         "url": "https://opencollective.com/eslint"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "devOptional": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/esquery": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
@@ -5857,6 +7260,114 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/execa": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
+      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.3",
+        "get-stream": "^6.0.0",
+        "human-signals": "^2.1.0",
+        "is-stream": "^2.0.0",
+        "merge-stream": "^2.0.0",
+        "npm-run-path": "^4.0.1",
+        "onetime": "^5.1.2",
+        "signal-exit": "^3.0.3",
+        "strip-final-newline": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/execa?sponsor=1"
+      }
+    },
+    "node_modules/execa/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/execa/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "devOptional": true,
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/expect": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-29.7.0.tgz",
+      "integrity": "sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/expect-utils": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/expect/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/expo": {
@@ -5932,6 +7443,18 @@
       },
       "peerDependencies": {
         "expo": "*",
+        "react": "*",
+        "react-native": "*"
+      }
+    },
+    "node_modules/expo-audio": {
+      "version": "57.0.3",
+      "resolved": "https://registry.npmjs.org/expo-audio/-/expo-audio-57.0.3.tgz",
+      "integrity": "sha512-FzO0gnVmlrKmNoox7xc/795uNiuuqnYBovo2kgnNICDKJ0kDi1Y5UJjqX+NATxCelZcNv5BtWs3POkKJADhNCA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*",
+        "expo-asset": "*",
         "react": "*",
         "react-native": "*"
       }
@@ -6168,6 +7691,15 @@
         "react-server-dom-webpack": {
           "optional": true
         }
+      }
+    },
+    "node_modules/expo-secure-store": {
+      "version": "57.0.1",
+      "resolved": "https://registry.npmjs.org/expo-secure-store/-/expo-secure-store-57.0.1.tgz",
+      "integrity": "sha512-tLa1VmSadOq19mA/dwkl99RbHyjLE0T1qqBYMY3/OsguZTI+rlrDy/DDJjupqlVtmr95hD7o1pYqx5aL+B4YMA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-server": {
@@ -6470,7 +8002,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
       "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -6713,6 +8245,46 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -6720,6 +8292,28 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -6827,6 +8421,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-package-type": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
+      "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/get-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
@@ -6839,6 +8443,19 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+      "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-symbol-description": {
@@ -7106,6 +8723,26 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "license": "ISC"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
@@ -7135,6 +8772,34 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -7148,11 +8813,34 @@
         "node": ">= 14"
       }
     },
+    "node_modules/human-signals": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
+      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10.17.0"
+      }
+    },
     "node_modules/hyphenate-style-name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.1.0.tgz",
       "integrity": "sha512-WDC/ui2VVRrz3jOVi+XtjqkDjiVjTtFaAGiW37k6b+ohyQ5wYDOGkvCZa8+H0nx3gyvv0+BST9xuOgIyGQ00gw==",
       "license": "BSD-3-Clause"
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -7205,11 +8893,31 @@
         "node": ">=4"
       }
     },
+    "node_modules/import-local": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.2.0.tgz",
+      "integrity": "sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "pkg-dir": "^4.2.0",
+        "resolve-cwd": "^3.0.0"
+      },
+      "bin": {
+        "import-local-fixture": "fixtures/cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -7222,6 +8930,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "node_modules/inherits": {
@@ -7479,6 +9199,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-generator-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-generator-fn/-/is-generator-fn-2.1.0.tgz",
+      "integrity": "sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/is-generator-function": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
@@ -7573,6 +9303,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -7619,6 +9356,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-string": {
@@ -7743,6 +9493,97 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
+      "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/core": "^7.12.3",
+        "@babel/parser": "^7.14.7",
+        "@istanbuljs/schema": "^0.1.2",
+        "istanbul-lib-coverage": "^3.2.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "devOptional": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-4.0.1.tgz",
+      "integrity": "sha512-n3s8EwkdFIJCG3BPKBYvskgXGoy88ARzvegkitk60NxRdwltLOTaH7CUiMRXvwYorl0Q712iEjcWB+fK/MrWVw==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0",
+        "source-map": "^0.6.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7761,11 +9602,864 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/jest": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest/-/jest-29.7.0.tgz",
+      "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "import-local": "^3.0.2",
+        "jest-cli": "^29.7.0"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-changed-files": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-changed-files/-/jest-changed-files-29.7.0.tgz",
+      "integrity": "sha512-fEArFiwf1BpQ+4bXSprcDc3/x4HSzL4al2tozwVpDFpsxALjLYdyiIK4e5Vz66GQJIbXJ82+35PtysofptNX2w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "execa": "^5.0.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-circus/-/jest-circus-29.7.0.tgz",
+      "integrity": "sha512-3E1nCMgipcTkCocFwM90XXQab9bS+GMsjdpmPrlelaxwD93Ad8iVEjX/vvHPdLPnFf+L40u+5+iutRdA1N9myw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/expect": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "co": "^4.6.0",
+        "dedent": "^1.0.0",
+        "is-generator-fn": "^2.0.0",
+        "jest-each": "^29.7.0",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "pretty-format": "^29.7.0",
+        "pure-rand": "^6.0.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-circus/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-cli": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-cli/-/jest-cli-29.7.0.tgz",
+      "integrity": "sha512-OVVobw2IubN/GSYsxETi+gOe7Ka59EFMR/twOU3Jb2GnKKeMGJB5SGUUrEz3SFVmJASUdZUzy83sLNNQ2gZslg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/core": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "create-jest": "^29.7.0",
+        "exit": "^0.1.2",
+        "import-local": "^3.0.2",
+        "jest-config": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "yargs": "^17.3.1"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "node-notifier": "^8.0.1 || ^9.0.0 || ^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "node-notifier": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-config/-/jest-config-29.7.0.tgz",
+      "integrity": "sha512-uXbpfeQ7R6TZBqI3/TxCU4q4ttk3u0PJeC+E0zbfSoSjq6bJ7buBPxzQPL0ifrkY4DNu4JUdk0ImlBUYi840eQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@jest/test-sequencer": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-jest": "^29.7.0",
+        "chalk": "^4.0.0",
+        "ci-info": "^3.2.0",
+        "deepmerge": "^4.2.2",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-circus": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-runner": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "parse-json": "^5.2.0",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "@types/node": "*",
+        "ts-node": ">=9.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "ts-node": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-config/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-config/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-config/node_modules/ci-info": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+      "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/sibiraj-s"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-config/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-config/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-diff": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-30.4.1.tgz",
+      "integrity": "sha512-CRpFK0RtLriVDGcPPAnR6HMVI8bSR2jnUIgralhauzYQZIb4RH9AtEInTuQr65LmmGggGcRT6HIASxwqsVsmlA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/diff-sequences": "30.4.0",
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-diff/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-diff/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-diff/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-docblock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-29.7.0.tgz",
+      "integrity": "sha512-q617Auw3A612guyaFgsbFeYpNP5t2aoUNLwBUbc/0kD1R4t9ixDbyFTHd1nok4epoVFpr7PmeWHrhvuV3XaJ4g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "detect-newline": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-each": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-each/-/jest-each-29.7.0.tgz",
+      "integrity": "sha512-gns+Er14+ZrEoC5fhOfYCY1LOHHr0TI+rQUHZS8Ttw2l7gl+80eHc/gFf2Ktkw0+SIACDTeWvpFcv3B04VembQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "chalk": "^4.0.0",
+        "jest-get-type": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-environment-jsdom": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-29.7.0.tgz",
+      "integrity": "sha512-k9iQbsf9OyOfdzWH8HDmrRT0gSIcX+FLNW7IQq94tFX0gynPwqDTW0Ho6iMVNjGz/nb+l/vW3dWM2bbLLpkbXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/jsdom": "^20.0.0",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jsdom": "^20.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-environment-node": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
+      "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-mock": "^29.7.0",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-expo": {
+      "version": "57.0.2",
+      "resolved": "https://registry.npmjs.org/jest-expo/-/jest-expo-57.0.2.tgz",
+      "integrity": "sha512-xoKiYyu8c0fdBsFMkeFnxoTZ/0g4rLldA9isVb7VJSGBGesmhkVor7YkftkHqQ5rWiZ99IY+/uIrzTgb1nC/UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/create-cache-key-function": "^29.2.1",
+        "@jest/globals": "^29.2.1",
+        "babel-jest": "^29.2.1",
+        "jest-environment-jsdom": "^29.2.1",
+        "jest-snapshot": "^29.2.1",
+        "jest-watch-select-projects": "^2.0.0",
+        "jest-watch-typeahead": "2.2.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.19",
+        "react-test-renderer": "19.2.3",
+        "server-only": "^0.0.1",
+        "stacktrace-js": "^2.0.2"
+      },
+      "bin": {
+        "jest": "bin/jest.js"
+      },
+      "peerDependencies": {
+        "@react-native/jest-preset": "^0.86.0",
+        "expo": "*",
+        "react-native": "*",
+        "react-server-dom-webpack": "~19.0.4 || ~19.1.5 || ~19.2.4"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-server-dom-webpack": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jest-get-type": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
       "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
       "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-haste-map": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
+      "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/graceful-fs": "^4.1.3",
+        "@types/node": "*",
+        "anymatch": "^3.0.3",
+        "fb-watchman": "^2.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-regex-util": "^29.6.3",
+        "jest-util": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "micromatch": "^4.0.4",
+        "walker": "^1.0.8"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "^2.3.2"
+      }
+    },
+    "node_modules/jest-leak-detector": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-29.7.0.tgz",
+      "integrity": "sha512-kYA8IJcSYtST2BY9I+SMC32nDpBT3J2NvWJx8+JCuCdl/CR1I4EKUJROiP8XtCcxqgTTBGJNdbB1A8XRKbTetw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-30.4.1.tgz",
+      "integrity": "sha512-zvYfX5CaeEkFrrLS9suWe9rvJrm9J1Iv3ua8kIBv9GEPzcnsfBf0bob37la7s67fs0nlBC3EuvkOLnXQKxtx4A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/get-type": "30.1.0",
+        "chalk": "^4.1.2",
+        "jest-diff": "30.4.1",
+        "pretty-format": "30.4.1"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@jest/schemas": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-30.4.1.tgz",
+      "integrity": "sha512-i6b4qw5qnP8c5FEeBJg/uZQ4ddrkN6Ca8qISJh0pr7a5hfn3h3v5x60BEbOC7OYAGZNMs1LfFLwnW2CuK8F57Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@sinclair/typebox": "^0.34.0"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/@sinclair/typebox": {
+      "version": "0.34.52",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.52.tgz",
+      "integrity": "sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-matcher-utils/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/jest-matcher-utils/node_modules/pretty-format": {
+      "version": "30.4.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.4.1.tgz",
+      "integrity": "sha512-K6KiKMHTL4jjX4u3Kir2EW07nRfcqVTXIImx50wbjHQTcZPgg+gjVeNTIT3l3L1Rd4UefxfogquC9J37SoFyyw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/schemas": "30.4.1",
+        "ansi-styles": "^5.2.0",
+        "react-is-18": "npm:react-is@^18.3.1",
+        "react-is-19": "npm:react-is@^19.2.5"
+      },
+      "engines": {
+        "node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
+      }
+    },
+    "node_modules/jest-message-util": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
+      "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.12.13",
+        "@jest/types": "^29.6.3",
+        "@types/stack-utils": "^2.0.0",
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "micromatch": "^4.0.4",
+        "pretty-format": "^29.7.0",
+        "slash": "^3.0.0",
+        "stack-utils": "^2.0.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-mock": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
+      "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "jest-util": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-pnp-resolver": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.3.tgz",
+      "integrity": "sha512-+3NpwQEnRoIBtx4fyhblQDPgJI0H1IEIkX7ShLUjPGA7TtUTvI1oiKi3SR4oBR0hQhQR80l4WAe5RrXBwWMA8w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "peerDependencies": {
+        "jest-resolve": "*"
+      },
+      "peerDependenciesMeta": {
+        "jest-resolve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jest-regex-util": {
+      "version": "29.6.3",
+      "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
+      "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve/-/jest-resolve-29.7.0.tgz",
+      "integrity": "sha512-IOVhZSrg+UvVAshDSDtHyFCCBUl/Q3AAJv8iZ6ZjnZ74xzvwuzLXid9IIIPgTnY62SJjfuupMKZsZQRsCvxEgA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-pnp-resolver": "^1.2.2",
+        "jest-util": "^29.7.0",
+        "jest-validate": "^29.7.0",
+        "resolve": "^1.20.0",
+        "resolve.exports": "^2.0.0",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-resolve-dependencies": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-resolve-dependencies/-/jest-resolve-dependencies-29.7.0.tgz",
+      "integrity": "sha512-un0zD/6qxJ+S0et7WxeI3H5XSe9lTBBR7bOHCHXkKR6luG5mwDDlIzVQ0V5cZCuoTgEdcdwzTghYkTWfubi+nA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "jest-regex-util": "^29.6.3",
+        "jest-snapshot": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runner/-/jest-runner-29.7.0.tgz",
+      "integrity": "sha512-fsc4N6cPCAahybGBfTRcq5wFR6fpLznMg47sY5aDpsoejOcVYFb07AHuSnR0liMcPTgBsA3ZJL6kFOjPdoNipQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/console": "^29.7.0",
+        "@jest/environment": "^29.7.0",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "graceful-fs": "^4.2.9",
+        "jest-docblock": "^29.7.0",
+        "jest-environment-node": "^29.7.0",
+        "jest-haste-map": "^29.7.0",
+        "jest-leak-detector": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-resolve": "^29.7.0",
+        "jest-runtime": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "jest-watcher": "^29.7.0",
+        "jest-worker": "^29.7.0",
+        "p-limit": "^3.1.0",
+        "source-map-support": "0.5.13"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "devOptional": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/jest-runner/node_modules/source-map-support": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
+      "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/jest-runtime": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-runtime/-/jest-runtime-29.7.0.tgz",
+      "integrity": "sha512-gUnLjgwdGqW7B4LvOIkbKs9WGbn+QLqRQQ9juC6HndeDiezIwhDP+mhMwHWCEcfQ5RUXa6OPnFF8BJh5xegwwQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/environment": "^29.7.0",
+        "@jest/fake-timers": "^29.7.0",
+        "@jest/globals": "^29.7.0",
+        "@jest/source-map": "^29.6.3",
+        "@jest/test-result": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "chalk": "^4.0.0",
+        "cjs-module-lexer": "^1.0.0",
+        "collect-v8-coverage": "^1.0.0",
+        "glob": "^7.1.3",
+        "graceful-fs": "^4.2.9",
+        "jest-haste-map": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-mock": "^29.7.0",
+        "jest-regex-util": "^29.6.3",
+        "jest-resolve": "^29.7.0",
+        "jest-snapshot": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "slash": "^3.0.0",
+        "strip-bom": "^4.0.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/jest-runtime/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/jest-runtime/node_modules/strip-bom": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-4.0.0.tgz",
+      "integrity": "sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-snapshot": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-snapshot/-/jest-snapshot-29.7.0.tgz",
+      "integrity": "sha512-Rm0BMWtxBcioHr1/OX5YCP8Uov4riHvKPknOGs804Zg9JGZgmIBkbtlxJC/7Z4msKYVbIJtfU+tKb8xlYNfdkw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.11.6",
+        "@babel/generator": "^7.7.2",
+        "@babel/plugin-syntax-jsx": "^7.7.2",
+        "@babel/plugin-syntax-typescript": "^7.7.2",
+        "@babel/types": "^7.3.3",
+        "@jest/expect-utils": "^29.7.0",
+        "@jest/transform": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "babel-preset-current-node-syntax": "^1.0.0",
+        "chalk": "^4.0.0",
+        "expect": "^29.7.0",
+        "graceful-fs": "^4.2.9",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "jest-matcher-utils": "^29.7.0",
+        "jest-message-util": "^29.7.0",
+        "jest-util": "^29.7.0",
+        "natural-compare": "^1.4.0",
+        "pretty-format": "^29.7.0",
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-diff": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-29.7.0.tgz",
+      "integrity": "sha512-LMIgiIrhigmPrs03JHpxUh2yISK3vLFPkAodPeo0+BuF7wA2FoQbkEg1u8gBYBThncu7e1oEDUfIXVuTqLRUjw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "diff-sequences": "^29.6.3",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-snapshot/node_modules/jest-matcher-utils": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-29.7.0.tgz",
+      "integrity": "sha512-sBkD+Xi9DtcChsI3L3u0+N0opgPYnCRPtGcQYrgXmR+hmt/fYfWAL0xRXYU8eWOdfuLgBe0YCW3AFtnRLagq/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "jest-diff": "^29.7.0",
+        "jest-get-type": "^29.6.3",
+        "pretty-format": "^29.7.0"
+      },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
@@ -7826,6 +10520,156 @@
         "jest-get-type": "^29.6.3",
         "leven": "^3.1.0",
         "pretty-format": "^29.7.0"
+      },
+      "engines": {
+        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/jest-watch-select-projects": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jest-watch-select-projects/-/jest-watch-select-projects-2.0.0.tgz",
+      "integrity": "sha512-j00nW4dXc2NiCW6znXgFLF9g8PJ0zP25cpQ1xRro/HU2GBfZQFZD0SoXnAlaoKkIY4MlfTMkKGbNXFpvCdjl1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^4.3.0",
+        "chalk": "^3.0.0",
+        "prompts": "^2.2.1"
+      }
+    },
+    "node_modules/jest-watch-select-projects/node_modules/chalk": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+      "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jest-watch-typeahead": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/jest-watch-typeahead/-/jest-watch-typeahead-2.2.1.tgz",
+      "integrity": "sha512-jYpYmUnTzysmVnwq49TAxlmtOAwp8QIqvZyoofQFn8fiWhEDZj33ZXzg3JA4nGnzWFm1hbWf3ADpteUokvXgFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^6.0.0",
+        "chalk": "^4.0.0",
+        "jest-regex-util": "^29.0.0",
+        "jest-watcher": "^29.0.0",
+        "slash": "^5.0.0",
+        "string-length": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.10.0 || >=18.0.0"
+      },
+      "peerDependencies": {
+        "jest": "^27.0.0 || ^28.0.0 || ^29.0.0"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-escapes": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-6.2.1.tgz",
+      "integrity": "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/char-regex": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-2.0.2.tgz",
+      "integrity": "sha512-cbGOjAptfM2LVmWhwRFHEKTPkLwNddVmuqYZQt895yXwAsWsXObCG+YN4DGQ/JBtT4GP1a1lPPdio2z413LmTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/string-length": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-5.0.1.tgz",
+      "integrity": "sha512-9Ep08KAMUn0OadnVaBuRdE2l615CQ508kr0XMadjClfYpdCyvrbFp6Taebo8yyxokQ4viUd/xPPUA4FGgUa0ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^2.0.0",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/jest-watch-typeahead/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/jest-watcher": {
+      "version": "29.7.0",
+      "resolved": "https://registry.npmjs.org/jest-watcher/-/jest-watcher-29.7.0.tgz",
+      "integrity": "sha512-49Fg7WXkU3Vl2h6LbLtMQ/HyB6rXSIX7SqvBLQmssRBGN9I0PNvPmAmCWSOY6SOvrjhI/F7/bGAv9RtnsPA03g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jest/test-result": "^29.7.0",
+        "@jest/types": "^29.6.3",
+        "@types/node": "*",
+        "ansi-escapes": "^4.2.1",
+        "chalk": "^4.0.0",
+        "emittery": "^0.13.1",
+        "jest-util": "^29.7.0",
+        "string-length": "^4.0.1"
       },
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -7901,6 +10745,138 @@
       "integrity": "sha512-0wM3YBWtYePOjfyXQH5MWQ8H7sdk5EXSwZvmSLKk2RboVQ2Bu239jycHDz5J/8Blf3K0Qnoy2b6xD+z10MFB+Q==",
       "license": "0BSD"
     },
+    "node_modules/jsdom": {
+      "version": "20.0.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-20.0.3.tgz",
+      "integrity": "sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "abab": "^2.0.6",
+        "acorn": "^8.8.1",
+        "acorn-globals": "^7.0.0",
+        "cssom": "^0.5.0",
+        "cssstyle": "^2.3.0",
+        "data-urls": "^3.0.2",
+        "decimal.js": "^10.4.2",
+        "domexception": "^4.0.0",
+        "escodegen": "^2.0.0",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.2",
+        "parse5": "^7.1.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.2",
+        "w3c-xmlserializer": "^4.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^2.0.0",
+        "whatwg-mimetype": "^3.0.0",
+        "whatwg-url": "^11.0.0",
+        "ws": "^8.11.0",
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "canvas": "^2.5.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/jsdom/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/jsdom/node_modules/tr46": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/whatwg-url": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^3.0.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.21.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.2.tgz",
+      "integrity": "sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7918,6 +10894,13 @@
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/json-schema-traverse": {
@@ -8287,6 +11270,13 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -8302,6 +11292,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.debounce": {
       "version": "4.0.8",
@@ -8434,6 +11431,22 @@
       "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/makeerror": {
@@ -8965,7 +11978,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/negotiator": {
@@ -9050,6 +12063,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/npm-package-arg": {
       "version": "11.0.3",
       "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.3.tgz",
@@ -9063,6 +12086,19 @@
       },
       "engines": {
         "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-run-path": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
+      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/nth-check": {
@@ -9081,6 +12117,13 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/nullthrows/-/nullthrows-1.1.1.tgz",
       "integrity": "sha512-2vPPEi+Z7WqML2jZYddDIfy5Dqb0r2fze2zTxNNknZaFpVHU3mFB3R+DWeJWGVx0ecvttSGlJTI+WG+8Z4cDWw==",
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ob1": {
@@ -9236,6 +12279,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
       }
     },
     "node_modules/onetime": {
@@ -9416,7 +12469,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -9444,6 +12497,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -9457,6 +12520,25 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/parse-png": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/parse-png/-/parse-png-2.1.0.tgz",
@@ -9467,6 +12549,32 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/parse5/node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -9482,10 +12590,20 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
       "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/path-key": {
@@ -9555,6 +12673,85 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pirates": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+      "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pkg-dir/node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/plist": {
@@ -9734,6 +12931,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -9743,6 +12953,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "devOptional": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/query-string": {
       "version": "7.1.3",
@@ -9761,6 +12988,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/queue": {
       "version": "6.0.2",
@@ -9833,6 +13067,22 @@
       "version": "19.2.8",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
       "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-is-18": {
+      "name": "react-is",
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
+      "integrity": "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/react-is-19": {
+      "name": "react-is",
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.2.8.tgz",
+      "integrity": "sha512-s5un28nYxKJw5gvUHyW5PCC28CvBqLu9r3cWgzHT4Vo/5fqqkFcdRYsGcKf50WMPpjjFZS5d76fn3YCo2njKwQ==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/react-native": {
@@ -10022,6 +13272,42 @@
       "integrity": "sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==",
       "license": "MIT"
     },
+    "node_modules/react-native-webrtc": {
+      "version": "124.0.8",
+      "resolved": "https://registry.npmjs.org/react-native-webrtc/-/react-native-webrtc-124.0.8.tgz",
+      "integrity": "sha512-uuQxvmk+mvnk5U0tr+1N42sKZqgm41fJrBA+fmCvML9J9P4roSh2So82t5RHAlu/vE9vxu5AKgivAiH61clCBg==",
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "1.5.1",
+        "debug": "4.3.4"
+      },
+      "peerDependencies": {
+        "react-native": ">=0.60.0"
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/debug": {
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-native-webrtc/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "license": "MIT"
+    },
     "node_modules/react-native-worklets": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/react-native-worklets/-/react-native-worklets-0.10.0.tgz",
@@ -10055,6 +13341,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/react-reconciler": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.33.0.tgz",
+      "integrity": "sha512-KetWRytFv1epdpJc3J4G75I4WrplZE5jOL7Yq0p34+OVOKF4Se7WrdIdVC45XsSSmUTlht2FM/fM1FZb1mfQeA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.0"
       }
     },
     "node_modules/react-refresh": {
@@ -10133,6 +13435,20 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-test-renderer": {
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-19.2.3.tgz",
+      "integrity": "sha512-TMR1LnSFiWZMJkCgNf5ATSvAheTT2NvKIwiVwdBPHxjBI7n/JbWd4gaZ16DVd9foAXdvDz+sB5yxZTwMjPRxpw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "react-is": "^19.2.3",
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.3"
       }
     },
     "node_modules/redent": {
@@ -10260,6 +13576,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -10279,6 +13602,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-cwd": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-cwd/-/resolve-cwd-3.0.0.tgz",
+      "integrity": "sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-from": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -10305,6 +13641,16 @@
       "resolved": "https://registry.npmjs.org/resolve-workspace-root/-/resolve-workspace-root-2.0.1.tgz",
       "integrity": "sha512-nR23LHAvaI6aHtMg6RWoaHpdR4D881Nydkzi2CixINyg9T00KgaJdJI6Vwty+Ps8WLxZHuxsS0BseWjxSA4C+w==",
       "license": "MIT"
+    },
+    "node_modules/resolve.exports": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-2.0.3.tgz",
+      "integrity": "sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/restore-cursor": {
       "version": "2.0.0",
@@ -10394,6 +13740,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/sax": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
@@ -10401,6 +13754,19 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -10746,6 +14112,16 @@
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "license": "MIT"
     },
+    "node_modules/slash": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+      "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/slugify": {
       "version": "1.6.9",
       "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
@@ -10801,6 +14177,13 @@
         "node": ">=6"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "devOptional": true,
+      "license": "BSD-3-Clause"
+    },
     "node_modules/stable-hash": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
@@ -10808,11 +14191,77 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stack-generator": {
+      "version": "2.0.10",
+      "resolved": "https://registry.npmjs.org/stack-generator/-/stack-generator-2.0.10.tgz",
+      "integrity": "sha512-mwnua/hkqM6pF4k8SnmZ2zfETsRUpWXREfA/goT8SLCV4iOFa4bzOX2nDipWAZFPTjLvQB82f5yaodMVhK0yJQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stack-utils": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
+      "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "escape-string-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/stack-utils/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stackframe": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-1.3.4.tgz",
       "integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
       "license": "MIT"
+    },
+    "node_modules/stacktrace-gps": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-gps/-/stacktrace-gps-3.1.2.tgz",
+      "integrity": "sha512-GcUgbO4Jsqqg6RxfyTHFiPxdPqF+3LFmQhm7MgCuYQOYuWyqxo5pwRPz5d/u6/WYJdEnWfK4r+jGbyD8TSggXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "source-map": "0.5.6",
+        "stackframe": "^1.3.4"
+      }
+    },
+    "node_modules/stacktrace-gps/node_modules/source-map": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+      "integrity": "sha512-MjZkVp0NHr5+TPihLcadqnlVoGIoWo4IBHptutGh9wI3ttUYvCG26HkSuDi+K6lsZ25syXJXcctwgyVCt//xqA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stacktrace-js": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/stacktrace-js/-/stacktrace-js-2.0.2.tgz",
+      "integrity": "sha512-Je5vBeY4S1r/RnLydLl0TBTi3F2qdfWmYsGvtfZgEI+SCprPppaIhQf5nGcal4gI4cGpCV/duLcAzT1np6sQqg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "error-stack-parser": "^2.0.6",
+        "stack-generator": "^2.0.5",
+        "stacktrace-gps": "^3.0.4"
+      }
     },
     "node_modules/stacktrace-parser": {
       "version": "0.1.11",
@@ -10871,6 +14320,20 @@
       "license": "MIT",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/string-length": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
+      "integrity": "sha512-+l6rNN5fYHNhZZy41RXsYptCjA2Igmq4EG7kZAYFQI1E1VTXarr6ZPXBg6eq7Y6eK4FEhY6AJlyuFIb/v/S0VQ==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "char-regex": "^1.0.2",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/string-width": {
@@ -11008,6 +14471,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/strip-final-newline": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/strip-indent": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
@@ -11024,7 +14497,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -11082,6 +14555,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -11121,6 +14601,88 @@
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
+      "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^7.1.4",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/test-exclude/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/test-exclude/node_modules/brace-expansion": {
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
+      "integrity": "sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/test-exclude/node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/test-exclude/node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/test-renderer": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/test-renderer/-/test-renderer-1.2.0.tgz",
+      "integrity": "sha512-JYiEGbgBGtmHAWX8Kf99gGRL1HtjcRVHLrmJNTZL4vFs9XrnWcuL45Iszw/pO4094+JR7havSrN+ds6YTOpSQA==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "~0.33.0",
+        "react-reconciler": "~0.33.0"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0"
+      }
     },
     "node_modules/throat": {
       "version": "5.0.0",
@@ -11176,6 +14738,22 @@
       "resolved": "https://registry.npmjs.org/toqr/-/toqr-0.1.1.tgz",
       "integrity": "sha512-FWAPzCIHZHnrE/5/w9MPk0kK25hSQSH2IKhYh9PyjS3SG/+IEMvlwIHbhz+oF7xl54I+ueZlVnMjyzdSwLmAwA==",
       "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/tr46": {
       "version": "0.0.3",
@@ -11239,6 +14817,16 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/type-detect": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+      "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+      "devOptional": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/type-fest": {
@@ -11433,6 +15021,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -11520,6 +15118,17 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
@@ -11591,6 +15200,21 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "node_modules/v8-to-istanbul": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.3.0.tgz",
+      "integrity": "sha512-kiGUalWN+rgBJ/1OHZsBtU4rXZOfj/7rKQxULKlIzwzQSvMJUUNgPwJEEh7gU6xEVxC0ahoOBvN2YI8GH6FNgA==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.12",
+        "@types/istanbul-lib-coverage": "^2.0.1",
+        "convert-source-map": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10.12.0"
+      }
+    },
     "node_modules/validate-npm-package-name": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.1.tgz",
@@ -11628,6 +15252,19 @@
       "integrity": "sha512-gQpnTgkubC6hQgdIcRdYGDSDc+SaujOdyesZQMv6JlfQee/9Mp0Qhnys6WxDWvQnL5WZdT7o2Ul187aSt0Rq+w==",
       "license": "MIT"
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-4.0.0.tgz",
+      "integrity": "sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/walker": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/walker/-/walker-1.0.8.tgz",
@@ -11658,11 +15295,35 @@
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/whatwg-fetch": {
       "version": "3.6.20",
       "resolved": "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.6.20.tgz",
       "integrity": "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg==",
       "license": "MIT"
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+      "integrity": "sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
@@ -11811,6 +15472,27 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "devOptional": true,
+      "license": "ISC"
+    },
+    "node_modules/write-file-atomic": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
+      "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
     "node_modules/ws": {
       "version": "7.5.13",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
@@ -11845,6 +15527,16 @@
         "node": ">=10.0.0"
       }
     },
+    "node_modules/xml-name-validator": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-4.0.0.tgz",
+      "integrity": "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/xml2js": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
@@ -11875,6 +15567,13 @@
       "engines": {
         "node": ">=8.0"
       }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",
@@ -11937,7 +15636,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"

--- a/frontend/mobile/package.json
+++ b/frontend/mobile/package.json
@@ -6,15 +6,19 @@
     "@expo/ui": "~57.0.7",
     "@expo/vector-icons": "^15.0.2",
     "@react-native-async-storage/async-storage": "2.2.0",
+    "@siteed/audio-studio": "^3.2.1",
     "expo": "~57.0.8",
+    "expo-audio": "~57.0.3",
     "expo-constants": "~57.0.7",
     "expo-device": "~57.0.1",
+    "expo-file-system": "~57.0.1",
     "expo-font": "~57.0.1",
     "expo-glass-effect": "~57.0.1",
     "expo-image": "~57.0.1",
     "expo-linear-gradient": "~57.0.1",
     "expo-linking": "~57.0.4",
     "expo-router": "~57.0.8",
+    "expo-secure-store": "~57.0.1",
     "expo-splash-screen": "~57.0.5",
     "expo-status-bar": "~57.0.1",
     "expo-symbols": "~57.0.1",
@@ -30,12 +34,19 @@
     "react-native-screens": "~4.26.0",
     "react-native-svg": "15.15.4",
     "react-native-web": "~0.21.0",
+    "react-native-webrtc": "^124.0.8",
     "react-native-worklets": "0.10.0"
   },
   "devDependencies": {
+    "@react-native/jest-preset": "^0.86.0",
+    "@testing-library/react-native": "^14.0.1",
+    "@types/jest": "^29.5.14",
     "@types/react": "~19.2.2",
     "eslint": "^9.0.0",
     "eslint-config-expo": "~57.0.1",
+    "jest": "^29.7.0",
+    "jest-expo": "^57.0.2",
+    "test-renderer": "^1.2.0",
     "typescript": "~6.0.3"
   },
   "overrides": {
@@ -47,7 +58,18 @@
     "android": "expo run:android",
     "ios": "expo run:ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest",
+    "test:ci": "jest --runInBand"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": [
+      "<rootDir>/jest.setup.ts"
+    ],
+    "transformIgnorePatterns": [
+      "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|react-native-svg|phosphor-react-native)"
+    ]
   },
   "private": true
 }

--- a/frontend/mobile/src/app/(app)/(tabs)/scenes/index.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/scenes/index.tsx
@@ -1,16 +1,5 @@
-import { useRouter } from 'expo-router';
-
-import { routes } from '@/navigation/routes';
-import { ScenesHome, type SceneRoute } from '@/screens/ScenesScreen';
+import { ScenesScreen } from '@/screens/ScenesScreen';
 
 export default function ScenesHomeRoute() {
-  const router = useRouter();
-
-  const open = (route: SceneRoute) => {
-    if (route.name === 'training') router.push(routes.scenes.training(route.id));
-    else if (route.name === 'ielts') router.push(routes.specialty.ielts);
-    else if (route.name === 'interview') router.push(routes.specialty.interview);
-  };
-
-  return <ScenesHome onOpen={open} />;
+  return <ScenesScreen />;
 }

--- a/frontend/mobile/src/app/(app)/learning/scenes/[id].tsx
+++ b/frontend/mobile/src/app/(app)/learning/scenes/[id].tsx
@@ -1,26 +1,18 @@
-import { Redirect, useLocalSearchParams, useRouter } from 'expo-router';
+import { useLocalSearchParams, useRouter } from 'expo-router';
 
-import { useAppModel } from '@/model/AppModel';
 import { routes } from '@/navigation/routes';
-import { SceneAssetDetail } from '@/screens/AssetsScreen';
+import { SceneAssetDetailLoader } from '@/screens/AssetsScreen';
 
 export default function SceneLearningDetailRoute() {
   const router = useRouter();
   const { id } = useLocalSearchParams<{ id: string }>();
-  const { sceneRecords, removeSceneRecord } = useAppModel();
-  const record = sceneRecords.find((item) => item.id === id);
-
-  if (!record) return <Redirect href={routes.tabs.learning} />;
 
   return (
-    <SceneAssetDetail
-      record={record}
+    <SceneAssetDetailLoader
+      sceneId={id}
       onBack={() => router.back()}
-      onPractice={() => router.push(routes.scenes.training(record.id, 'speak'))}
-      onDelete={() => {
-        removeSceneRecord(record.id);
-        router.replace(routes.tabs.learning);
-      }}
+      onPractice={() => router.push(routes.scenes.training(id, 'speak'))}
+      onDelete={() => router.replace(routes.tabs.learning)}
     />
   );
 }

--- a/frontend/mobile/src/features/audio/TtsPlayer.ts
+++ b/frontend/mobile/src/features/audio/TtsPlayer.ts
@@ -1,0 +1,110 @@
+import type { TokenStore } from '@/infrastructure/auth/SecureTokenStore';
+
+export type SpeechAsset = {
+  uri: string;
+  remove(): void;
+};
+
+type SpeechClientOptions = {
+  baseUrl: string;
+  tokenStore: Pick<TokenStore, 'get'>;
+  fetchImpl?: typeof fetch;
+  writeWav?: (bytes: Uint8Array) => Promise<SpeechAsset>;
+};
+
+function createWavAsset(bytes: Uint8Array): SpeechAsset {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { File, Paths } = require('expo-file-system') as typeof import('expo-file-system');
+  const file = new File(
+    Paths.cache,
+    `unispeaking-tts-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.wav`,
+  );
+  file.create({ overwrite: true });
+  file.write(bytes);
+  return {
+    uri: file.uri,
+    remove: () => {
+      if (file.exists) file.delete();
+    },
+  };
+}
+
+export class SceneSpeechClient {
+  private readonly baseUrl: string;
+  private readonly fetchImpl: typeof fetch;
+  private readonly writeWav: (bytes: Uint8Array) => Promise<SpeechAsset>;
+
+  constructor(private readonly options: SpeechClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.writeWav = options.writeWav ?? (async (bytes) => createWavAsset(bytes));
+  }
+
+  async synthesize(sceneId: string, text: string, model: string | null = null) {
+    const token = await this.options.tokenStore.get();
+    const response = await this.fetchImpl(
+      `${this.baseUrl}/api/custom-scenes/${encodeURIComponent(sceneId)}/speech`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({ text: text.trim(), model }),
+      },
+    );
+    if (!response.ok) {
+      let message = `语音生成失败（${response.status}）`;
+      if ((response.headers.get('content-type') ?? '').includes('application/json')) {
+        const body = (await response.json()) as { message?: string; code?: string };
+        message = body.message || body.code || message;
+      }
+      throw new Error(message);
+    }
+    return this.writeWav(new Uint8Array(await response.arrayBuffer()));
+  }
+}
+
+type NativeAudioPlayer = {
+  play(): void;
+  remove(): void;
+};
+
+type TtsPlayerOptions = {
+  speechClient: Pick<SceneSpeechClient, 'synthesize'>;
+  createPlayer?: (uri: string) => NativeAudioPlayer;
+};
+
+function createNativePlayer(uri: string): NativeAudioPlayer {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { createAudioPlayer } = require('expo-audio') as typeof import('expo-audio');
+  return createAudioPlayer(uri);
+}
+
+export class TtsPlayer {
+  private readonly createPlayer: (uri: string) => NativeAudioPlayer;
+  private player: NativeAudioPlayer | null = null;
+  private asset: SpeechAsset | null = null;
+
+  constructor(private readonly options: TtsPlayerOptions) {
+    this.createPlayer = options.createPlayer ?? createNativePlayer;
+  }
+
+  async play(sceneId: string, text: string) {
+    this.stop();
+    const asset = await this.options.speechClient.synthesize(sceneId, text);
+    const player = this.createPlayer(asset.uri);
+    this.asset = asset;
+    this.player = player;
+    player.play();
+  }
+
+  stop() {
+    const player = this.player;
+    const asset = this.asset;
+    this.player = null;
+    this.asset = null;
+    player?.remove();
+    asset?.remove();
+  }
+}

--- a/frontend/mobile/src/features/audio/WavRecorder.ts
+++ b/frontend/mobile/src/features/audio/WavRecorder.ts
@@ -1,0 +1,70 @@
+export type PcmRecordingConfig = {
+  sampleRate: 16_000;
+  channels: 1;
+  encoding: 'pcm_16bit';
+  output: {
+    primary: {
+      enabled: true;
+      format: 'wav';
+    };
+  };
+};
+
+export type PcmRecorderPort = {
+  requestPermissionsAsync(): Promise<{ granted: boolean }>;
+  startRecording(config: PcmRecordingConfig): Promise<unknown>;
+  stopRecording(): Promise<{ fileUri?: string } | null>;
+};
+
+function createNativeRecorder(): PcmRecorderPort {
+  // Keep unit tests independent from the Expo native module.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { AudioStudioModule } = require('@siteed/audio-studio') as typeof import('@siteed/audio-studio');
+  return {
+    requestPermissionsAsync: () => AudioStudioModule.requestPermissionsAsync(),
+    startRecording: (config) => AudioStudioModule.startRecording(config),
+    stopRecording: () => AudioStudioModule.stopRecording(),
+  };
+}
+
+const pcm16WavConfig: PcmRecordingConfig = {
+  sampleRate: 16_000,
+  channels: 1,
+  encoding: 'pcm_16bit',
+  output: {
+    primary: {
+      enabled: true,
+      format: 'wav',
+    },
+  },
+};
+
+export class WavRecorder {
+  private active = false;
+
+  constructor(private readonly nativeRecorder: PcmRecorderPort = createNativeRecorder()) {}
+
+  async start() {
+    if (this.active) return;
+    const permission = await this.nativeRecorder.requestPermissionsAsync();
+    if (!permission.granted) {
+      throw new Error('请允许麦克风权限后再朗读');
+    }
+    await this.nativeRecorder.startRecording(pcm16WavConfig);
+    this.active = true;
+  }
+
+  async stop() {
+    if (!this.active) throw new Error('当前没有正在进行的录音');
+    this.active = false;
+    const result = await this.nativeRecorder.stopRecording();
+    if (!result?.fileUri) throw new Error('录音文件生成失败，请重新朗读');
+    return result.fileUri;
+  }
+
+  async cancel() {
+    if (!this.active) return;
+    this.active = false;
+    await this.nativeRecorder.stopRecording();
+  }
+}

--- a/frontend/mobile/src/features/audio/__tests__/TtsPlayer.test.ts
+++ b/frontend/mobile/src/features/audio/__tests__/TtsPlayer.test.ts
@@ -1,0 +1,78 @@
+import { SceneSpeechClient, TtsPlayer } from '../TtsPlayer';
+
+function wavResponse(bytes: number[], status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => 'audio/wav' },
+    arrayBuffer: jest.fn(async () => new Uint8Array(bytes).buffer),
+    json: jest.fn(async () => ({ message: 'TTS 生成失败' })),
+  } as unknown as Response;
+}
+
+describe('SceneSpeechClient', () => {
+  it('downloads authenticated backend WAV into a removable local asset', async () => {
+    const remove = jest.fn();
+    const writeWav = jest.fn(async () => ({
+      uri: 'file:///tts.wav',
+      remove,
+    }));
+    const fetchImpl = jest.fn(async () => wavResponse([82, 73, 70, 70]));
+    const client = new SceneSpeechClient({
+      baseUrl: 'http://127.0.0.1:8080/',
+      tokenStore: { get: async () => 'jwt-token' },
+      fetchImpl,
+      writeWav,
+    });
+
+    await expect(client.synthesize('scene/1', 'Hello.')).resolves.toEqual({
+      uri: 'file:///tts.wav',
+      remove,
+    });
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:8080/api/custom-scenes/scene%2F1/speech',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer jwt-token',
+        },
+        body: JSON.stringify({ text: 'Hello.', model: null }),
+      },
+    );
+    expect(writeWav).toHaveBeenCalledWith(
+      expect.objectContaining({ byteLength: 4 }),
+    );
+  });
+});
+
+describe('TtsPlayer', () => {
+  it('replaces and releases the previous player and cached WAV', async () => {
+    const firstAsset = { uri: 'file:///first.wav', remove: jest.fn() };
+    const secondAsset = { uri: 'file:///second.wav', remove: jest.fn() };
+    const speechClient = {
+      synthesize: jest
+        .fn()
+        .mockResolvedValueOnce(firstAsset)
+        .mockResolvedValueOnce(secondAsset),
+    };
+    const firstPlayer = { play: jest.fn(), remove: jest.fn() };
+    const secondPlayer = { play: jest.fn(), remove: jest.fn() };
+    const createPlayer = jest
+      .fn()
+      .mockReturnValueOnce(firstPlayer)
+      .mockReturnValueOnce(secondPlayer);
+    const player = new TtsPlayer({ speechClient, createPlayer });
+
+    await player.play('scene-1', 'First');
+    await player.play('scene-1', 'Second');
+
+    expect(firstPlayer.remove).toHaveBeenCalledTimes(1);
+    expect(firstAsset.remove).toHaveBeenCalledTimes(1);
+    expect(secondPlayer.play).toHaveBeenCalledTimes(1);
+    player.stop();
+    player.stop();
+    expect(secondPlayer.remove).toHaveBeenCalledTimes(1);
+    expect(secondAsset.remove).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/features/audio/__tests__/WavRecorder.test.ts
+++ b/frontend/mobile/src/features/audio/__tests__/WavRecorder.test.ts
@@ -1,0 +1,61 @@
+import {
+  WavRecorder,
+  type PcmRecorderPort,
+} from '../WavRecorder';
+
+function createNativeRecorder(): PcmRecorderPort & {
+  requestPermissionsAsync: jest.Mock;
+  startRecording: jest.Mock;
+  stopRecording: jest.Mock;
+} {
+  return {
+    requestPermissionsAsync: jest.fn(async () => ({ granted: true })),
+    startRecording: jest.fn(async () => undefined),
+    stopRecording: jest.fn(async () => ({ fileUri: 'file:///take.wav' })),
+  };
+}
+
+describe('WavRecorder', () => {
+  it('requests permission and records 16 kHz mono PCM16 WAV', async () => {
+    const nativeRecorder = createNativeRecorder();
+    const recorder = new WavRecorder(nativeRecorder);
+
+    await recorder.start();
+    await expect(recorder.stop()).resolves.toBe('file:///take.wav');
+
+    expect(nativeRecorder.requestPermissionsAsync).toHaveBeenCalledTimes(1);
+    expect(nativeRecorder.startRecording).toHaveBeenCalledWith({
+      sampleRate: 16_000,
+      channels: 1,
+      encoding: 'pcm_16bit',
+      output: {
+        primary: {
+          enabled: true,
+          format: 'wav',
+        },
+      },
+    });
+    expect(nativeRecorder.stopRecording).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps a denied microphone permission to a user-facing error', async () => {
+    const nativeRecorder = createNativeRecorder();
+    nativeRecorder.requestPermissionsAsync.mockResolvedValue({ granted: false });
+    const recorder = new WavRecorder(nativeRecorder);
+
+    await expect(recorder.start()).rejects.toThrow('请允许麦克风权限后再朗读');
+    expect(nativeRecorder.startRecording).not.toHaveBeenCalled();
+  });
+
+  it('cancels idempotently and refuses to stop when no recording is active', async () => {
+    const nativeRecorder = createNativeRecorder();
+    const recorder = new WavRecorder(nativeRecorder);
+
+    await expect(recorder.stop()).rejects.toThrow('当前没有正在进行的录音');
+    await recorder.start();
+    await recorder.cancel();
+    await recorder.cancel();
+
+    expect(nativeRecorder.stopRecording).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/features/auth/AuthService.ts
+++ b/frontend/mobile/src/features/auth/AuthService.ts
@@ -1,0 +1,77 @@
+export type UserAccount = {
+  id: string;
+  username: string;
+  nickname: string | null;
+  role: string;
+  status: string;
+  lastLoginAt: string | null;
+  createdAt: string;
+};
+
+export type AuthResponse = {
+  tokenType: string;
+  accessToken: string;
+  expiresAt: string;
+  user: UserAccount;
+};
+
+export type PreferredVoice =
+  | 'Katerina'
+  | 'Aiden'
+  | 'Raymond'
+  | 'Tina'
+  | 'Harvey'
+  | 'Dolce';
+
+export type PreferredAiSpeechSpeed =
+  | 'SLOWER'
+  | 'MODERATE'
+  | 'NATURAL'
+  | 'FASTER';
+
+export type CefrLevel = 'A' | 'B' | 'C' | 'D';
+
+export type UserPreference = {
+  userId: string;
+  preferredVoice: PreferredVoice | null;
+  preferredAiSpeechSpeed: PreferredAiSpeechSpeed | null;
+  cefrLevel: CefrLevel | null;
+  memoryText: string | null;
+};
+
+type ApiRequester = {
+  request(path: string, options?: RequestInit): Promise<unknown>;
+};
+
+export class AuthService {
+  constructor(private readonly client: ApiRequester) {}
+
+  login(input: { username: string; password: string }) {
+    return this.client.request('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }) as Promise<AuthResponse>;
+  }
+
+  register(input: { username: string; password: string; nickname: string | null }) {
+    return this.client.request('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify(input),
+    }) as Promise<AuthResponse>;
+  }
+
+  currentUser() {
+    return this.client.request('/api/auth/me') as Promise<UserAccount>;
+  }
+
+  getPreference() {
+    return this.client.request('/api/user-preferences') as Promise<UserPreference>;
+  }
+
+  updatePreference(patch: Partial<UserPreference>) {
+    return this.client.request('/api/user-preferences', {
+      method: 'PUT',
+      body: JSON.stringify(patch),
+    }) as Promise<UserPreference>;
+  }
+}

--- a/frontend/mobile/src/features/auth/AuthSessionController.ts
+++ b/frontend/mobile/src/features/auth/AuthSessionController.ts
@@ -1,0 +1,162 @@
+import type { TokenStore } from '@/infrastructure/auth/SecureTokenStore';
+import { ApiError } from '@/infrastructure/http/ApiClient';
+
+import type {
+  AuthResponse,
+  UserAccount,
+  UserPreference,
+} from './AuthService';
+
+export type AuthSessionStatus =
+  | 'booting'
+  | 'anonymous'
+  | 'authenticating'
+  | 'authenticated';
+
+export type AuthSessionState = Readonly<{
+  status: AuthSessionStatus;
+  user: UserAccount | null;
+  preference: UserPreference | null;
+  error: string | null;
+}>;
+
+type AuthServicePort = {
+  login(input: { username: string; password: string }): Promise<AuthResponse>;
+  register(input: {
+    username: string;
+    password: string;
+    nickname: string | null;
+  }): Promise<AuthResponse>;
+  currentUser(): Promise<UserAccount>;
+  getPreference(): Promise<UserPreference>;
+  updatePreference(patch: Partial<UserPreference>): Promise<UserPreference>;
+};
+
+export type AuthSessionDependencies = {
+  tokenStore: TokenStore;
+  authService: AuthServicePort;
+};
+
+type AuthStateListener = (state: AuthSessionState) => void;
+
+const initialState: AuthSessionState = {
+  status: 'booting',
+  user: null,
+  preference: null,
+  error: null,
+};
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : '请求失败，请稍后重试';
+}
+
+export class AuthSessionController {
+  private state = initialState;
+  private readonly listeners = new Set<AuthStateListener>();
+
+  constructor(private readonly dependencies: AuthSessionDependencies) {}
+
+  getSnapshot() {
+    return this.state;
+  }
+
+  subscribe(listener: AuthStateListener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async bootstrap() {
+    this.setState({ ...initialState, status: 'booting' });
+    const token = await this.dependencies.tokenStore.get();
+    if (!token) {
+      this.setAnonymous();
+      return;
+    }
+
+    try {
+      const [user, preference] = await Promise.all([
+        this.dependencies.authService.currentUser(),
+        this.dependencies.authService.getPreference(),
+      ]);
+      this.setAuthenticated(user, preference);
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 401) {
+        await this.dependencies.tokenStore.clear();
+      }
+      this.setAnonymous(errorMessage(error));
+    }
+  }
+
+  async login(input: { username: string; password: string }) {
+    this.setState({ ...initialState, status: 'authenticating' });
+    try {
+      const auth = await this.dependencies.authService.login(input);
+      await this.finishAuthentication(auth);
+    } catch (error) {
+      this.setAnonymous(errorMessage(error));
+      throw error;
+    }
+  }
+
+  async register(input: {
+    username: string;
+    password: string;
+    nickname: string | null;
+  }) {
+    this.setState({ ...initialState, status: 'authenticating' });
+    try {
+      const auth = await this.dependencies.authService.register(input);
+      await this.finishAuthentication(auth);
+    } catch (error) {
+      this.setAnonymous(errorMessage(error));
+      throw error;
+    }
+  }
+
+  async updatePreference(patch: Partial<UserPreference>) {
+    if (this.state.status !== 'authenticated') {
+      throw new Error('需要登录后才能更新偏好');
+    }
+    const preference = await this.dependencies.authService.updatePreference(patch);
+    this.setState({ ...this.state, preference, error: null });
+    return preference;
+  }
+
+  async logout() {
+    await this.unauthorized();
+  }
+
+  async unauthorized() {
+    await this.dependencies.tokenStore.clear();
+    this.setAnonymous();
+  }
+
+  private async finishAuthentication(auth: AuthResponse) {
+    await this.dependencies.tokenStore.set(auth.accessToken);
+    const preference = await this.dependencies.authService.getPreference();
+    this.setAuthenticated(auth.user, preference);
+  }
+
+  private setAuthenticated(user: UserAccount, preference: UserPreference) {
+    this.setState({
+      status: 'authenticated',
+      user,
+      preference,
+      error: null,
+    });
+  }
+
+  private setAnonymous(error: string | null = null) {
+    this.setState({
+      status: 'anonymous',
+      user: null,
+      preference: null,
+      error,
+    });
+  }
+
+  private setState(state: AuthSessionState) {
+    this.state = state;
+    this.listeners.forEach((listener) => listener(state));
+  }
+}

--- a/frontend/mobile/src/features/auth/__tests__/AuthService.test.ts
+++ b/frontend/mobile/src/features/auth/__tests__/AuthService.test.ts
@@ -1,0 +1,71 @@
+import { AuthService, type UserPreference } from '../AuthService';
+
+function createClient() {
+  return {
+    request: jest.fn(async () => undefined),
+  };
+}
+
+describe('AuthService', () => {
+  it('logs in with the Java auth request shape', async () => {
+    const client = createClient();
+    const service = new AuthService(client);
+
+    await service.login({ username: 'learner@example.com', password: 'password123' });
+
+    expect(client.request).toHaveBeenCalledWith('/api/auth/login', {
+      method: 'POST',
+      body: JSON.stringify({
+        username: 'learner@example.com',
+        password: 'password123',
+      }),
+    });
+  });
+
+  it('registers with nickname using the Java auth request shape', async () => {
+    const client = createClient();
+    const service = new AuthService(client);
+
+    await service.register({
+      username: 'learner@example.com',
+      password: 'password123',
+      nickname: 'Yufan',
+    });
+
+    expect(client.request).toHaveBeenCalledWith('/api/auth/register', {
+      method: 'POST',
+      body: JSON.stringify({
+        username: 'learner@example.com',
+        password: 'password123',
+        nickname: 'Yufan',
+      }),
+    });
+  });
+
+  it('loads the current account and preference from protected endpoints', async () => {
+    const client = createClient();
+    const service = new AuthService(client);
+
+    await service.currentUser();
+    await service.getPreference();
+
+    expect(client.request).toHaveBeenNthCalledWith(1, '/api/auth/me');
+    expect(client.request).toHaveBeenNthCalledWith(2, '/api/user-preferences');
+  });
+
+  it('updates only the supplied preference fields', async () => {
+    const client = createClient();
+    const service = new AuthService(client);
+    const patch: Partial<UserPreference> = {
+      cefrLevel: 'B',
+      preferredVoice: 'Harvey',
+    };
+
+    await service.updatePreference(patch);
+
+    expect(client.request).toHaveBeenCalledWith('/api/user-preferences', {
+      method: 'PUT',
+      body: JSON.stringify(patch),
+    });
+  });
+});

--- a/frontend/mobile/src/features/auth/__tests__/AuthSessionController.test.ts
+++ b/frontend/mobile/src/features/auth/__tests__/AuthSessionController.test.ts
@@ -1,0 +1,172 @@
+import { ApiError } from '@/infrastructure/http/ApiClient';
+
+import {
+  AuthSessionController,
+  type AuthSessionDependencies,
+} from '../AuthSessionController';
+import type { AuthResponse, UserAccount, UserPreference } from '../AuthService';
+
+const user: UserAccount = {
+  id: 'user-1',
+  username: 'learner@example.com',
+  nickname: 'Yufan',
+  role: 'USER',
+  status: 'ACTIVE',
+  lastLoginAt: null,
+  createdAt: '2026-08-05T00:00:00Z',
+};
+
+const preference: UserPreference = {
+  userId: 'user-1',
+  preferredVoice: 'Harvey',
+  preferredAiSpeechSpeed: 'NATURAL',
+  cefrLevel: 'B',
+  memoryText: null,
+};
+
+const authResponse: AuthResponse = {
+  tokenType: 'Bearer',
+  accessToken: 'jwt-token',
+  expiresAt: '2026-08-06T00:00:00Z',
+  user,
+};
+
+function createDependencies(
+  token: string | null = null,
+): AuthSessionDependencies & {
+  tokenStore: AuthSessionDependencies['tokenStore'] & {
+    set: jest.Mock;
+    clear: jest.Mock;
+  };
+  authService: AuthSessionDependencies['authService'] & {
+    login: jest.Mock;
+    register: jest.Mock;
+    currentUser: jest.Mock;
+    getPreference: jest.Mock;
+    updatePreference: jest.Mock;
+  };
+} {
+  return {
+    tokenStore: {
+      get: jest.fn(async () => token),
+      set: jest.fn(async () => undefined),
+      clear: jest.fn(async () => undefined),
+    },
+    authService: {
+      login: jest.fn(async () => authResponse),
+      register: jest.fn(async () => authResponse),
+      currentUser: jest.fn(async () => user),
+      getPreference: jest.fn(async () => preference),
+      updatePreference: jest.fn(async (patch: Partial<UserPreference>) => ({
+        ...preference,
+        ...patch,
+      })),
+    },
+  };
+}
+
+describe('AuthSessionController', () => {
+  it('notifies subscribers when authentication state changes', async () => {
+    const controller = new AuthSessionController(createDependencies());
+    const listener = jest.fn();
+    const unsubscribe = controller.subscribe(listener);
+
+    await controller.bootstrap();
+
+    expect(listener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ status: 'anonymous' }),
+    );
+    const notificationCount = listener.mock.calls.length;
+    unsubscribe();
+    await controller.login({ username: 'learner@example.com', password: 'password123' });
+    expect(listener).toHaveBeenCalledTimes(notificationCount);
+  });
+
+  it('boots into anonymous state when no token is stored', async () => {
+    const controller = new AuthSessionController(createDependencies());
+
+    await controller.bootstrap();
+
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ status: 'anonymous', user: null, preference: null }),
+    );
+  });
+
+  it('restores the user and preferences when the saved token is valid', async () => {
+    const dependencies = createDependencies('saved-token');
+    const controller = new AuthSessionController(dependencies);
+
+    await controller.bootstrap();
+
+    expect(controller.getSnapshot()).toEqual({
+      status: 'authenticated',
+      user,
+      preference,
+      error: null,
+    });
+  });
+
+  it('clears an invalid saved token after a 401 bootstrap response', async () => {
+    const dependencies = createDependencies('expired-token');
+    dependencies.authService.currentUser.mockRejectedValue(
+      new ApiError('登录已过期', 401),
+    );
+    const controller = new AuthSessionController(dependencies);
+
+    await controller.bootstrap();
+
+    expect(dependencies.tokenStore.clear).toHaveBeenCalledTimes(1);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ status: 'anonymous', error: '登录已过期' }),
+    );
+  });
+
+  it('preserves a saved token after a recoverable network bootstrap failure', async () => {
+    const dependencies = createDependencies('saved-token');
+    dependencies.authService.currentUser.mockRejectedValue(new Error('Network request failed'));
+    const controller = new AuthSessionController(dependencies);
+
+    await controller.bootstrap();
+
+    expect(dependencies.tokenStore.clear).not.toHaveBeenCalled();
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ status: 'anonymous', error: 'Network request failed' }),
+    );
+  });
+
+  it('stores the token and loads preferences after login', async () => {
+    const dependencies = createDependencies();
+    const controller = new AuthSessionController(dependencies);
+
+    await controller.login({ username: 'learner@example.com', password: 'password123' });
+
+    expect(dependencies.tokenStore.set).toHaveBeenCalledWith('jwt-token');
+    expect(controller.getSnapshot()).toEqual({
+      status: 'authenticated',
+      user,
+      preference,
+      error: null,
+    });
+  });
+
+  it('updates the authenticated preference snapshot', async () => {
+    const dependencies = createDependencies('saved-token');
+    const controller = new AuthSessionController(dependencies);
+    await controller.bootstrap();
+
+    await controller.updatePreference({ preferredAiSpeechSpeed: 'SLOWER' });
+
+    expect(controller.getSnapshot().preference?.preferredAiSpeechSpeed).toBe('SLOWER');
+  });
+
+  it('clears local authentication on logout or unauthorized notification', async () => {
+    const dependencies = createDependencies('saved-token');
+    const controller = new AuthSessionController(dependencies);
+    await controller.bootstrap();
+
+    await controller.unauthorized();
+
+    expect(dependencies.tokenStore.clear).toHaveBeenCalledTimes(1);
+    expect(controller.getSnapshot().status).toBe('anonymous');
+  });
+});

--- a/frontend/mobile/src/features/auth/__tests__/preferenceMappings.test.ts
+++ b/frontend/mobile/src/features/auth/__tests__/preferenceMappings.test.ts
@@ -1,0 +1,30 @@
+import { levels, speedOptions, teachers } from '@/theme/tokens';
+
+import {
+  cefrLevelForLevel,
+  levelForCefrLevel,
+  speedCodeForLabel,
+  speedLabelForCode,
+  teacherForVoice,
+  voiceForTeacher,
+} from '../preferenceMappings';
+
+describe('preference mappings', () => {
+  it('maps backend preference codes to the finalized mobile choices', () => {
+    expect(levelForCefrLevel('B', levels).id).toBe('basic');
+    expect(teacherForVoice('Harvey', teachers).id).toBe('james');
+    expect(speedLabelForCode('NATURAL')).toBe('自然');
+  });
+
+  it('maps mobile choices back to backend enum codes', () => {
+    expect(cefrLevelForLevel(levels[1])).toBe('B');
+    expect(voiceForTeacher(teachers[1])).toBe('Harvey');
+    expect(speedCodeForLabel(speedOptions[0])).toBe('SLOWER');
+  });
+
+  it('uses safe UI defaults for missing backend preferences', () => {
+    expect(levelForCefrLevel(null, levels).id).toBe('starter');
+    expect(teacherForVoice(null, teachers).id).toBe('clara');
+    expect(speedLabelForCode(null)).toBe('自然');
+  });
+});

--- a/frontend/mobile/src/features/auth/preferenceMappings.ts
+++ b/frontend/mobile/src/features/auth/preferenceMappings.ts
@@ -1,0 +1,53 @@
+import type { Teacher } from '@/theme/tokens';
+
+import type {
+  CefrLevel,
+  PreferredAiSpeechSpeed,
+  PreferredVoice,
+} from './AuthService';
+
+type LevelOption = {
+  id: string;
+  cefrLevel: CefrLevel;
+};
+
+const speedCodeByLabel = {
+  '慢一些': 'SLOWER',
+  '适中': 'MODERATE',
+  '自然': 'NATURAL',
+  '快一些': 'FASTER',
+} as const satisfies Record<string, PreferredAiSpeechSpeed>;
+
+const speedLabelByCode = Object.fromEntries(
+  Object.entries(speedCodeByLabel).map(([label, code]) => [code, label]),
+) as Record<PreferredAiSpeechSpeed, keyof typeof speedCodeByLabel>;
+
+export function levelForCefrLevel<T extends LevelOption>(
+  cefrLevel: CefrLevel | null,
+  options: readonly T[],
+) {
+  return options.find((option) => option.cefrLevel === cefrLevel) ?? options[0];
+}
+
+export function cefrLevelForLevel(level: LevelOption) {
+  return level.cefrLevel;
+}
+
+export function teacherForVoice(
+  voice: PreferredVoice | null,
+  options: readonly Teacher[],
+) {
+  return options.find((teacher) => teacher.voiceId === voice) ?? options[0];
+}
+
+export function voiceForTeacher(teacher: Teacher) {
+  return teacher.voiceId;
+}
+
+export function speedLabelForCode(code: PreferredAiSpeechSpeed | null) {
+  return code ? speedLabelByCode[code] : '自然';
+}
+
+export function speedCodeForLabel(label: string): PreferredAiSpeechSpeed {
+  return speedCodeByLabel[label as keyof typeof speedCodeByLabel] ?? 'NATURAL';
+}

--- a/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
+++ b/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
@@ -1,0 +1,132 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Pressable, Text, View } from 'react-native';
+
+import type { RealtimeSessionSnapshot } from '@/features/realtime/RealtimeSessionController';
+
+import {
+  type FreeChatControllerPort,
+  useFreeChatSession,
+} from '../useFreeChatSession';
+
+const idleSnapshot: RealtimeSessionSnapshot = {
+  state: 'idle',
+  muted: false,
+  sessionId: null,
+  userTranscript: '',
+  assistantTranscript: '',
+  error: null,
+};
+
+function createController(): FreeChatControllerPort & {
+  emit(snapshot: RealtimeSessionSnapshot): void;
+  start: jest.Mock;
+  setMuted: jest.Mock;
+  interrupt: jest.Mock;
+  end: jest.Mock;
+} {
+  let snapshot = idleSnapshot;
+  let listener: ((next: RealtimeSessionSnapshot) => void) | null = null;
+  return {
+    getSnapshot: () => snapshot,
+    subscribe: jest.fn((nextListener) => {
+      listener = nextListener;
+      nextListener(snapshot);
+      return () => {
+        listener = null;
+      };
+    }),
+    start: jest.fn(async () => undefined),
+    setMuted: jest.fn(),
+    interrupt: jest.fn(),
+    end: jest.fn(async () => undefined),
+    emit(next) {
+      snapshot = next;
+      listener?.(snapshot);
+    },
+  };
+}
+
+function SessionProbe({
+  createController,
+}: {
+  createController: () => FreeChatControllerPort;
+}) {
+  const session = useFreeChatSession(
+    {
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    },
+    createController,
+  );
+  return (
+    <View>
+      <Text testID="snapshot">
+        {JSON.stringify({
+          state: session.state,
+          label: session.statusLabel,
+          muted: session.muted,
+          user: session.userTranscript,
+          assistant: session.assistantTranscript,
+          error: session.error,
+        })}
+      </Text>
+      <Pressable accessibilityLabel="mute" onPress={session.toggleMuted} />
+      <Pressable accessibilityLabel="interrupt" onPress={session.interrupt} />
+      <Pressable accessibilityLabel="end" onPress={() => void session.end()} />
+    </View>
+  );
+}
+
+describe('useFreeChatSession', () => {
+  it('starts once and exposes live state, transcripts, mute and interrupt actions', async () => {
+    const controller = createController();
+    const factory = jest.fn(() => controller);
+    const screen = await render(<SessionProbe createController={factory} />);
+
+    await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1));
+    expect(factory).toHaveBeenCalledWith({
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+
+    await act(() => {
+      controller.emit({
+        ...idleSnapshot,
+        state: 'assistant_speaking',
+        sessionId: 'session-1',
+        userTranscript: 'Hello.',
+        assistantTranscript: 'Hi, how are you?',
+      });
+    });
+    await waitFor(() =>
+      expect(screen.getByTestId('snapshot').props.children).toContain(
+        'AI 正在回答',
+      ),
+    );
+    await fireEvent.press(screen.getByLabelText('mute'));
+    await fireEvent.press(screen.getByLabelText('interrupt'));
+
+    expect(controller.setMuted).toHaveBeenCalledWith(true);
+    expect(controller.interrupt).toHaveBeenCalledTimes(1);
+  });
+
+  it('exposes startup errors and performs idempotent cleanup after ending', async () => {
+    const controller = createController();
+    controller.start.mockRejectedValue(new Error('麦克风权限被拒绝'));
+    const screen = await render(
+      <SessionProbe createController={() => controller} />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('snapshot').props.children).toContain(
+        '麦克风权限被拒绝',
+      ),
+    );
+    await fireEvent.press(screen.getByLabelText('end'));
+    screen.unmount();
+
+    await waitFor(() => expect(controller.end).toHaveBeenCalledTimes(1));
+  });
+});

--- a/frontend/mobile/src/features/conversation/useFreeChatSession.ts
+++ b/frontend/mobile/src/features/conversation/useFreeChatSession.ts
@@ -1,0 +1,133 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { ReactNativeWebRTCTransport } from '@/features/realtime/ReactNativeWebRTCTransport';
+import {
+  RealtimeSessionController,
+  type RealtimeSessionOptions,
+  type RealtimeSessionSnapshot,
+} from '@/features/realtime/RealtimeSessionController';
+import { RealtimeSessionApi } from '@/features/realtime/RealtimeSessionApi';
+import { SessionMessageSocket } from '@/features/realtime/SessionMessageSocket';
+import type { RealtimeState } from '@/features/realtime/types';
+import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
+import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
+import { ApiClient } from '@/infrastructure/http/ApiClient';
+
+export type FreeChatConfig = Pick<
+  RealtimeSessionOptions,
+  'voice' | 'model' | 'speechSpeed'
+>;
+
+export type FreeChatControllerPort = {
+  getSnapshot(): RealtimeSessionSnapshot;
+  subscribe(listener: (snapshot: RealtimeSessionSnapshot) => void): () => void;
+  start(): Promise<unknown>;
+  setMuted(muted: boolean): void;
+  interrupt(): void;
+  end(): Promise<unknown>;
+};
+
+export type FreeChatControllerFactory = (
+  config: FreeChatConfig,
+) => FreeChatControllerPort;
+
+const statusLabels: Record<RealtimeState, string> = {
+  idle: '正在准备',
+  requesting_permission: '正在请求麦克风权限',
+  creating_offer: '正在创建实时连接',
+  exchanging_sdp: '正在连接服务',
+  connecting: '正在连接 AI',
+  ready: '可以开始说了',
+  user_speaking: '正在聆听',
+  assistant_speaking: 'AI 正在回答',
+  paused: '会话已暂停',
+  ending: '正在结束',
+  ended: '会话已结束',
+  error: '连接失败',
+};
+
+export function createFreeChatController(
+  config: FreeChatConfig,
+): FreeChatControllerPort {
+  const tokenStore = new SecureTokenStore();
+  const { backendUrl } = getRuntimeConfig();
+  const apiClient = new ApiClient({ baseUrl: backendUrl, tokenStore });
+  return new RealtimeSessionController(
+    {
+      transport: new ReactNativeWebRTCTransport(),
+      sessionApi: new RealtimeSessionApi(apiClient),
+      sessionSocket: new SessionMessageSocket({ baseUrl: backendUrl, tokenStore }),
+    },
+    {
+      mode: 'free_chat',
+      ...config,
+    },
+  );
+}
+
+const initialSnapshot: RealtimeSessionSnapshot = {
+  state: 'idle',
+  muted: false,
+  sessionId: null,
+  userTranscript: '',
+  assistantTranscript: '',
+  error: null,
+};
+
+export function useFreeChatSession(
+  config: FreeChatConfig,
+  createController: FreeChatControllerFactory = createFreeChatController,
+) {
+  const [controller] = useState(() => createController(config));
+  const [snapshot, setSnapshot] = useState<RealtimeSessionSnapshot>(() =>
+    controller.getSnapshot?.() ?? initialSnapshot,
+  );
+  const [startupError, setStartupError] = useState<string | null>(null);
+  const [elapsed, setElapsed] = useState(0);
+  const endPromise = useRef<Promise<unknown> | null>(null);
+
+  const end = useCallback(() => {
+    if (!endPromise.current) {
+      endPromise.current = Promise.resolve(controller.end());
+    }
+    return endPromise.current;
+  }, [controller]);
+
+  useEffect(() => controller.subscribe(setSnapshot), [controller]);
+
+  useEffect(() => {
+    let active = true;
+    void controller.start().catch((error: unknown) => {
+      if (active) {
+        setStartupError(
+          error instanceof Error ? error.message : '实时对话启动失败',
+        );
+      }
+    });
+    return () => {
+      active = false;
+      void end().catch(() => undefined);
+    };
+  }, [controller, end]);
+
+  useEffect(() => {
+    const active = !['idle', 'ending', 'ended', 'error'].includes(snapshot.state);
+    if (!active) return;
+    const timer = setInterval(() => setElapsed((current) => current + 1), 1_000);
+    return () => clearInterval(timer);
+  }, [snapshot.state]);
+
+  const toggleMuted = useCallback(() => {
+    controller.setMuted(!snapshot.muted);
+  }, [controller, snapshot.muted]);
+
+  return {
+    ...snapshot,
+    elapsed,
+    statusLabel: statusLabels[snapshot.state],
+    error: snapshot.error?.message ?? startupError,
+    toggleMuted,
+    interrupt: () => controller.interrupt(),
+    end,
+  };
+}

--- a/frontend/mobile/src/features/realtime/QwenEventNormalizer.ts
+++ b/frontend/mobile/src/features/realtime/QwenEventNormalizer.ts
@@ -1,0 +1,158 @@
+import type { RealtimeDomainEvent } from './types';
+
+type JsonRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function nonEmptyString(value: unknown) {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function providerItemId(raw: JsonRecord) {
+  const item = isRecord(raw.item) ? raw.item : undefined;
+  return (
+    nonEmptyString(raw.item_id) ??
+    nonEmptyString(item?.id) ??
+    nonEmptyString(raw.event_id)
+  );
+}
+
+function assistantOutput(raw: JsonRecord) {
+  const response = isRecord(raw.response) ? raw.response : undefined;
+  const output = Array.isArray(response?.output) ? response.output : [];
+  const item = output.find(
+    (candidate) =>
+      isRecord(candidate) &&
+      candidate.role === 'assistant' &&
+      Array.isArray(candidate.content),
+  );
+  if (!isRecord(item) || !Array.isArray(item.content)) return null;
+  const text = item.content
+    .map((part) => {
+      if (!isRecord(part)) return '';
+      return nonEmptyString(part.transcript) ?? nonEmptyString(part.text) ?? '';
+    })
+    .join('')
+    .trim();
+  if (!text) return null;
+  return {
+    itemId:
+      nonEmptyString(item.id) ??
+      nonEmptyString(response?.id) ??
+      nonEmptyString(raw.event_id),
+    text,
+  };
+}
+
+export function normalizeQwenEvent(raw: unknown): RealtimeDomainEvent[] {
+  if (!isRecord(raw)) return [];
+  const type = nonEmptyString(raw.type);
+
+  switch (type) {
+    case 'session.created':
+      return [{ type: 'session.created' }];
+    case 'session.updated':
+      return [{ type: 'session.updated' }];
+    case 'input_audio_buffer.speech_started':
+      return [{ type: 'user.speech.started' }];
+    case 'input_audio_buffer.speech_stopped':
+      return [{ type: 'user.speech.stopped' }];
+    case 'conversation.item.input_audio_transcription.delta': {
+      const preview = `${nonEmptyString(raw.text) ?? ''}${nonEmptyString(raw.stash) ?? ''}`;
+      const previewText = nonEmptyString(preview);
+      if (previewText) {
+        return [
+          {
+            type: 'user.transcript.preview',
+            itemId: providerItemId(raw),
+            text: previewText,
+          },
+        ];
+      }
+      const delta = nonEmptyString(raw.delta);
+      if (!delta) return [];
+      return [
+        {
+          type: 'user.transcript.delta',
+          itemId: providerItemId(raw),
+          text: delta,
+        },
+      ];
+    }
+    case 'conversation.item.input_audio_transcription.text': {
+      const text = `${nonEmptyString(raw.text) ?? ''}${nonEmptyString(raw.stash) ?? ''}`;
+      const preview = nonEmptyString(text) ?? nonEmptyString(raw.delta);
+      if (!preview) return [];
+      return [
+        {
+          type: 'user.transcript.preview',
+          itemId: providerItemId(raw),
+          text: preview,
+        },
+      ];
+    }
+    case 'conversation.item.input_audio_transcription.completed': {
+      const text = nonEmptyString(raw.transcript) ?? nonEmptyString(raw.text);
+      if (!text) return [];
+      return [
+        {
+          type: 'user.transcript.completed',
+          itemId: providerItemId(raw),
+          text,
+        },
+      ];
+    }
+    case 'response.created':
+      return [{ type: 'assistant.response.started' }];
+    case 'response.audio_transcript.delta':
+    case 'response.text.delta': {
+      const text = nonEmptyString(raw.delta);
+      return text ? [{ type: 'assistant.transcript.delta', text }] : [];
+    }
+    case 'response.audio_transcript.done':
+    case 'response.text.done': {
+      const text = nonEmptyString(raw.transcript) ?? nonEmptyString(raw.text);
+      if (!text) return [];
+      return [
+        {
+          type: 'assistant.transcript.completed',
+          itemId:
+            nonEmptyString(raw.item_id) ??
+            nonEmptyString(raw.response_id) ??
+            nonEmptyString(raw.event_id),
+          text,
+        },
+      ];
+    }
+    case 'response.done': {
+      const response = isRecord(raw.response) ? raw.response : {};
+      const completed: RealtimeDomainEvent[] = [];
+      const output = assistantOutput(raw);
+      if (output) {
+        completed.push({ type: 'assistant.transcript.completed', ...output });
+      }
+      completed.push({
+        type: 'assistant.response.completed',
+        cancelled: response.status === 'cancelled',
+      });
+      return completed;
+    }
+    case 'error': {
+      const error = isRecord(raw.error) ? raw.error : {};
+      return [
+        {
+          type: 'provider.error',
+          code: nonEmptyString(error.code),
+          message:
+            nonEmptyString(error.message) ??
+            nonEmptyString(raw.message) ??
+            'Realtime provider returned an error.',
+        },
+      ];
+    }
+    default:
+      return [];
+  }
+}

--- a/frontend/mobile/src/features/realtime/ReactNativeWebRTCTransport.ts
+++ b/frontend/mobile/src/features/realtime/ReactNativeWebRTCTransport.ts
@@ -1,0 +1,266 @@
+import type {
+  RealtimeTransport,
+  RealtimeTransportEvent,
+} from './RealtimeSessionController';
+
+export type MediaStreamTrackLike = {
+  enabled: boolean;
+  stop(): void;
+};
+
+export type MediaStreamLike = {
+  getTracks(): MediaStreamTrackLike[];
+  getAudioTracks(): MediaStreamTrackLike[];
+};
+
+export type RTCDataChannelLike = {
+  readyState: 'connecting' | 'open' | 'closing' | 'closed';
+  onopen: (() => void) | null;
+  onerror: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  send(data: string): void;
+  close(): void;
+};
+
+export type SdpDescription = {
+  type: 'offer' | 'answer';
+  sdp: string;
+};
+
+export type PeerConnectionLike = {
+  iceGatheringState: string;
+  connectionState: string;
+  iceConnectionState: string;
+  localDescription: SdpDescription | null;
+  onicegatheringstatechange: (() => void) | null;
+  onconnectionstatechange: (() => void) | null;
+  oniceconnectionstatechange: (() => void) | null;
+  ondatachannel: ((event: { channel: RTCDataChannelLike }) => void) | null;
+  addTrack(track: MediaStreamTrackLike, stream: MediaStreamLike): unknown;
+  createDataChannel(label: string): RTCDataChannelLike;
+  createOffer(): Promise<SdpDescription>;
+  setLocalDescription(description: SdpDescription): Promise<void>;
+  setRemoteDescription(description: SdpDescription): Promise<void>;
+  close(): void;
+};
+
+export type ReactNativeWebRTCAdapter = {
+  getUserMedia(constraints: {
+    audio: {
+      echoCancellation: boolean;
+      noiseSuppression: boolean;
+      autoGainControl: boolean;
+    };
+    video: false;
+  }): Promise<MediaStreamLike>;
+  createPeerConnection(): PeerConnectionLike;
+  createSessionDescription(description: SdpDescription): SdpDescription;
+};
+
+type TransportOptions = ReactNativeWebRTCAdapter & {
+  iceGatheringTimeoutMs?: number;
+  dataChannelTimeoutMs?: number;
+};
+
+function createDefaultAdapter(): ReactNativeWebRTCAdapter {
+  // A literal require keeps Jest unit tests independent from the native module while
+  // Metro can still statically include it in the Android/iOS development build.
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const native = require('react-native-webrtc') as typeof import('react-native-webrtc');
+  return {
+    getUserMedia: (constraints) =>
+      native.mediaDevices.getUserMedia(
+        constraints as unknown as Parameters<typeof native.mediaDevices.getUserMedia>[0],
+      ) as unknown as Promise<MediaStreamLike>,
+    createPeerConnection: () =>
+      new native.RTCPeerConnection() as unknown as PeerConnectionLike,
+    createSessionDescription: (description) =>
+      new native.RTCSessionDescription(
+        description as ConstructorParameters<typeof native.RTCSessionDescription>[0],
+      ) as unknown as SdpDescription,
+  };
+}
+
+function normalizeSdp(sdp: string) {
+  const normalized = String(sdp || '').trim().replace(/\r?\n/g, '\r\n');
+  return normalized.endsWith('\r\n') ? normalized : `${normalized}\r\n`;
+}
+
+type Listener = (event: RealtimeTransportEvent) => void;
+
+export class ReactNativeWebRTCTransport implements RealtimeTransport {
+  private readonly adapter: ReactNativeWebRTCAdapter;
+  private readonly iceGatheringTimeoutMs: number;
+  private readonly dataChannelTimeoutMs: number;
+  private readonly listeners = new Set<Listener>();
+  private readonly channels = new Set<RTCDataChannelLike>();
+  private peer: PeerConnectionLike | null = null;
+  private stream: MediaStreamLike | null = null;
+  private channel: RTCDataChannelLike | null = null;
+
+  constructor(options?: Partial<TransportOptions>) {
+    const defaults = options ? null : createDefaultAdapter();
+    if (
+      !options?.getUserMedia ||
+      !options.createPeerConnection ||
+      !options.createSessionDescription
+    ) {
+      if (!defaults) {
+        throw new Error('React Native WebRTC adapter 配置不完整');
+      }
+    }
+    this.adapter = (options ?? defaults) as ReactNativeWebRTCAdapter;
+    this.iceGatheringTimeoutMs = options?.iceGatheringTimeoutMs ?? 10_000;
+    this.dataChannelTimeoutMs = options?.dataChannelTimeoutMs ?? 10_000;
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  async prepare() {
+    if (this.peer || this.stream) this.close();
+    const stream = await this.adapter.getUserMedia({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      video: false,
+    });
+    const peer = this.adapter.createPeerConnection();
+    this.stream = stream;
+    this.peer = peer;
+
+    for (const track of stream.getAudioTracks()) {
+      track.enabled = false;
+      peer.addTrack(track, stream);
+    }
+
+    peer.onconnectionstatechange = () => {
+      if (peer.connectionState === 'failed') {
+        this.emit({
+          type: 'connection.failed',
+          message: 'WebRTC 连接失败',
+        });
+      }
+    };
+    peer.oniceconnectionstatechange = () => {
+      if (peer.iceConnectionState === 'failed') {
+        this.emit({ type: 'ice.failed', message: 'ICE 连接失败' });
+      }
+    };
+    peer.ondatachannel = ({ channel }) => this.bindChannel(channel);
+    this.bindChannel(peer.createDataChannel('oai-events'));
+  }
+
+  async createOffer() {
+    const peer = this.requirePeer();
+    const offer = await peer.createOffer();
+    await peer.setLocalDescription(offer);
+    await this.waitForIceGathering(peer);
+    const sdp = peer.localDescription?.sdp;
+    if (!sdp?.trim()) throw new Error('本地 Offer SDP 为空');
+    return sdp;
+  }
+
+  async applyAnswer(answerSdp: string) {
+    const peer = this.requirePeer();
+    const answer = this.adapter.createSessionDescription({
+      type: 'answer',
+      sdp: normalizeSdp(answerSdp),
+    });
+    await peer.setRemoteDescription(answer);
+  }
+
+  waitForDataChannel() {
+    const channel = this.channel;
+    if (!channel) return Promise.reject(new Error('实时数据通道尚未创建'));
+    if (channel.readyState === 'open') return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const previousOpen = channel.onopen;
+      const previousError = channel.onerror;
+      const timer = setTimeout(() => {
+        reject(new Error('实时数据通道连接超时'));
+      }, this.dataChannelTimeoutMs);
+      channel.onopen = () => {
+        previousOpen?.();
+        clearTimeout(timer);
+        resolve();
+      };
+      channel.onerror = () => {
+        previousError?.();
+        clearTimeout(timer);
+        reject(new Error('实时数据通道连接失败'));
+      };
+    });
+  }
+
+  sendProviderEvent(event: Record<string, unknown>) {
+    const channel = this.channel;
+    if (!channel || channel.readyState !== 'open') {
+      throw new Error('实时数据通道尚未连接');
+    }
+    channel.send(JSON.stringify(event));
+  }
+
+  setAudioEnabled(enabled: boolean) {
+    for (const track of this.stream?.getAudioTracks() ?? []) {
+      track.enabled = enabled;
+    }
+  }
+
+  close() {
+    const stream = this.stream;
+    const peer = this.peer;
+    this.stream = null;
+    this.peer = null;
+    this.channel = null;
+
+    for (const track of stream?.getTracks() ?? []) track.stop();
+    for (const channel of this.channels) channel.close();
+    this.channels.clear();
+    peer?.close();
+  }
+
+  private bindChannel(channel: RTCDataChannelLike) {
+    this.channel = channel;
+    this.channels.add(channel);
+    channel.onmessage = ({ data }) => {
+      this.emit({ type: 'provider.message', data });
+    };
+    channel.onerror = () => {
+      this.emit({
+        type: 'datachannel.failed',
+        message: '实时数据通道连接失败',
+      });
+    };
+  }
+
+  private waitForIceGathering(peer: PeerConnectionLike) {
+    if (peer.iceGatheringState === 'complete') return Promise.resolve();
+    return new Promise<void>((resolve, reject) => {
+      const previous = peer.onicegatheringstatechange;
+      const timer = setTimeout(() => {
+        reject(new Error('ICE 候选收集超时'));
+      }, this.iceGatheringTimeoutMs);
+      peer.onicegatheringstatechange = () => {
+        previous?.();
+        if (peer.iceGatheringState === 'complete') {
+          clearTimeout(timer);
+          resolve();
+        }
+      };
+    });
+  }
+
+  private requirePeer() {
+    if (!this.peer) throw new Error('WebRTC 尚未准备');
+    return this.peer;
+  }
+
+  private emit(event: RealtimeTransportEvent) {
+    this.listeners.forEach((listener) => listener(event));
+  }
+}

--- a/frontend/mobile/src/features/realtime/RealtimeSessionApi.ts
+++ b/frontend/mobile/src/features/realtime/RealtimeSessionApi.ts
@@ -1,0 +1,26 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+import type {
+  RealtimeSessionStartRequest,
+  RealtimeSessionStartResponse,
+} from './RealtimeSessionController';
+
+type ApiRequester = {
+  request(path: string, options?: ApiRequestOptions): Promise<unknown>;
+};
+
+export class RealtimeSessionApi {
+  constructor(private readonly client: ApiRequester) {}
+
+  start(request: RealtimeSessionStartRequest) {
+    const { sceneId, ...body } = request;
+    const path = sceneId
+      ? `/api/custom-scenes/${encodeURIComponent(sceneId)}/sessions`
+      : '/api/scene-sessions';
+    return this.client.request(path, {
+      method: 'POST',
+      body: JSON.stringify(body),
+      timeoutMs: 20_000,
+    }) as Promise<RealtimeSessionStartResponse>;
+  }
+}

--- a/frontend/mobile/src/features/realtime/RealtimeSessionController.ts
+++ b/frontend/mobile/src/features/realtime/RealtimeSessionController.ts
@@ -1,0 +1,568 @@
+import { normalizeQwenEvent } from './QwenEventNormalizer';
+import { RealtimeStateMachine } from './RealtimeStateMachine';
+import type {
+  RealtimeDomainEvent,
+  RealtimeError,
+  RealtimeErrorCode,
+  RealtimeState,
+} from './types';
+import type {
+  DialogueCompletion,
+  ScenarioDialogueState,
+} from '@/features/scenes/SceneDialogueApi';
+
+export type RealtimeTransportEvent =
+  | { type: 'provider.message'; data: string }
+  | { type: 'connection.failed'; message?: string }
+  | { type: 'ice.failed'; message?: string }
+  | { type: 'datachannel.failed'; message?: string };
+
+export type RealtimeTransport = {
+  subscribe(listener: (event: RealtimeTransportEvent) => void): () => void;
+  prepare(): Promise<void>;
+  createOffer(): Promise<string>;
+  applyAnswer(answerSdp: string): Promise<void>;
+  waitForDataChannel(): Promise<void>;
+  sendProviderEvent(event: Record<string, unknown>): void;
+  setAudioEnabled(enabled: boolean): void;
+  close(): void;
+};
+
+export type RealtimeSessionStartRequest = {
+  sceneId: string | null;
+  offerSdp: string;
+  provider: 'QWEN';
+  model: string;
+  voice: string;
+  translationEnabled: boolean;
+};
+
+export type RealtimeSessionStartResponse = {
+  sessionId: string;
+  answerSdp: string;
+  voiceId: string;
+  systemPrompt: string;
+};
+
+export type SessionMessage = {
+  owner: 0 | 1;
+  content: string;
+  providerMessageId?: string;
+};
+
+export type RealtimeSessionDependencies = {
+  transport: RealtimeTransport;
+  sessionApi: {
+    start(request: RealtimeSessionStartRequest): Promise<RealtimeSessionStartResponse>;
+  };
+  sessionSocket: {
+    connect(sessionId: string): Promise<void>;
+    persistMessage(message: SessionMessage): Promise<void>;
+    end(stopTime: string): Promise<unknown>;
+    close(): void;
+  };
+  sceneDialogue?: {
+    advanceState(
+      sessionId: string,
+      turnNo: number,
+      transcript: string,
+    ): Promise<ScenarioDialogueState>;
+    evaluateTurn(
+      sessionId: string,
+      turnNo: number,
+      transcript: string,
+    ): Promise<unknown>;
+    complete(
+      sessionId: string,
+      stopTime: string,
+    ): Promise<DialogueCompletion | null>;
+  };
+  now?: () => Date;
+  createEventId?: () => string;
+};
+
+export type RealtimeSessionOptions = {
+  mode: 'free_chat' | 'scene';
+  sceneId?: string;
+  voice: string;
+  model: string;
+  speechSpeed: 'SLOWER' | 'MODERATE' | 'NATURAL' | 'FASTER';
+};
+
+export type RealtimeSessionSnapshot = Readonly<{
+  state: RealtimeState;
+  muted: boolean;
+  sessionId: string | null;
+  userTranscript: string;
+  assistantTranscript: string;
+  error: RealtimeError | null;
+  sceneState?: ScenarioDialogueState | null;
+  completion?: DialogueCompletion | null;
+}>;
+
+const speechSpeedInstructions = {
+  SLOWER:
+    'Voice delivery rule: speak distinctly and very slowly, around 70 English words per minute, with clear pauses between short phrases.',
+  MODERATE:
+    'Voice delivery rule: speak at a calm moderate pace, around 120 English words per minute, with clear pauses between ideas.',
+  NATURAL:
+    'Voice delivery rule: speak at a natural conversational pace, around 165 English words per minute.',
+  FASTER:
+    'Voice delivery rule: speak quickly but clearly, around 210 English words per minute, without dropping or slurring words.',
+} as const;
+
+function buildSessionUpdate(
+  eventId: string,
+  response: RealtimeSessionStartResponse,
+  options: RealtimeSessionOptions,
+) {
+  return {
+    event_id: eventId,
+    type: 'session.update',
+    session: {
+      modalities: ['text', 'audio'],
+      voice: response.voiceId || options.voice,
+      instructions: [
+        response.systemPrompt,
+        speechSpeedInstructions[options.speechSpeed],
+      ]
+        .filter(Boolean)
+        .join('\n\n'),
+      input_audio_format: 'pcm',
+      output_audio_format: 'pcm',
+      input_audio_transcription: { model: 'qwen3-asr-flash-realtime' },
+      smooth_output: false,
+      turn_detection: {
+        type: options.model.startsWith('qwen3.5-omni-')
+          ? 'semantic_vad'
+          : 'server_vad',
+        threshold: 0.5,
+        prefix_padding_ms: 500,
+        silence_duration_ms: 600,
+        create_response: options.mode === 'free_chat',
+        interrupt_response: true,
+      },
+    },
+  };
+}
+
+function toRealtimeError(
+  code: RealtimeErrorCode,
+  error: unknown,
+  retryable: boolean,
+): RealtimeError {
+  return {
+    code,
+    message: error instanceof Error ? error.message : '无法开始实时对话',
+    retryable,
+  };
+}
+
+type SnapshotListener = (snapshot: RealtimeSessionSnapshot) => void;
+
+export class RealtimeSessionController {
+  private readonly machine = new RealtimeStateMachine();
+  private readonly listeners = new Set<SnapshotListener>();
+  private readonly now: () => Date;
+  private readonly createEventId: () => string;
+  private readonly unsubscribeTransport: () => void;
+  private backendSession: RealtimeSessionStartResponse | null = null;
+  private muted = false;
+  private inputEnabled = false;
+  private userTranscript = '';
+  private assistantTranscript = '';
+  private providerConfigured = false;
+  private initialResponseRequested = false;
+  private readonly persistedMessageIds = new Set<string>();
+  private endPromise: Promise<unknown> | null = null;
+  private learnerTurnNo = 0;
+  private sceneState: ScenarioDialogueState | null = null;
+  private completion: DialogueCompletion | null = null;
+  private sceneCompletionPending = false;
+
+  constructor(
+    private readonly dependencies: RealtimeSessionDependencies,
+    private readonly options: RealtimeSessionOptions,
+  ) {
+    this.now = dependencies.now ?? (() => new Date());
+    this.createEventId =
+      dependencies.createEventId ??
+      (() => `event_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    this.unsubscribeTransport = dependencies.transport.subscribe((event) => {
+      void this.handleTransportEvent(event);
+    });
+  }
+
+  getSnapshot(): RealtimeSessionSnapshot {
+    return {
+      state: this.machine.state,
+      muted: this.muted,
+      sessionId: this.backendSession?.sessionId ?? null,
+      userTranscript: this.userTranscript,
+      assistantTranscript: this.assistantTranscript,
+      error: this.machine.error,
+      sceneState: this.sceneState,
+      completion: this.completion,
+    };
+  }
+
+  subscribe(listener: SnapshotListener) {
+    this.listeners.add(listener);
+    listener(this.getSnapshot());
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async start() {
+    if (this.machine.state === 'ended' || this.machine.state === 'error') {
+      this.machine.dispatch({ type: 'RESET' });
+    }
+    this.resetSessionValues();
+    let failureCode: RealtimeErrorCode = 'MEDIA_PREPARATION_FAILED';
+    try {
+      this.transition({ type: 'START' });
+      await this.dependencies.transport.prepare();
+      this.dependencies.transport.setAudioEnabled(false);
+      this.transition({ type: 'PERMISSION_GRANTED' });
+
+      failureCode = 'OFFER_CREATION_FAILED';
+      const offerSdp = await this.dependencies.transport.createOffer();
+      this.transition({ type: 'OFFER_CREATED' });
+
+      failureCode = 'SDP_EXCHANGE_FAILED';
+      const backend = await this.dependencies.sessionApi.start({
+        sceneId: this.options.sceneId ?? null,
+        offerSdp,
+        provider: 'QWEN',
+        model: this.options.model,
+        voice: this.options.voice,
+        translationEnabled: true,
+      });
+      if (!backend.answerSdp?.trim()) throw new Error('后端没有返回 Answer SDP');
+      if (!backend.systemPrompt?.trim()) throw new Error('后端没有返回会话提示词');
+      this.backendSession = backend;
+
+      failureCode = 'SESSION_SOCKET_FAILED';
+      await this.dependencies.sessionSocket.connect(backend.sessionId);
+
+      failureCode = 'ANSWER_APPLY_FAILED';
+      await this.dependencies.transport.applyAnswer(backend.answerSdp);
+      this.transition({ type: 'ANSWER_APPLIED' });
+
+      failureCode = 'DATA_CHANNEL_FAILED';
+      await this.dependencies.transport.waitForDataChannel();
+      this.publish();
+      return { sessionId: backend.sessionId };
+    } catch (error) {
+      this.inputEnabled = false;
+      this.dependencies.transport.setAudioEnabled(false);
+      this.dependencies.transport.close();
+      this.dependencies.sessionSocket.close();
+      this.machine.dispatch({
+        type: 'FAIL',
+        error: toRealtimeError(
+          failureCode,
+          error,
+          failureCode !== 'MEDIA_PREPARATION_FAILED',
+        ),
+      });
+      this.publish();
+      throw error;
+    }
+  }
+
+  async handleProviderMessage(data: string) {
+    let raw: unknown;
+    try {
+      raw = JSON.parse(data);
+    } catch {
+      return;
+    }
+    for (const event of normalizeQwenEvent(raw)) {
+      await this.applyProviderEvent(event);
+    }
+  }
+
+  setMuted(muted: boolean) {
+    this.muted = muted;
+    this.applyAudioEnabled();
+    this.publish();
+  }
+
+  interrupt() {
+    if (this.machine.state !== 'assistant_speaking') return;
+    this.dependencies.transport.sendProviderEvent({
+      event_id: this.createEventId(),
+      type: 'response.cancel',
+    });
+  }
+
+  end() {
+    if (!this.endPromise) {
+      this.endPromise = this.performEnd();
+    }
+    return this.endPromise;
+  }
+
+  private async handleTransportEvent(event: RealtimeTransportEvent) {
+    if (event.type === 'provider.message') {
+      await this.handleProviderMessage(event.data);
+      return;
+    }
+    const code: RealtimeErrorCode =
+      event.type === 'ice.failed'
+        ? 'ICE_FAILED'
+        : event.type === 'datachannel.failed'
+          ? 'DATA_CHANNEL_FAILED'
+          : 'PEER_CONNECTION_FAILED';
+    this.inputEnabled = false;
+    this.applyAudioEnabled();
+    this.machine.dispatch({
+      type: 'FAIL',
+      error: {
+        code,
+        message: event.message ?? '实时连接失败',
+        retryable: true,
+      },
+    });
+    this.publish();
+  }
+
+  private async applyProviderEvent(event: RealtimeDomainEvent) {
+    switch (event.type) {
+      case 'session.created':
+        if (!this.providerConfigured && this.backendSession) {
+          this.dependencies.transport.sendProviderEvent(
+            buildSessionUpdate(
+              this.createEventId(),
+              this.backendSession,
+              this.options,
+            ),
+          );
+          this.providerConfigured = true;
+        }
+        return;
+      case 'session.updated':
+        if (this.machine.state === 'connecting') {
+          this.transition({ type: 'CHANNEL_OPEN' });
+        }
+        if (!this.initialResponseRequested) {
+          this.dependencies.transport.sendProviderEvent({
+            event_id: this.createEventId(),
+            type: 'response.create',
+          });
+          this.initialResponseRequested = true;
+        }
+        this.inputEnabled = this.options.mode === 'free_chat';
+        this.applyAudioEnabled();
+        this.publish();
+        return;
+      case 'user.speech.started':
+        if (
+          this.machine.state === 'ready' ||
+          this.machine.state === 'assistant_speaking'
+        ) {
+          this.userTranscript = '';
+          this.assistantTranscript = '';
+          this.transition({ type: 'USER_SPEECH_STARTED' });
+        }
+        return;
+      case 'user.speech.stopped':
+        if (this.machine.state === 'user_speaking') {
+          this.transition({ type: 'USER_SPEECH_STOPPED' });
+        }
+        return;
+      case 'user.transcript.delta':
+        this.userTranscript += event.text;
+        this.publish();
+        return;
+      case 'user.transcript.preview':
+        this.userTranscript = event.text;
+        this.publish();
+        return;
+      case 'user.transcript.completed':
+        this.userTranscript = event.text;
+        this.publish();
+        await this.persistTranscript(1, event.text, event.itemId);
+        if (this.options.mode === 'scene') {
+          await this.coordinateSceneTurn(event.text);
+        }
+        return;
+      case 'assistant.response.started':
+        if (
+          this.machine.state === 'ready' ||
+          this.machine.state === 'user_speaking'
+        ) {
+          this.assistantTranscript = '';
+          this.transition({ type: 'ASSISTANT_SPEECH_STARTED' });
+        }
+        return;
+      case 'assistant.transcript.delta':
+        this.assistantTranscript += event.text;
+        this.publish();
+        return;
+      case 'assistant.transcript.completed':
+        this.assistantTranscript = event.text;
+        this.publish();
+        await this.persistTranscript(0, event.text, event.itemId);
+        return;
+      case 'assistant.response.completed':
+        if (this.machine.state === 'assistant_speaking') {
+          this.transition({ type: 'ASSISTANT_SPEECH_STOPPED' });
+        }
+        if (this.options.mode === 'scene') {
+          this.inputEnabled = true;
+          this.applyAudioEnabled();
+          if (this.sceneCompletionPending) {
+            await this.end();
+          }
+        }
+        return;
+      case 'provider.error':
+        this.inputEnabled = false;
+        this.applyAudioEnabled();
+        this.machine.dispatch({
+          type: 'FAIL',
+          error: {
+            code: 'PROVIDER_ERROR',
+            message: event.message,
+            retryable: true,
+          },
+        });
+        this.publish();
+        return;
+    }
+  }
+
+  private async persistTranscript(
+    owner: 0 | 1,
+    content: string,
+    providerMessageId?: string,
+  ) {
+    const messageId = providerMessageId ? `${owner}:${providerMessageId}` : null;
+    if (messageId && this.persistedMessageIds.has(messageId)) return;
+    if (messageId) this.persistedMessageIds.add(messageId);
+    try {
+      await this.dependencies.sessionSocket.persistMessage({
+        owner,
+        content,
+        providerMessageId,
+      });
+    } catch (error) {
+      if (messageId) this.persistedMessageIds.delete(messageId);
+      throw error;
+    }
+  }
+
+  private async performEnd() {
+    if (this.machine.state === 'ended') return null;
+    if (this.machine.state === 'idle') {
+      this.dependencies.transport.close();
+      this.dependencies.sessionSocket.close();
+      return null;
+    }
+    this.transition({ type: 'STOP' });
+    this.inputEnabled = false;
+    this.applyAudioEnabled();
+    let completion: unknown = null;
+    try {
+      if (this.backendSession) {
+        const stopTime = this.now().toISOString();
+        completion =
+          this.options.mode === 'scene' && this.dependencies.sceneDialogue
+            ? await this.dependencies.sceneDialogue.complete(
+                this.backendSession.sessionId,
+                stopTime,
+              )
+            : await this.dependencies.sessionSocket.end(stopTime);
+        if (completion && typeof completion === 'object' && 'sessionId' in completion) {
+          this.completion = completion as DialogueCompletion;
+        }
+      }
+      return completion;
+    } finally {
+      this.dependencies.transport.close();
+      this.dependencies.sessionSocket.close();
+      this.unsubscribeTransport();
+      if (this.machine.state === 'ending') {
+        this.transition({ type: 'ENDED' });
+      }
+    }
+  }
+
+  private applyAudioEnabled() {
+    const activeState =
+      this.machine.state === 'ready' || this.machine.state === 'user_speaking';
+    this.dependencies.transport.setAudioEnabled(
+      activeState && this.inputEnabled && !this.muted,
+    );
+  }
+
+  private async coordinateSceneTurn(transcript: string) {
+    const sessionId = this.backendSession?.sessionId;
+    const sceneDialogue = this.dependencies.sceneDialogue;
+    if (!sessionId || !sceneDialogue) {
+      throw new Error('场景对话服务尚未配置');
+    }
+    this.inputEnabled = false;
+    this.applyAudioEnabled();
+    const turnNo = ++this.learnerTurnNo;
+    const evaluation = sceneDialogue
+      .evaluateTurn(sessionId, turnNo, transcript)
+      .catch(() => null);
+    const state = await sceneDialogue.advanceState(
+      sessionId,
+      turnNo,
+      transcript,
+    );
+    await evaluation;
+    this.sceneState = state;
+    this.sceneCompletionPending = state.completed;
+    this.publish();
+
+    if (state.controlInstruction?.trim() && this.backendSession) {
+      const update = buildSessionUpdate(
+        this.createEventId(),
+        this.backendSession,
+        this.options,
+      );
+      update.session.instructions = [
+        update.session.instructions,
+        state.controlInstruction.trim(),
+      ]
+        .filter(Boolean)
+        .join('\n\n');
+      this.dependencies.transport.sendProviderEvent(update);
+    }
+    this.dependencies.transport.sendProviderEvent({
+      event_id: this.createEventId(),
+      type: 'response.create',
+    });
+  }
+
+  private transition(event: Parameters<RealtimeStateMachine['dispatch']>[0]) {
+    this.machine.dispatch(event);
+    this.publish();
+  }
+
+  private publish() {
+    const snapshot = this.getSnapshot();
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+
+  private resetSessionValues() {
+    this.backendSession = null;
+    this.userTranscript = '';
+    this.assistantTranscript = '';
+    this.providerConfigured = false;
+    this.initialResponseRequested = false;
+    this.inputEnabled = false;
+    this.persistedMessageIds.clear();
+    this.endPromise = null;
+    this.learnerTurnNo = 0;
+    this.sceneState = null;
+    this.completion = null;
+    this.sceneCompletionPending = false;
+  }
+}

--- a/frontend/mobile/src/features/realtime/RealtimeStateMachine.ts
+++ b/frontend/mobile/src/features/realtime/RealtimeStateMachine.ts
@@ -1,0 +1,92 @@
+import type { RealtimeError, RealtimeState } from './types';
+
+export type RealtimeStateEvent =
+  | { type: 'START' }
+  | { type: 'PERMISSION_GRANTED' }
+  | { type: 'OFFER_CREATED' }
+  | { type: 'ANSWER_APPLIED' }
+  | { type: 'CHANNEL_OPEN' }
+  | { type: 'USER_SPEECH_STARTED' }
+  | { type: 'USER_SPEECH_STOPPED' }
+  | { type: 'ASSISTANT_SPEECH_STARTED' }
+  | { type: 'ASSISTANT_SPEECH_STOPPED' }
+  | { type: 'PAUSE' }
+  | { type: 'RESUME' }
+  | { type: 'STOP' }
+  | { type: 'ENDED' }
+  | { type: 'RESET' }
+  | { type: 'FAIL'; error: RealtimeError };
+
+const transitions: Partial<
+  Record<RealtimeState, Partial<Record<RealtimeStateEvent['type'], RealtimeState>>>
+> = {
+  idle: { START: 'requesting_permission' },
+  requesting_permission: {
+    PERMISSION_GRANTED: 'creating_offer',
+    STOP: 'ending',
+  },
+  creating_offer: { OFFER_CREATED: 'exchanging_sdp', STOP: 'ending' },
+  exchanging_sdp: { ANSWER_APPLIED: 'connecting', STOP: 'ending' },
+  connecting: { CHANNEL_OPEN: 'ready', STOP: 'ending' },
+  ready: {
+    USER_SPEECH_STARTED: 'user_speaking',
+    ASSISTANT_SPEECH_STARTED: 'assistant_speaking',
+    PAUSE: 'paused',
+    STOP: 'ending',
+  },
+  user_speaking: {
+    USER_SPEECH_STOPPED: 'ready',
+    ASSISTANT_SPEECH_STARTED: 'assistant_speaking',
+    PAUSE: 'paused',
+    STOP: 'ending',
+  },
+  assistant_speaking: {
+    USER_SPEECH_STARTED: 'user_speaking',
+    ASSISTANT_SPEECH_STOPPED: 'ready',
+    PAUSE: 'paused',
+    STOP: 'ending',
+  },
+  paused: { RESUME: 'ready', STOP: 'ending' },
+  ending: { ENDED: 'ended' },
+  ended: { RESET: 'idle' },
+  error: { RESET: 'idle', STOP: 'ending' },
+};
+
+export class RealtimeStateMachine {
+  private currentError: RealtimeError | null = null;
+
+  constructor(private currentState: RealtimeState = 'idle') {}
+
+  static ready() {
+    return new RealtimeStateMachine('ready');
+  }
+
+  get state() {
+    return this.currentState;
+  }
+
+  get error() {
+    return this.currentError;
+  }
+
+  dispatch(event: RealtimeStateEvent): RealtimeState {
+    if (this.currentState === 'ended' && event.type !== 'RESET') {
+      return this.currentState;
+    }
+    if (event.type === 'FAIL') {
+      this.currentError = event.error;
+      this.currentState = 'error';
+      return this.currentState;
+    }
+
+    const nextState = transitions[this.currentState]?.[event.type];
+    if (!nextState) {
+      throw new Error(`INVALID_TRANSITION:${this.currentState}:${event.type}`);
+    }
+    this.currentState = nextState;
+    if (event.type === 'RESET' || event.type === 'START') {
+      this.currentError = null;
+    }
+    return this.currentState;
+  }
+}

--- a/frontend/mobile/src/features/realtime/SessionMessageSocket.ts
+++ b/frontend/mobile/src/features/realtime/SessionMessageSocket.ts
@@ -1,0 +1,196 @@
+import type { TokenStore } from '@/infrastructure/auth/SecureTokenStore';
+
+import type { SessionMessage } from './RealtimeSessionController';
+
+export type SessionWebSocketLike = {
+  readyState: number;
+  onopen: (() => void) | null;
+  onmessage: ((event: { data: string }) => void) | null;
+  onerror: (() => void) | null;
+  onclose: (() => void) | null;
+  send(data: string): void;
+  close(): void;
+};
+
+type SessionSocketAck = {
+  type?: string;
+  success?: boolean;
+  code?: string;
+  message?: string;
+  sessionId?: string;
+};
+
+type PendingAck = {
+  operation: 'message' | 'end';
+  resolve: (ack: SessionSocketAck) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
+};
+
+export type SessionMessageSocketOptions = {
+  baseUrl: string;
+  tokenStore: Pick<TokenStore, 'get'>;
+  webSocketFactory?: (url: string) => SessionWebSocketLike;
+  connectTimeoutMs?: number;
+  ackTimeoutMs?: number;
+};
+
+export function sessionWebSocketUrl(baseUrl: string, accessToken: string) {
+  const normalizedBase = String(baseUrl).trim();
+  const url = new URL(normalizedBase.endsWith('/') ? normalizedBase : `${normalizedBase}/`);
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('后端地址必须使用 HTTP 或 HTTPS');
+  }
+  const basePath = url.pathname.replace(/\/$/, '');
+  url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
+  url.pathname = `${basePath}/ws/session-messages`.replace(/\/{2,}/g, '/');
+  url.search = '';
+  url.searchParams.set('access_token', accessToken);
+  url.hash = '';
+  return url.toString();
+}
+
+export class SessionMessageSocket {
+  private readonly webSocketFactory: (url: string) => SessionWebSocketLike;
+  private readonly connectTimeoutMs: number;
+  private readonly ackTimeoutMs: number;
+  private socket: SessionWebSocketLike | null = null;
+  private sessionId: string | null = null;
+  private pendingAcks: PendingAck[] = [];
+  private connectPromise: Promise<void> | null = null;
+
+  constructor(private readonly options: SessionMessageSocketOptions) {
+    this.webSocketFactory =
+      options.webSocketFactory ??
+      ((url) => new WebSocket(url) as unknown as SessionWebSocketLike);
+    this.connectTimeoutMs = options.connectTimeoutMs ?? 5_000;
+    this.ackTimeoutMs = options.ackTimeoutMs ?? 5_000;
+  }
+
+  async connect(sessionId: string) {
+    const normalizedSessionId = sessionId.trim();
+    if (!normalizedSessionId) throw new Error('会话 ID 尚未建立');
+    if (this.socket?.readyState === 1 && this.sessionId === normalizedSessionId) {
+      return;
+    }
+    if (this.connectPromise && this.sessionId === normalizedSessionId) {
+      return this.connectPromise;
+    }
+
+    const token = await this.options.tokenStore.get();
+    if (!token) throw new Error('请先登录后再建立会话 WebSocket');
+
+    this.close();
+    this.sessionId = normalizedSessionId;
+    const socket = this.webSocketFactory(
+      sessionWebSocketUrl(this.options.baseUrl, token),
+    );
+    this.socket = socket;
+    socket.onmessage = (event) => this.handleAck(event.data);
+    socket.onclose = () => {
+      this.rejectPendingAcks(new Error('会话 WebSocket 已关闭'));
+      this.connectPromise = null;
+    };
+
+    this.connectPromise = new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.connectPromise = null;
+        reject(new Error('会话 WebSocket 连接超时'));
+      }, this.connectTimeoutMs);
+      socket.onopen = () => {
+        clearTimeout(timer);
+        this.connectPromise = null;
+        resolve();
+      };
+      socket.onerror = () => {
+        clearTimeout(timer);
+        this.connectPromise = null;
+        reject(new Error('会话 WebSocket 连接失败'));
+      };
+    });
+    return this.connectPromise;
+  }
+
+  async persistMessage(message: SessionMessage) {
+    const content = message.content.trim();
+    if (!content) return;
+    await this.sendFrame('message', {
+      owner: message.owner,
+      content,
+      audio: null,
+    });
+  }
+
+  end(stopTime: string) {
+    return this.sendFrame('end', null, stopTime);
+  }
+
+  close() {
+    const socket = this.socket;
+    this.socket = null;
+    this.sessionId = null;
+    this.connectPromise = null;
+    this.rejectPendingAcks(new Error('会话 WebSocket 已关闭'));
+    if (socket && socket.readyState < 2) {
+      socket.close();
+    }
+  }
+
+  private async sendFrame(
+    type: 'message' | 'end',
+    message: { owner: 0 | 1; content: string; audio: null } | null,
+    stopTime: string | null = null,
+  ) {
+    const socket = this.socket;
+    const sessionId = this.sessionId;
+    if (!sessionId) throw new Error('会话 ID 尚未建立');
+    if (!socket || socket.readyState !== 1) {
+      throw new Error('会话 WebSocket 尚未连接');
+    }
+
+    const ack = new Promise<SessionSocketAck>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pendingAcks = this.pendingAcks.filter(
+          (pending) => pending.resolve !== resolve,
+        );
+        reject(new Error(`等待 session.${type}.accepted 超时`));
+      }, this.ackTimeoutMs);
+      this.pendingAcks.push({ operation: type, resolve, reject, timer });
+    });
+    socket.send(
+      JSON.stringify({ type, sessionId, message, stopTime }),
+    );
+    return ack;
+  }
+
+  private handleAck(data: string) {
+    let ack: SessionSocketAck;
+    try {
+      ack = JSON.parse(data) as SessionSocketAck;
+    } catch {
+      return;
+    }
+    const operation = String(ack.type ?? '').split('.')[1];
+    const index = this.pendingAcks.findIndex(
+      (pending) => pending.operation === operation,
+    );
+    if (index < 0) return;
+    const [pending] = this.pendingAcks.splice(index, 1);
+    clearTimeout(pending.timer);
+    if (ack.success) {
+      pending.resolve(ack);
+    } else {
+      pending.reject(
+        new Error(ack.message || ack.code || '会话消息处理失败'),
+      );
+    }
+  }
+
+  private rejectPendingAcks(error: Error) {
+    const pending = this.pendingAcks.splice(0);
+    pending.forEach((ack) => {
+      clearTimeout(ack.timer);
+      ack.reject(error);
+    });
+  }
+}

--- a/frontend/mobile/src/features/realtime/__tests__/QwenEventNormalizer.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/QwenEventNormalizer.test.ts
@@ -1,0 +1,140 @@
+import { normalizeQwenEvent } from '../QwenEventNormalizer';
+
+describe('normalizeQwenEvent', () => {
+  it('normalizes session and speech lifecycle events', () => {
+    expect(normalizeQwenEvent({ type: 'session.created' })).toEqual([
+      { type: 'session.created' },
+    ]);
+    expect(normalizeQwenEvent({ type: 'session.updated' })).toEqual([
+      { type: 'session.updated' },
+    ]);
+    expect(normalizeQwenEvent({ type: 'input_audio_buffer.speech_started' })).toEqual([
+      { type: 'user.speech.started' },
+    ]);
+    expect(normalizeQwenEvent({ type: 'input_audio_buffer.speech_stopped' })).toEqual([
+      { type: 'user.speech.stopped' },
+    ]);
+  });
+
+  it('normalizes the completed user transcript with its provider item id', () => {
+    expect(
+      normalizeQwenEvent({
+        type: 'conversation.item.input_audio_transcription.completed',
+        item_id: 'user-item-1',
+        transcript: 'I would like a latte.',
+      }),
+    ).toEqual([
+      {
+        type: 'user.transcript.completed',
+        itemId: 'user-item-1',
+        text: 'I would like a latte.',
+      },
+    ]);
+  });
+
+  it('normalizes live user transcript delta and text preview events', () => {
+    expect(
+      normalizeQwenEvent({
+        type: 'conversation.item.input_audio_transcription.delta',
+        item_id: 'user-item-live',
+        delta: 'I would ',
+      }),
+    ).toEqual([
+      {
+        type: 'user.transcript.delta',
+        itemId: 'user-item-live',
+        text: 'I would ',
+      },
+    ]);
+    expect(
+      normalizeQwenEvent({
+        type: 'conversation.item.input_audio_transcription.delta',
+        item_id: 'user-item-live',
+        text: 'I would like',
+        stash: ' a latte',
+      }),
+    ).toEqual([
+      {
+        type: 'user.transcript.preview',
+        itemId: 'user-item-live',
+        text: 'I would like a latte',
+      },
+    ]);
+    expect(
+      normalizeQwenEvent({
+        type: 'conversation.item.input_audio_transcription.text',
+        item_id: 'user-item-live',
+        text: 'I would like',
+        stash: ' a latte',
+      }),
+    ).toEqual([
+      {
+        type: 'user.transcript.preview',
+        itemId: 'user-item-live',
+        text: 'I would like a latte',
+      },
+    ]);
+  });
+
+  it('normalizes assistant transcript deltas and direct completion events', () => {
+    expect(
+      normalizeQwenEvent({ type: 'response.audio_transcript.delta', delta: 'Good ' }),
+    ).toEqual([{ type: 'assistant.transcript.delta', text: 'Good ' }]);
+    expect(
+      normalizeQwenEvent({
+        type: 'response.audio_transcript.done',
+        item_id: 'assistant-item-1',
+        transcript: 'Good morning!',
+      }),
+    ).toEqual([
+      {
+        type: 'assistant.transcript.completed',
+        itemId: 'assistant-item-1',
+        text: 'Good morning!',
+      },
+    ]);
+  });
+
+  it('extracts an assistant completion nested in response.done output', () => {
+    expect(
+      normalizeQwenEvent({
+        type: 'response.done',
+        response: {
+          id: 'response-1',
+          status: 'completed',
+          output: [
+            {
+              id: 'assistant-item-2',
+              role: 'assistant',
+              content: [{ transcript: 'What would you like to drink?' }],
+            },
+          ],
+        },
+      }),
+    ).toEqual([
+      {
+        type: 'assistant.transcript.completed',
+        itemId: 'assistant-item-2',
+        text: 'What would you like to drink?',
+      },
+      { type: 'assistant.response.completed', cancelled: false },
+    ]);
+  });
+
+  it('normalizes provider errors and ignores malformed payloads', () => {
+    expect(
+      normalizeQwenEvent({
+        type: 'error',
+        error: { code: 'provider_busy', message: 'Please retry later.' },
+      }),
+    ).toEqual([
+      {
+        type: 'provider.error',
+        code: 'provider_busy',
+        message: 'Please retry later.',
+      },
+    ]);
+    expect(normalizeQwenEvent('not-an-object')).toEqual([]);
+    expect(normalizeQwenEvent({ type: 'unknown.event' })).toEqual([]);
+  });
+});

--- a/frontend/mobile/src/features/realtime/__tests__/ReactNativeWebRTCTransport.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/ReactNativeWebRTCTransport.test.ts
@@ -1,0 +1,154 @@
+import {
+  ReactNativeWebRTCTransport,
+  type MediaStreamLike,
+  type MediaStreamTrackLike,
+  type PeerConnectionLike,
+  type RTCDataChannelLike,
+} from '../ReactNativeWebRTCTransport';
+
+class FakeDataChannel implements RTCDataChannelLike {
+  readyState: 'connecting' | 'open' | 'closing' | 'closed' = 'connecting';
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  send = jest.fn();
+  close = jest.fn(() => {
+    this.readyState = 'closed';
+  });
+
+  open() {
+    this.readyState = 'open';
+    this.onopen?.();
+  }
+}
+
+function createFixture() {
+  const track: MediaStreamTrackLike = {
+    enabled: true,
+    stop: jest.fn(),
+  };
+  const stream: MediaStreamLike = {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  };
+  const channel = new FakeDataChannel();
+  const peer: PeerConnectionLike = {
+    iceGatheringState: 'complete',
+    connectionState: 'new',
+    iceConnectionState: 'new',
+    localDescription: null,
+    onicegatheringstatechange: null,
+    onconnectionstatechange: null,
+    oniceconnectionstatechange: null,
+    ondatachannel: null,
+    addTrack: jest.fn(),
+    createDataChannel: jest.fn(() => channel),
+    createOffer: jest.fn(async () => ({ type: 'offer' as const, sdp: 'offer\nsdp' })),
+    setLocalDescription: jest.fn(async (description) => {
+      peer.localDescription = description;
+    }),
+    setRemoteDescription: jest.fn(async () => undefined),
+    close: jest.fn(),
+  };
+  const adapter = {
+    getUserMedia: jest.fn(async () => stream),
+    createPeerConnection: jest.fn(() => peer),
+    createSessionDescription: jest.fn((description) => description),
+  };
+  return { track, stream, channel, peer, adapter };
+}
+
+describe('ReactNativeWebRTCTransport', () => {
+  it('prepares a disabled microphone track with mobile speech constraints', async () => {
+    const fixture = createFixture();
+    const transport = new ReactNativeWebRTCTransport(fixture.adapter);
+
+    await transport.prepare();
+
+    expect(fixture.adapter.getUserMedia).toHaveBeenCalledWith({
+      audio: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+      },
+      video: false,
+    });
+    expect(fixture.peer.addTrack).toHaveBeenCalledWith(
+      fixture.track,
+      fixture.stream,
+    );
+    expect(fixture.track.enabled).toBe(false);
+    expect(fixture.peer.createDataChannel).toHaveBeenCalledWith('oai-events');
+  });
+
+  it('returns the gathered local SDP and applies a normalized answer', async () => {
+    const fixture = createFixture();
+    const transport = new ReactNativeWebRTCTransport(fixture.adapter);
+    await transport.prepare();
+
+    await expect(transport.createOffer()).resolves.toBe('offer\nsdp');
+    await transport.applyAnswer('answer\nsdp');
+
+    expect(fixture.peer.setRemoteDescription).toHaveBeenCalledWith({
+      type: 'answer',
+      sdp: 'answer\r\nsdp\r\n',
+    });
+  });
+
+  it('waits for the data channel, sends provider JSON and emits provider messages', async () => {
+    const fixture = createFixture();
+    const transport = new ReactNativeWebRTCTransport(fixture.adapter);
+    const events: unknown[] = [];
+    transport.subscribe((event) => events.push(event));
+    await transport.prepare();
+
+    const waiting = transport.waitForDataChannel();
+    fixture.channel.open();
+    await waiting;
+    transport.sendProviderEvent({ type: 'session.update' });
+    fixture.channel.onmessage?.({ data: '{"type":"session.updated"}' });
+
+    expect(fixture.channel.send).toHaveBeenCalledWith(
+      '{"type":"session.update"}',
+    );
+    expect(events).toContainEqual({
+      type: 'provider.message',
+      data: '{"type":"session.updated"}',
+    });
+  });
+
+  it('accepts a provider-created channel and reports connection failures', async () => {
+    const fixture = createFixture();
+    const incomingChannel = new FakeDataChannel();
+    const transport = new ReactNativeWebRTCTransport(fixture.adapter);
+    const events: unknown[] = [];
+    transport.subscribe((event) => events.push(event));
+    await transport.prepare();
+
+    fixture.peer.ondatachannel?.({ channel: incomingChannel });
+    incomingChannel.open();
+    fixture.peer.connectionState = 'failed';
+    fixture.peer.onconnectionstatechange?.();
+
+    await expect(transport.waitForDataChannel()).resolves.toBeUndefined();
+    expect(events).toContainEqual({
+      type: 'connection.failed',
+      message: 'WebRTC 连接失败',
+    });
+  });
+
+  it('toggles and then releases every native resource exactly once', async () => {
+    const fixture = createFixture();
+    const transport = new ReactNativeWebRTCTransport(fixture.adapter);
+    await transport.prepare();
+
+    transport.setAudioEnabled(true);
+    expect(fixture.track.enabled).toBe(true);
+    transport.close();
+    transport.close();
+
+    expect(fixture.track.stop).toHaveBeenCalledTimes(1);
+    expect(fixture.channel.close).toHaveBeenCalledTimes(1);
+    expect(fixture.peer.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionApi.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionApi.test.ts
@@ -1,0 +1,48 @@
+import { RealtimeSessionApi } from '../RealtimeSessionApi';
+
+describe('RealtimeSessionApi', () => {
+  it('starts free chat with the existing Java endpoint and body', async () => {
+    const client = { request: jest.fn(async () => ({ sessionId: 'session-1' })) };
+    const api = new RealtimeSessionApi(client);
+
+    await api.start({
+      sceneId: null,
+      offerSdp: 'offer-sdp',
+      provider: 'QWEN',
+      model: 'qwen3.5-omni-flash-realtime',
+      voice: 'Harvey',
+      translationEnabled: true,
+    });
+
+    expect(client.request).toHaveBeenCalledWith('/api/scene-sessions', {
+      method: 'POST',
+      body: JSON.stringify({
+        offerSdp: 'offer-sdp',
+        provider: 'QWEN',
+        model: 'qwen3.5-omni-flash-realtime',
+        voice: 'Harvey',
+        translationEnabled: true,
+      }),
+      timeoutMs: 20_000,
+    });
+  });
+
+  it('starts scene conversation with the encoded scene endpoint', async () => {
+    const client = { request: jest.fn(async () => ({ sessionId: 'session-1' })) };
+    const api = new RealtimeSessionApi(client);
+
+    await api.start({
+      sceneId: 'scene/with space',
+      offerSdp: 'offer-sdp',
+      provider: 'QWEN',
+      model: 'qwen3.5-omni-flash-realtime',
+      voice: 'Harvey',
+      translationEnabled: true,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/custom-scenes/scene%2Fwith%20space/sessions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+});

--- a/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionController.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionController.test.ts
@@ -1,0 +1,334 @@
+import {
+  RealtimeSessionController,
+  type RealtimeSessionDependencies,
+  type RealtimeTransportEvent,
+} from '../RealtimeSessionController';
+
+function createDependencies(): RealtimeSessionDependencies & {
+  transport: RealtimeSessionDependencies['transport'] & {
+    emit(event: RealtimeTransportEvent): void;
+    prepare: jest.Mock;
+    createOffer: jest.Mock;
+    applyAnswer: jest.Mock;
+    waitForDataChannel: jest.Mock;
+    sendProviderEvent: jest.Mock;
+    setAudioEnabled: jest.Mock;
+    close: jest.Mock;
+  };
+  sessionApi: RealtimeSessionDependencies['sessionApi'] & {
+    start: jest.Mock;
+  };
+  sessionSocket: RealtimeSessionDependencies['sessionSocket'] & {
+    connect: jest.Mock;
+    persistMessage: jest.Mock;
+    end: jest.Mock;
+    close: jest.Mock;
+  };
+} {
+  let listener: ((event: RealtimeTransportEvent) => void) | null = null;
+  const transport = {
+    subscribe: jest.fn((nextListener: (event: RealtimeTransportEvent) => void) => {
+      listener = nextListener;
+      return () => {
+        listener = null;
+      };
+    }),
+    prepare: jest.fn(async () => undefined),
+    createOffer: jest.fn(async () => 'offer-sdp'),
+    applyAnswer: jest.fn(async () => undefined),
+    waitForDataChannel: jest.fn(async () => undefined),
+    sendProviderEvent: jest.fn(),
+    setAudioEnabled: jest.fn(),
+    close: jest.fn(),
+    emit(event: RealtimeTransportEvent) {
+      listener?.(event);
+    },
+  };
+  return {
+    transport,
+    sessionApi: {
+      start: jest.fn(async () => ({
+        sessionId: 'session-1',
+        answerSdp: 'answer-sdp',
+        voiceId: 'Harvey',
+        systemPrompt: 'You are the configured UniSpeaking teacher.',
+      })),
+    },
+    sessionSocket: {
+      connect: jest.fn(async () => undefined),
+      persistMessage: jest.fn(async () => undefined),
+      end: jest.fn(async () => undefined),
+      close: jest.fn(),
+    },
+    now: () => new Date('2026-08-05T06:00:00.000Z'),
+    createEventId: () => 'event-1',
+  };
+}
+
+describe('RealtimeSessionController', () => {
+  it('exchanges SDP through Java and waits for provider configuration before listening', async () => {
+    const dependencies = createDependencies();
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+
+    await controller.start();
+
+    expect(dependencies.sessionApi.start).toHaveBeenCalledWith({
+      sceneId: null,
+      offerSdp: 'offer-sdp',
+      provider: 'QWEN',
+      model: 'qwen3.5-omni-flash-realtime',
+      voice: 'Harvey',
+      translationEnabled: true,
+    });
+    expect(dependencies.transport.applyAnswer).toHaveBeenCalledWith('answer-sdp');
+    expect(dependencies.sessionSocket.connect).toHaveBeenCalledWith('session-1');
+    expect(controller.getSnapshot().state).toBe('connecting');
+
+    await controller.handleProviderMessage(JSON.stringify({ type: 'session.created' }));
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'session.update',
+        session: expect.objectContaining({
+          voice: 'Harvey',
+          instructions: expect.stringContaining('configured UniSpeaking teacher'),
+        }),
+      }),
+    );
+
+    await controller.handleProviderMessage(JSON.stringify({ type: 'session.updated' }));
+    expect(controller.getSnapshot().state).toBe('ready');
+    expect(dependencies.transport.setAudioEnabled).toHaveBeenLastCalledWith(true);
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'response.create' }),
+    );
+  });
+
+  it('publishes and persists completed user and assistant transcripts', async () => {
+    const dependencies = createDependencies();
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+    await controller.start();
+
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.completed',
+        item_id: 'user-1',
+        transcript: 'I would like a latte.',
+      }),
+    );
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'response.audio_transcript.done',
+        item_id: 'assistant-1',
+        transcript: 'Would you like oat milk?',
+      }),
+    );
+
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        userTranscript: 'I would like a latte.',
+        assistantTranscript: 'Would you like oat milk?',
+      }),
+    );
+    expect(dependencies.sessionSocket.persistMessage).toHaveBeenNthCalledWith(1, {
+      owner: 1,
+      content: 'I would like a latte.',
+      providerMessageId: 'user-1',
+    });
+    expect(dependencies.sessionSocket.persistMessage).toHaveBeenNthCalledWith(2, {
+      owner: 0,
+      content: 'Would you like oat milk?',
+      providerMessageId: 'assistant-1',
+    });
+  });
+
+  it('publishes live learner subtitles and clears the previous AI turn when speech starts', async () => {
+    const dependencies = createDependencies();
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+    await controller.start();
+    await controller.handleProviderMessage(JSON.stringify({ type: 'session.updated' }));
+    await controller.handleProviderMessage(JSON.stringify({ type: 'response.created' }));
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'response.audio_transcript.done',
+        item_id: 'assistant-previous',
+        transcript: 'What would you like to order?',
+      }),
+    );
+    await controller.handleProviderMessage(
+      JSON.stringify({ type: 'response.done', response: { status: 'completed' } }),
+    );
+
+    await controller.handleProviderMessage(
+      JSON.stringify({ type: 'input_audio_buffer.speech_started' }),
+    );
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        state: 'user_speaking',
+        userTranscript: '',
+        assistantTranscript: '',
+      }),
+    );
+
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.delta',
+        item_id: 'user-live',
+        delta: 'I would ',
+      }),
+    );
+    expect(controller.getSnapshot().userTranscript).toBe('I would ');
+
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.text',
+        item_id: 'user-live',
+        text: 'I would like',
+        stash: ' a latte',
+      }),
+    );
+    expect(controller.getSnapshot().userTranscript).toBe('I would like a latte');
+    expect(dependencies.sessionSocket.persistMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it('mutes the local track and sends a response cancellation when interrupted', async () => {
+    const dependencies = createDependencies();
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+    await controller.start();
+    await controller.handleProviderMessage(JSON.stringify({ type: 'session.updated' }));
+    controller.setMuted(true);
+    await controller.handleProviderMessage(JSON.stringify({ type: 'response.created' }));
+    controller.interrupt();
+
+    expect(dependencies.transport.setAudioEnabled).toHaveBeenLastCalledWith(false);
+    expect(controller.getSnapshot().muted).toBe(true);
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith({
+      event_id: 'event-1',
+      type: 'response.cancel',
+    });
+  });
+
+  it('ends once and cleans all native resources even when called twice', async () => {
+    const dependencies = createDependencies();
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+    await controller.start();
+
+    await Promise.all([controller.end(), controller.end()]);
+
+    expect(dependencies.sessionSocket.end).toHaveBeenCalledWith(
+      '2026-08-05T06:00:00.000Z',
+    );
+    expect(dependencies.sessionSocket.end).toHaveBeenCalledTimes(1);
+    expect(dependencies.transport.close).toHaveBeenCalledTimes(1);
+    expect(dependencies.sessionSocket.close).toHaveBeenCalledTimes(1);
+    expect(controller.getSnapshot().state).toBe('ended');
+  });
+
+  it('classifies offer creation failure and closes partial resources', async () => {
+    const dependencies = createDependencies();
+    dependencies.transport.createOffer.mockRejectedValue(new Error('offer failed'));
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'free_chat',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+
+    await expect(controller.start()).rejects.toThrow('offer failed');
+
+    expect(dependencies.transport.close).toHaveBeenCalledTimes(1);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        state: 'error',
+        error: expect.objectContaining({ code: 'OFFER_CREATION_FAILED' }),
+      }),
+    );
+  });
+
+  it('coordinates each scene transcript and applies the backend control instruction once', async () => {
+    const dependencies = createDependencies();
+    const sceneDialogue = {
+      advanceState: jest.fn(async () => ({
+        sceneId: 'scene-1',
+        sessionId: 'session-1',
+        stage: 'CORE_TASK',
+        effectiveUserTurns: 1,
+        maximumUserTurns: 6,
+        outcomes: [],
+        completed: false,
+        completionReason: null,
+        controlInstruction: 'Ask the learner to confirm the final price.',
+        warning: null,
+      })),
+      evaluateTurn: jest.fn(async () => ({ score: 86 })),
+      complete: jest.fn(async () => null),
+    };
+    dependencies.sceneDialogue = sceneDialogue;
+    const controller = new RealtimeSessionController(dependencies, {
+      mode: 'scene',
+      sceneId: 'scene-1',
+      voice: 'Harvey',
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: 'NATURAL',
+    });
+    await controller.start();
+    await controller.handleProviderMessage(JSON.stringify({ type: 'session.updated' }));
+
+    await controller.handleProviderMessage(
+      JSON.stringify({
+        type: 'conversation.item.input_audio_transcription.completed',
+        item_id: 'user-turn-1',
+        transcript: 'How much is the total?',
+      }),
+    );
+
+    expect(sceneDialogue.advanceState).toHaveBeenCalledWith(
+      'session-1',
+      1,
+      'How much is the total?',
+    );
+    expect(sceneDialogue.evaluateTurn).toHaveBeenCalledWith(
+      'session-1',
+      1,
+      'How much is the total?',
+    );
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'session.update',
+        session: expect.objectContaining({
+          instructions: expect.stringContaining('confirm the final price'),
+        }),
+      }),
+    );
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'response.create' }),
+    );
+    expect(controller.getSnapshot().sceneState).toEqual(
+      expect.objectContaining({ effectiveUserTurns: 1, completed: false }),
+    );
+  });
+});

--- a/frontend/mobile/src/features/realtime/__tests__/RealtimeStateMachine.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/RealtimeStateMachine.test.ts
@@ -1,0 +1,54 @@
+import { RealtimeStateMachine } from '../RealtimeStateMachine';
+
+describe('RealtimeStateMachine', () => {
+  it('follows the complete WebRTC connection lifecycle', () => {
+    const machine = new RealtimeStateMachine();
+
+    expect(machine.dispatch({ type: 'START' })).toBe('requesting_permission');
+    expect(machine.dispatch({ type: 'PERMISSION_GRANTED' })).toBe('creating_offer');
+    expect(machine.dispatch({ type: 'OFFER_CREATED' })).toBe('exchanging_sdp');
+    expect(machine.dispatch({ type: 'ANSWER_APPLIED' })).toBe('connecting');
+    expect(machine.dispatch({ type: 'CHANNEL_OPEN' })).toBe('ready');
+  });
+
+  it('tracks user speech, assistant speech, pause and resume', () => {
+    const machine = RealtimeStateMachine.ready();
+
+    expect(machine.dispatch({ type: 'USER_SPEECH_STARTED' })).toBe('user_speaking');
+    expect(machine.dispatch({ type: 'USER_SPEECH_STOPPED' })).toBe('ready');
+    expect(machine.dispatch({ type: 'ASSISTANT_SPEECH_STARTED' })).toBe('assistant_speaking');
+    expect(machine.dispatch({ type: 'PAUSE' })).toBe('paused');
+    expect(machine.dispatch({ type: 'RESUME' })).toBe('ready');
+  });
+
+  it('ends idempotently and ignores provider events after ending', () => {
+    const machine = RealtimeStateMachine.ready();
+
+    expect(machine.dispatch({ type: 'STOP' })).toBe('ending');
+    expect(machine.dispatch({ type: 'ENDED' })).toBe('ended');
+    expect(machine.dispatch({ type: 'USER_SPEECH_STARTED' })).toBe('ended');
+    expect(machine.dispatch({ type: 'STOP' })).toBe('ended');
+  });
+
+  it('records a typed failure and can reset for one clean retry', () => {
+    const machine = new RealtimeStateMachine();
+
+    expect(
+      machine.dispatch({
+        type: 'FAIL',
+        error: { code: 'MICROPHONE_DENIED', message: '请允许麦克风权限', retryable: false },
+      }),
+    ).toBe('error');
+    expect(machine.error?.code).toBe('MICROPHONE_DENIED');
+    expect(machine.dispatch({ type: 'RESET' })).toBe('idle');
+    expect(machine.error).toBeNull();
+  });
+
+  it('rejects an invalid transition before a session is ready', () => {
+    const machine = new RealtimeStateMachine();
+
+    expect(() => machine.dispatch({ type: 'ASSISTANT_SPEECH_STARTED' })).toThrow(
+      'INVALID_TRANSITION:idle:ASSISTANT_SPEECH_STARTED',
+    );
+  });
+});

--- a/frontend/mobile/src/features/realtime/__tests__/SessionMessageSocket.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/SessionMessageSocket.test.ts
@@ -1,0 +1,140 @@
+import {
+  SessionMessageSocket,
+  sessionWebSocketUrl,
+  type SessionWebSocketLike,
+} from '../SessionMessageSocket';
+
+class FakeWebSocket implements SessionWebSocketLike {
+  static readonly CONNECTING = 0;
+  static readonly OPEN = 1;
+
+  readyState = FakeWebSocket.CONNECTING;
+  onopen: (() => void) | null = null;
+  onmessage: ((event: { data: string }) => void) | null = null;
+  onerror: (() => void) | null = null;
+  onclose: (() => void) | null = null;
+  readonly sent: string[] = [];
+  close = jest.fn(() => {
+    this.readyState = 3;
+    this.onclose?.();
+  });
+
+  send(data: string) {
+    this.sent.push(data);
+  }
+
+  open() {
+    this.readyState = FakeWebSocket.OPEN;
+    this.onopen?.();
+  }
+
+  message(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) });
+  }
+}
+
+describe('sessionWebSocketUrl', () => {
+  it('maps HTTP to an authenticated WebSocket URL and preserves a base path', () => {
+    expect(
+      sessionWebSocketUrl('https://api.example.com/backend/', 'signed token/+'),
+    ).toBe(
+      'wss://api.example.com/backend/ws/session-messages?access_token=signed+token%2F%2B',
+    );
+  });
+});
+
+describe('SessionMessageSocket', () => {
+  it('requires a saved access token before connecting', async () => {
+    const socket = new SessionMessageSocket({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: { get: async () => null },
+      webSocketFactory: jest.fn(),
+    });
+
+    await expect(socket.connect('session-1')).rejects.toThrow(
+      '请先登录后再建立会话 WebSocket',
+    );
+  });
+
+  it('persists a transcript and resolves only after the matching accepted ACK', async () => {
+    const nativeSocket = new FakeWebSocket();
+    const socket = new SessionMessageSocket({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: { get: async () => 'jwt-token' },
+      webSocketFactory: jest.fn(() => nativeSocket),
+    });
+
+    const connecting = socket.connect('session-1');
+    await Promise.resolve();
+    nativeSocket.open();
+    await connecting;
+    const pending = socket.persistMessage({
+      owner: 1,
+      content: '  Hello there.  ',
+      providerMessageId: 'provider-1',
+    });
+
+    expect(JSON.parse(nativeSocket.sent[0])).toEqual({
+      type: 'message',
+      sessionId: 'session-1',
+      message: { owner: 1, content: 'Hello there.', audio: null },
+      stopTime: null,
+    });
+    nativeSocket.message({
+      type: 'session.message.accepted',
+      success: true,
+      sessionId: 'session-1',
+    });
+    await expect(pending).resolves.toBeUndefined();
+  });
+
+  it('sends the stop timestamp and rejects a backend failure ACK', async () => {
+    const nativeSocket = new FakeWebSocket();
+    const socket = new SessionMessageSocket({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: { get: async () => 'jwt-token' },
+      webSocketFactory: () => nativeSocket,
+    });
+    const connecting = socket.connect('session-1');
+    await Promise.resolve();
+    nativeSocket.open();
+    await connecting;
+
+    const pending = socket.end('2026-08-05T08:00:00.000Z');
+    expect(JSON.parse(nativeSocket.sent[0])).toEqual({
+      type: 'end',
+      sessionId: 'session-1',
+      message: null,
+      stopTime: '2026-08-05T08:00:00.000Z',
+    });
+    nativeSocket.message({
+      type: 'session.end.failed',
+      success: false,
+      code: 'SESSION_SOCKET_ERROR',
+      message: 'session already ended',
+    });
+
+    await expect(pending).rejects.toThrow('session already ended');
+  });
+
+  it('rejects pending acknowledgements when the socket closes', async () => {
+    const nativeSocket = new FakeWebSocket();
+    const socket = new SessionMessageSocket({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: { get: async () => 'jwt-token' },
+      webSocketFactory: () => nativeSocket,
+    });
+    const connecting = socket.connect('session-1');
+    await Promise.resolve();
+    nativeSocket.open();
+    await connecting;
+
+    const pending = socket.persistMessage({ owner: 0, content: 'Welcome.' });
+    socket.close();
+
+    await expect(pending).rejects.toThrow('会话 WebSocket 已关闭');
+    expect(nativeSocket.close).toHaveBeenCalledTimes(1);
+    socket.close();
+    expect(nativeSocket.close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/features/realtime/types.ts
+++ b/frontend/mobile/src/features/realtime/types.ts
@@ -1,0 +1,47 @@
+export type RealtimeState =
+  | 'idle'
+  | 'requesting_permission'
+  | 'creating_offer'
+  | 'exchanging_sdp'
+  | 'connecting'
+  | 'ready'
+  | 'user_speaking'
+  | 'assistant_speaking'
+  | 'paused'
+  | 'ending'
+  | 'ended'
+  | 'error';
+
+export type RealtimeErrorCode =
+  | 'MICROPHONE_DENIED'
+  | 'MEDIA_PREPARATION_FAILED'
+  | 'OFFER_CREATION_FAILED'
+  | 'SDP_EXCHANGE_FAILED'
+  | 'SDP_EXCHANGE_TIMEOUT'
+  | 'ANSWER_APPLY_FAILED'
+  | 'ICE_FAILED'
+  | 'PEER_CONNECTION_FAILED'
+  | 'DATA_CHANNEL_FAILED'
+  | 'PROVIDER_ERROR'
+  | 'SESSION_SOCKET_FAILED'
+  | 'UNKNOWN';
+
+export type RealtimeError = Readonly<{
+  code: RealtimeErrorCode;
+  message: string;
+  retryable: boolean;
+}>;
+
+export type RealtimeDomainEvent =
+  | { type: 'session.created' }
+  | { type: 'session.updated' }
+  | { type: 'user.speech.started' }
+  | { type: 'user.speech.stopped' }
+  | { type: 'user.transcript.delta'; itemId?: string; text: string }
+  | { type: 'user.transcript.preview'; itemId?: string; text: string }
+  | { type: 'user.transcript.completed'; itemId?: string; text: string }
+  | { type: 'assistant.response.started' }
+  | { type: 'assistant.transcript.delta'; text: string }
+  | { type: 'assistant.transcript.completed'; itemId?: string; text: string }
+  | { type: 'assistant.response.completed'; cancelled: boolean }
+  | { type: 'provider.error'; code?: string; message: string };

--- a/frontend/mobile/src/features/scenes/LearningAssetService.ts
+++ b/frontend/mobile/src/features/scenes/LearningAssetService.ts
@@ -1,0 +1,158 @@
+import type {
+  AssetDialogueMessage,
+  LearningExpression,
+  SceneLearningRecord,
+} from '@/data/learningAssets';
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+import type { LearningContentItem } from './SceneService';
+
+type ApiRequester = {
+  request(path: string, options?: ApiRequestOptions): Promise<unknown>;
+};
+
+type LearningAssetSummary = {
+  sceneId: string;
+  title: string;
+  latestSessionId: string | null;
+  latestScore: number | null;
+  latestPracticedAt: string | null;
+  practiceCount: number;
+  createdAt: string;
+};
+
+type DialogueMessage = {
+  owner: 0 | 1;
+  content: string;
+};
+
+type DialogueTurnEvaluation = {
+  turnNo: number;
+  transcript: string;
+  feedbackSummary: string | null;
+  suggestedExpression: string | null;
+};
+
+type DialogueReport = {
+  finalScore: number;
+};
+
+type LearningAssetDetail = {
+  sceneId: string;
+  title: string;
+  aiRole: string;
+  wordList: LearningContentItem[];
+  phraseList: LearningContentItem[];
+  sentenceList: LearningContentItem[];
+  latestSessionId: string | null;
+  dialogueEvaluation: {
+    dialogue: DialogueMessage[];
+    turnEvaluation: DialogueTurnEvaluation[];
+  } | null;
+  latestReport: DialogueReport | null;
+  reportHistory: { createdAt: string }[];
+};
+
+function displayDate(value: string | null | undefined) {
+  return value?.slice(0, 10) || '待练习';
+}
+
+function mapExpressions(
+  items: LearningContentItem[],
+  type: LearningExpression['type'],
+): LearningExpression[] {
+  return items.map((item) => ({
+    id: item.contentId,
+    type,
+    englishText: item.englishText,
+    chineseText: item.chineseText,
+    phonetic: item.phonetic ?? undefined,
+  }));
+}
+
+function mapConversation(detail: LearningAssetDetail): AssetDialogueMessage[] {
+  const evaluation = detail.dialogueEvaluation;
+  if (!evaluation) return [];
+  let learnerTurn = 0;
+  return evaluation.dialogue.map((message, index) => {
+    const role = message.owner === 0 ? 'assistant' : 'user';
+    const feedback =
+      role === 'user' ? evaluation.turnEvaluation[learnerTurn++] : undefined;
+    return {
+      id: `${detail.latestSessionId ?? detail.sceneId}-${index}`,
+      role,
+      speaker: role === 'assistant' ? detail.aiRole : '你',
+      text: message.content,
+      ...(feedback?.feedbackSummary && feedback.suggestedExpression
+        ? {
+            feedback: {
+              feedbackSummary: feedback.feedbackSummary,
+              suggestedExpression: feedback.suggestedExpression,
+            },
+          }
+        : {}),
+    };
+  });
+}
+
+function isSummaryList(value: unknown): value is LearningAssetSummary[] {
+  return Array.isArray(value) && value.every((item) => {
+    if (!item || typeof item !== 'object') return false;
+    const summary = item as Partial<LearningAssetSummary>;
+    return Boolean(summary.sceneId && summary.title);
+  });
+}
+
+function isDetail(value: unknown): value is LearningAssetDetail {
+  if (!value || typeof value !== 'object') return false;
+  const detail = value as Partial<LearningAssetDetail>;
+  return Boolean(
+    detail.sceneId &&
+      detail.title &&
+      Array.isArray(detail.wordList) &&
+      Array.isArray(detail.phraseList) &&
+      Array.isArray(detail.sentenceList) &&
+      Array.isArray(detail.reportHistory),
+  );
+}
+
+export class LearningAssetService {
+  constructor(private readonly client: ApiRequester) {}
+
+  async listRecords(): Promise<SceneLearningRecord[]> {
+    const summaries = await this.client.request('/api/custom-scenes/assets');
+    if (!isSummaryList(summaries)) throw new Error('学习资产列表格式不正确');
+    return summaries.map((summary) => ({
+      id: summary.sceneId,
+      title: summary.title,
+      date: displayDate(summary.latestPracticedAt ?? summary.createdAt),
+      status: summary.latestSessionId ? '已完成' : '待练习',
+      score: summary.latestScore,
+      practiceCount: summary.practiceCount,
+      expressions: [],
+      conversation: [],
+    }));
+  }
+
+  async getRecord(sceneId: string): Promise<SceneLearningRecord> {
+    const value = await this.client.request(
+      `/api/custom-scenes/${encodeURIComponent(sceneId)}/assets`,
+    );
+    if (!isDetail(value)) throw new Error('学习资产详情格式不正确');
+    const latestHistory = value.reportHistory[value.reportHistory.length - 1];
+    return {
+      id: value.sceneId,
+      title: value.title,
+      date: displayDate(latestHistory?.createdAt),
+      status: value.latestSessionId ? '已完成' : '待练习',
+      score: value.latestReport?.finalScore ?? null,
+      practiceCount: value.reportHistory.length,
+      expressions: [
+        ...mapExpressions(value.wordList, '单词'),
+        ...mapExpressions(value.phraseList, '词组'),
+        ...mapExpressions(value.sentenceList, '句子'),
+      ],
+      conversation: mapConversation(value),
+    };
+  }
+}

--- a/frontend/mobile/src/features/scenes/SceneDialogueApi.ts
+++ b/frontend/mobile/src/features/scenes/SceneDialogueApi.ts
@@ -1,0 +1,89 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+export type ScenarioDialogueState = {
+  sceneId: string;
+  sessionId: string;
+  stage: string;
+  effectiveUserTurns: number;
+  maximumUserTurns: number;
+  outcomes: unknown[];
+  completed: boolean;
+  completionReason: string | null;
+  controlInstruction: string;
+  warning: string | null;
+};
+
+export type DialogueReport = {
+  accuracyScore: number;
+  fluencyScore: number;
+  grammarScore: number;
+  vocabularyScore: number;
+  naturalnessScore: number;
+  finalScore: number;
+  summary: string;
+  strengths: string[];
+  improvements: string[];
+};
+
+export type DialogueCompletion = {
+  sceneId: string;
+  sessionId: string;
+  stopTime: string;
+  evaluation?: DialogueReport;
+  state?: ScenarioDialogueState;
+};
+
+type ApiRequester = {
+  request(path: string, options?: ApiRequestOptions): Promise<unknown>;
+};
+
+export class SceneDialogueApi {
+  constructor(
+    private readonly client: ApiRequester,
+    private readonly sceneId: string,
+  ) {}
+
+  advanceState(sessionId: string, turnNo: number, transcript: string) {
+    return this.client.request(
+      `${this.turnPath(sessionId, turnNo)}/state`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ transcript }),
+      },
+    ) as Promise<ScenarioDialogueState>;
+  }
+
+  evaluateTurn(sessionId: string, turnNo: number, transcript: string) {
+    const body = new FormData();
+    body.append('transcript', transcript);
+    return this.client.request(
+      `${this.turnPath(sessionId, turnNo)}/evaluation`,
+      { method: 'POST', body },
+    );
+  }
+
+  complete(sessionId: string, stopTime: string) {
+    return this.client.request(
+      `${this.sessionPath(sessionId)}/complete`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ stopTime }),
+        timeoutMs: 25_000,
+      },
+    ) as Promise<DialogueCompletion>;
+  }
+
+  getReport(sessionId: string) {
+    return this.client.request(
+      `${this.sessionPath(sessionId)}/evaluation`,
+    ) as Promise<DialogueReport>;
+  }
+
+  private sessionPath(sessionId: string) {
+    return `/api/custom-scenes/${encodeURIComponent(this.sceneId)}/sessions/${encodeURIComponent(sessionId)}`;
+  }
+
+  private turnPath(sessionId: string, turnNo: number) {
+    return `${this.sessionPath(sessionId)}/turns/${turnNo}`;
+  }
+}

--- a/frontend/mobile/src/features/scenes/SceneService.ts
+++ b/frontend/mobile/src/features/scenes/SceneService.ts
@@ -1,0 +1,125 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+import { File } from 'expo-file-system';
+
+export type SceneFlowStage =
+  | 'WORD_LEARNING'
+  | 'PHRASE_LEARNING'
+  | 'SENTENCE_LEARNING'
+  | 'DIALOGUE'
+  | 'COMPLETED';
+
+export type LearningContentItem = {
+  contentId: string;
+  englishText: string;
+  chineseText: string;
+  phonetic: string | null;
+};
+
+export type GeneratedScene = {
+  sceneId: string;
+  title: string;
+  background: string;
+  aiRole: string;
+  userRole: string;
+  learningGoal: string;
+  estimatedMinutes: number;
+  wordList: LearningContentItem[];
+  phraseList: LearningContentItem[];
+  sentenceList: LearningContentItem[];
+  scenePrompt: string;
+};
+
+export type SceneFlow = {
+  sceneId: string;
+  stage: SceneFlowStage;
+  completed: boolean;
+};
+
+export type PhonemeScore = {
+  expectedPhoneme: string;
+  actualPhoneme: string;
+  score: number;
+};
+
+export type WordPronunciationScore = {
+  word: string;
+  wordScore: number;
+  phonemes: PhonemeScore[];
+};
+
+export type SentenceEvaluation = {
+  overallScore: number;
+  passed: boolean;
+  words: WordPronunciationScore[];
+};
+
+type ApiRequester = {
+  request(path: string, options?: ApiRequestOptions): Promise<unknown>;
+};
+
+function isGeneratedScene(value: unknown): value is GeneratedScene {
+  if (!value || typeof value !== 'object') return false;
+  const scene = value as Partial<GeneratedScene>;
+  return Boolean(
+    scene.sceneId?.trim() &&
+      Array.isArray(scene.wordList) &&
+      scene.wordList.length &&
+      Array.isArray(scene.phraseList) &&
+      scene.phraseList.length &&
+      Array.isArray(scene.sentenceList) &&
+      scene.sentenceList.length,
+  );
+}
+
+export function createWavUploadFile(wavUri: string) {
+  return new File(wavUri);
+}
+
+export class SceneService {
+  constructor(private readonly client: ApiRequester) {}
+
+  async generate(sceneInput: string, userPreference: string | null = null) {
+    const scene = await this.client.request('/api/custom-scenes/generate', {
+      method: 'POST',
+      body: JSON.stringify({ sceneInput: sceneInput.trim(), userPreference }),
+      timeoutMs: 60_000,
+    });
+    if (!isGeneratedScene(scene)) {
+      throw new Error('场景生成内容不完整，请重新生成');
+    }
+    return scene;
+  }
+
+  createFlow(sceneId: string) {
+    return this.client.request('/api/custom-scenes/flows', {
+      method: 'POST',
+      body: JSON.stringify({ sceneId }),
+    }) as Promise<SceneFlow>;
+  }
+
+  getContent(sceneId: string, stage?: SceneFlowStage) {
+    const query = stage ? `?stage=${encodeURIComponent(stage)}` : '';
+    return this.client.request(
+      `/api/custom-scenes/flows/${encodeURIComponent(sceneId)}/content${query}`,
+    ) as Promise<LearningContentItem[]>;
+  }
+
+  advanceStage(sceneId: string, stage: SceneFlowStage) {
+    return this.client.request('/api/custom-scenes/flows/advance', {
+      method: 'POST',
+      body: JSON.stringify({ sceneId, stage }),
+    }) as Promise<SceneFlow>;
+  }
+
+  evaluateSentence(sceneId: string, sentenceId: string, wavUri: string) {
+    const body = new FormData();
+    // Expo SDK 57's fetch implementation accepts Blob-compatible files with a
+    // `bytes()` method. React Native's legacy `{ uri, name, type }` descriptor
+    // is rejected before the request reaches the backend.
+    body.append('audio', createWavUploadFile(wavUri));
+    return this.client.request(
+      `/api/custom-scenes/${encodeURIComponent(sceneId)}/sentences/${encodeURIComponent(sentenceId)}/evaluation`,
+      { method: 'POST', body },
+    ) as Promise<SentenceEvaluation>;
+  }
+}

--- a/frontend/mobile/src/features/scenes/SceneTrainingController.ts
+++ b/frontend/mobile/src/features/scenes/SceneTrainingController.ts
@@ -1,0 +1,221 @@
+import type {
+  GeneratedScene,
+  LearningContentItem,
+  SceneFlow,
+  SceneFlowStage,
+  SentenceEvaluation,
+} from './SceneService';
+
+export type SceneTrainingServicePort = {
+  createFlow(sceneId: string): Promise<SceneFlow>;
+  getContent(
+    sceneId: string,
+    stage?: SceneFlowStage,
+  ): Promise<LearningContentItem[]>;
+  advanceStage(sceneId: string, stage: SceneFlowStage): Promise<SceneFlow>;
+  evaluateSentence(
+    sceneId: string,
+    sentenceId: string,
+    wavUri: string,
+  ): Promise<SentenceEvaluation>;
+};
+
+export type SceneTrainingSnapshot = Readonly<{
+  status: 'idle' | 'loading' | 'ready' | 'scoring' | 'error';
+  scene: GeneratedScene | null;
+  stage: 'learn' | 'read' | 'speak';
+  learningGroup: 'words' | 'phrases';
+  items: LearningContentItem[];
+  currentItem: LearningContentItem | null;
+  index: number;
+  unlockedStage: 0 | 1 | 2;
+  readingResult: SentenceEvaluation | null;
+  error: string | null;
+}>;
+
+const initialSnapshot: SceneTrainingSnapshot = {
+  status: 'idle',
+  scene: null,
+  stage: 'learn',
+  learningGroup: 'words',
+  items: [],
+  currentItem: null,
+  index: 0,
+  unlockedStage: 0,
+  readingResult: null,
+  error: null,
+};
+
+type Listener = (snapshot: SceneTrainingSnapshot) => void;
+
+export class SceneTrainingController {
+  private snapshot = initialSnapshot;
+  private readonly listeners = new Set<Listener>();
+
+  constructor(private readonly service: SceneTrainingServicePort) {}
+
+  getSnapshot() {
+    return this.snapshot;
+  }
+
+  subscribe(listener: Listener) {
+    this.listeners.add(listener);
+    listener(this.snapshot);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  async start(scene: GeneratedScene) {
+    this.update({
+      ...initialSnapshot,
+      status: 'loading',
+      scene,
+    });
+    try {
+      await this.service.createFlow(scene.sceneId);
+      const items = await this.requireContent(scene.sceneId, 'WORD_LEARNING');
+      this.update({
+        ...this.snapshot,
+        status: 'ready',
+        items,
+        currentItem: items[0],
+      });
+    } catch (error) {
+      this.fail(error);
+      throw error;
+    }
+  }
+
+  async next() {
+    const scene = this.requireScene();
+    if (this.snapshot.stage === 'speak') return false;
+    if (this.snapshot.index < this.snapshot.items.length - 1) {
+      const index = this.snapshot.index + 1;
+      this.update({
+        ...this.snapshot,
+        index,
+        currentItem: this.snapshot.items[index],
+        readingResult: null,
+      });
+      return true;
+    }
+
+    if (this.snapshot.stage === 'learn') {
+      const currentStage: SceneFlowStage =
+        this.snapshot.learningGroup === 'words'
+          ? 'WORD_LEARNING'
+          : 'PHRASE_LEARNING';
+      const nextStage: SceneFlowStage =
+        currentStage === 'WORD_LEARNING'
+          ? 'PHRASE_LEARNING'
+          : 'SENTENCE_LEARNING';
+      await this.loadStage(scene.sceneId, currentStage, nextStage);
+      return true;
+    }
+
+    if (!this.snapshot.readingResult?.passed) return false;
+    const flow = await this.service.advanceStage(
+      scene.sceneId,
+      'SENTENCE_LEARNING',
+    );
+    if (flow.stage !== 'DIALOGUE') {
+      throw new Error('后端未进入场景对话阶段');
+    }
+    this.update({
+      ...this.snapshot,
+      status: 'ready',
+      stage: 'speak',
+      unlockedStage: 2,
+      readingResult: null,
+    });
+    return true;
+  }
+
+  previous() {
+    if (this.snapshot.index <= 0) return false;
+    const index = this.snapshot.index - 1;
+    this.update({
+      ...this.snapshot,
+      index,
+      currentItem: this.snapshot.items[index],
+      readingResult: null,
+    });
+    return true;
+  }
+
+  async scoreReading(wavUri: string) {
+    const scene = this.requireScene();
+    const sentence = this.snapshot.currentItem;
+    if (this.snapshot.stage !== 'read' || !sentence) {
+      throw new Error('当前不在朗读阶段');
+    }
+    this.update({ ...this.snapshot, status: 'scoring', error: null });
+    try {
+      const readingResult = await this.service.evaluateSentence(
+        scene.sceneId,
+        sentence.contentId,
+        wavUri,
+      );
+      this.update({ ...this.snapshot, status: 'ready', readingResult });
+      return readingResult;
+    } catch (error) {
+      this.fail(error);
+      throw error;
+    }
+  }
+
+  private async loadStage(
+    sceneId: string,
+    currentStage: SceneFlowStage,
+    nextStage: SceneFlowStage,
+  ) {
+    this.update({ ...this.snapshot, status: 'loading', error: null });
+    try {
+      const flow = await this.service.advanceStage(sceneId, currentStage);
+      if (flow.stage !== nextStage) {
+        throw new Error(`后端未进入预期训练阶段：${nextStage}`);
+      }
+      const items = await this.requireContent(sceneId, nextStage);
+      this.update({
+        ...this.snapshot,
+        status: 'ready',
+        stage: nextStage === 'SENTENCE_LEARNING' ? 'read' : 'learn',
+        learningGroup:
+          nextStage === 'PHRASE_LEARNING' ? 'phrases' : this.snapshot.learningGroup,
+        items,
+        currentItem: items[0],
+        index: 0,
+        unlockedStage: nextStage === 'SENTENCE_LEARNING' ? 1 : 0,
+        readingResult: null,
+      });
+    } catch (error) {
+      this.fail(error);
+      throw error;
+    }
+  }
+
+  private async requireContent(sceneId: string, stage: SceneFlowStage) {
+    const items = await this.service.getContent(sceneId, stage);
+    if (!items.length) throw new Error('当前训练阶段没有可用内容');
+    return items;
+  }
+
+  private requireScene() {
+    if (!this.snapshot.scene) throw new Error('场景训练尚未开始');
+    return this.snapshot.scene;
+  }
+
+  private fail(error: unknown) {
+    this.update({
+      ...this.snapshot,
+      status: 'error',
+      error: error instanceof Error ? error.message : '场景训练请求失败',
+    });
+  }
+
+  private update(snapshot: SceneTrainingSnapshot) {
+    this.snapshot = snapshot;
+    this.listeners.forEach((listener) => listener(snapshot));
+  }
+}

--- a/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
@@ -1,0 +1,162 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+import { LearningAssetService } from '../LearningAssetService';
+
+function createClient(responses: unknown[]) {
+  return {
+    request: jest.fn(
+      async (_path: string, _options?: ApiRequestOptions) => responses.shift(),
+    ),
+  };
+}
+
+const summary = {
+  sceneId: 'scene/airport',
+  title: '机场行李托运',
+  background: '在机场柜台办理行李托运。',
+  wordCount: 1,
+  phraseCount: 1,
+  sentenceCount: 1,
+  latestSessionId: 'session-1',
+  latestScore: 88,
+  latestPracticedAt: '2026-08-05T08:00:00+08:00',
+  practiceCount: 2,
+  createdAt: '2026-08-04T08:00:00+08:00',
+};
+
+const detail = {
+  sceneId: summary.sceneId,
+  title: summary.title,
+  background: summary.background,
+  aiRole: '航空公司工作人员',
+  userRole: '乘客',
+  learningGoal: '确认行李重量和登机信息。',
+  wordList: [
+    {
+      contentId: 'word-1',
+      englishText: 'baggage',
+      chineseText: '行李',
+      phonetic: '/ˈbæɡɪdʒ/',
+    },
+  ],
+  phraseList: [
+    {
+      contentId: 'phrase-1',
+      englishText: 'check in',
+      chineseText: '办理托运',
+      phonetic: null,
+    },
+  ],
+  sentenceList: [
+    {
+      contentId: 'sentence-1',
+      englishText: 'I would like to check in this bag.',
+      chineseText: '我想托运这个行李。',
+      phonetic: null,
+    },
+  ],
+  latestSessionId: 'session-1',
+  dialogueEvaluation: {
+    dialogue: [
+      { owner: 0, content: 'May I see your passport?', audio: null },
+      { owner: 1, content: 'Here you are.', audio: null },
+    ],
+    turnEvaluation: [
+      {
+        turnNo: 1,
+        transcript: 'Here you are.',
+        overallScore: 86,
+        rhythmScore: 84,
+        toneScore: 85,
+        integrityScore: 88,
+        pronunciationScore: 87,
+        fluencyScore: 86,
+        feedbackSummary: '表达清楚。',
+        suggestedExpression: 'Here is my passport.',
+        words: [],
+      },
+    ],
+  },
+  latestReport: {
+    accuracyScore: 88,
+    fluencyScore: 86,
+    grammarScore: 90,
+    vocabularyScore: 84,
+    naturalnessScore: 87,
+    finalScore: 88,
+    summary: '完成了托运任务。',
+    strengths: ['表达清楚'],
+    improvements: ['补充礼貌用语'],
+  },
+  reportHistory: [
+    {
+      sceneId: summary.sceneId,
+      sessionId: 'session-1',
+      report: { finalScore: 88 },
+      createdAt: '2026-08-05T08:00:00+08:00',
+    },
+  ],
+};
+
+describe('LearningAssetService', () => {
+  it('loads the authenticated asset summary list and maps display metadata', async () => {
+    const client = createClient([[summary]]);
+    const service = new LearningAssetService(client);
+
+    await expect(service.listRecords()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'scene/airport',
+        title: '机场行李托运',
+        date: '2026-08-05',
+        status: '已完成',
+        score: 88,
+        practiceCount: 2,
+        expressions: [],
+        conversation: [],
+      }),
+    ]);
+    expect(client.request).toHaveBeenCalledWith('/api/custom-scenes/assets');
+  });
+
+  it('loads an encoded asset detail and maps learning items and turn feedback', async () => {
+    const client = createClient([detail]);
+    const service = new LearningAssetService(client);
+
+    const record = await service.getRecord('scene/airport');
+
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/custom-scenes/scene%2Fairport/assets',
+    );
+    expect(record).toEqual(
+      expect.objectContaining({
+        id: 'scene/airport',
+        score: 88,
+        practiceCount: 1,
+        expressions: [
+          expect.objectContaining({ type: '单词', englishText: 'baggage' }),
+          expect.objectContaining({ type: '词组', englishText: 'check in' }),
+          expect.objectContaining({
+            type: '句子',
+            englishText: 'I would like to check in this bag.',
+          }),
+        ],
+        conversation: [
+          expect.objectContaining({
+            role: 'assistant',
+            speaker: '航空公司工作人员',
+            text: 'May I see your passport?',
+          }),
+          expect.objectContaining({
+            role: 'user',
+            speaker: '你',
+            text: 'Here you are.',
+            feedback: {
+              feedbackSummary: '表达清楚。',
+              suggestedExpression: 'Here is my passport.',
+            },
+          }),
+        ],
+      }),
+    );
+  });
+});

--- a/frontend/mobile/src/features/scenes/__tests__/SceneDialogueApi.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/SceneDialogueApi.test.ts
@@ -1,0 +1,59 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+import { SceneDialogueApi } from '../SceneDialogueApi';
+
+function createClient() {
+  return {
+    request: jest.fn<Promise<unknown>, [string, ApiRequestOptions?]>(
+      async () => ({ completed: false }),
+    ),
+  };
+}
+
+describe('SceneDialogueApi', () => {
+  it('advances state and evaluates each learner turn on encoded scene/session paths', async () => {
+    const client = createClient();
+    const api = new SceneDialogueApi(client, 'scene/1');
+
+    await api.advanceState('session 1', 2, 'I need a window seat.');
+    await api.evaluateTurn('session 1', 2, 'I need a window seat.');
+
+    expect(client.request.mock.calls[0]).toEqual([
+      '/api/custom-scenes/scene%2F1/sessions/session%201/turns/2/state',
+      {
+        method: 'POST',
+        body: JSON.stringify({ transcript: 'I need a window seat.' }),
+      },
+    ]);
+    const [evaluationPath, evaluationOptions] = client.request.mock.calls[1];
+    expect(evaluationPath).toBe(
+      '/api/custom-scenes/scene%2F1/sessions/session%201/turns/2/evaluation',
+    );
+    expect(evaluationOptions).toEqual(
+      expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+    );
+  });
+
+  it('completes a dialogue with the stop time and can recover its report', async () => {
+    const client = createClient();
+    const api = new SceneDialogueApi(client, 'scene/1');
+
+    await api.complete('session 1', '2026-08-05T10:00:00.000Z');
+    await api.getReport('session 1');
+
+    expect(client.request.mock.calls).toEqual([
+      [
+        '/api/custom-scenes/scene%2F1/sessions/session%201/complete',
+        {
+          method: 'POST',
+          body: JSON.stringify({ stopTime: '2026-08-05T10:00:00.000Z' }),
+          timeoutMs: 25_000,
+        },
+      ],
+      [
+        '/api/custom-scenes/scene%2F1/sessions/session%201/evaluation',
+        undefined,
+      ],
+    ]);
+  });
+});

--- a/frontend/mobile/src/features/scenes/__tests__/SceneService.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/SceneService.test.ts
@@ -1,0 +1,129 @@
+import type { ApiRequestOptions } from '@/infrastructure/http/ApiClient';
+
+import { createWavUploadFile, SceneService } from '../SceneService';
+
+function createClient(responses: unknown[]) {
+  return {
+    request: jest.fn(
+      async (_path: string, _options?: ApiRequestOptions) => responses.shift(),
+    ),
+  };
+}
+
+const generatedScene = {
+  sceneId: 'scene/1',
+  title: 'Coffee order',
+  background: 'A busy coffee shop.',
+  aiRole: 'Barista',
+  userRole: 'Customer',
+  learningGoal: 'Order and customize a drink.',
+  estimatedMinutes: 8,
+  wordList: [
+    {
+      contentId: 'word-1',
+      englishText: 'decaf',
+      chineseText: '无咖啡因的',
+      phonetic: '/ˈdiːkæf/',
+    },
+  ],
+  phraseList: [
+    {
+      contentId: 'phrase-1',
+      englishText: 'Could I get',
+      chineseText: '我可以要……吗',
+      phonetic: null,
+    },
+  ],
+  sentenceList: [
+    {
+      contentId: 'sentence-1',
+      englishText: 'Could I get a decaf latte?',
+      chineseText: '我可以要一杯无咖啡因拿铁吗？',
+      phonetic: null,
+    },
+  ],
+  scenePrompt: 'Provider prompt',
+};
+
+describe('SceneService', () => {
+  it('generates and validates all three learning content groups', async () => {
+    const client = createClient([generatedScene]);
+    const service = new SceneService(client);
+
+    await expect(
+      service.generate('  I want to order coffee.  ', 'CEFR B'),
+    ).resolves.toEqual(generatedScene);
+    expect(client.request).toHaveBeenCalledWith('/api/custom-scenes/generate', {
+      method: 'POST',
+      body: JSON.stringify({
+        sceneInput: 'I want to order coffee.',
+        userPreference: 'CEFR B',
+      }),
+      timeoutMs: 60_000,
+    });
+  });
+
+  it('rejects an incomplete generated scene before the UI starts training', async () => {
+    const client = createClient([{ ...generatedScene, sentenceList: [] }]);
+    const service = new SceneService(client);
+
+    await expect(service.generate('Coffee')).rejects.toThrow(
+      '场景生成内容不完整，请重新生成',
+    );
+  });
+
+  it('creates a flow, loads an explicit stage and advances it', async () => {
+    const client = createClient([
+      { sceneId: 'scene/1', stage: 'WORD_LEARNING', completed: false },
+      generatedScene.wordList,
+      { sceneId: 'scene/1', stage: 'PHRASE_LEARNING', completed: false },
+    ]);
+    const service = new SceneService(client);
+
+    await service.createFlow('scene/1');
+    await service.getContent('scene/1', 'WORD_LEARNING');
+    await service.advanceStage('scene/1', 'PHRASE_LEARNING');
+
+    expect(client.request.mock.calls).toEqual([
+      [
+        '/api/custom-scenes/flows',
+        { method: 'POST', body: JSON.stringify({ sceneId: 'scene/1' }) },
+      ],
+      [
+        '/api/custom-scenes/flows/scene%2F1/content?stage=WORD_LEARNING',
+        undefined,
+      ],
+      [
+        '/api/custom-scenes/flows/advance',
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            sceneId: 'scene/1',
+            stage: 'PHRASE_LEARNING',
+          }),
+        },
+      ],
+    ]);
+  });
+
+  it('uploads a React Native WAV file descriptor for sentence scoring', async () => {
+    const client = createClient([
+      { overallScore: 86, passed: true, words: [] },
+    ]);
+    const service = new SceneService(client);
+
+    await service.evaluateSentence('scene/1', 'sentence 1', 'file:///take.wav');
+
+    const [path, options] = client.request.mock.calls[0];
+    expect(path).toBe(
+      '/api/custom-scenes/scene%2F1/sentences/sentence%201/evaluation',
+    );
+    expect(options).toEqual(
+      expect.objectContaining({ method: 'POST', body: expect.any(FormData) }),
+    );
+    const uploadFile = createWavUploadFile('file:///take.wav');
+    expect(uploadFile.uri).toBe('file:///take.wav');
+    expect(uploadFile.bytes).toEqual(expect.any(Function));
+    expect((options as ApiRequestOptions).headers).toBeUndefined();
+  });
+});

--- a/frontend/mobile/src/features/scenes/__tests__/SceneTrainingController.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/SceneTrainingController.test.ts
@@ -1,0 +1,155 @@
+import {
+  SceneTrainingController,
+  type SceneTrainingServicePort,
+} from '../SceneTrainingController';
+import type {
+  GeneratedScene,
+  LearningContentItem,
+  SceneFlowStage,
+  SentenceEvaluation,
+} from '../SceneService';
+
+const word: LearningContentItem = {
+  contentId: 'word-1',
+  englishText: 'decaf',
+  chineseText: '无咖啡因的',
+  phonetic: '/ˈdiːkæf/',
+};
+const phrase: LearningContentItem = {
+  contentId: 'phrase-1',
+  englishText: 'Could I get',
+  chineseText: '我可以要……吗',
+  phonetic: null,
+};
+const sentence: LearningContentItem = {
+  contentId: 'sentence-1',
+  englishText: 'Could I get a decaf latte?',
+  chineseText: '我可以要一杯无咖啡因拿铁吗？',
+  phonetic: null,
+};
+const scene: GeneratedScene = {
+  sceneId: 'scene-1',
+  title: '咖啡店点单',
+  background: 'A coffee shop.',
+  aiRole: 'Barista',
+  userRole: 'Customer',
+  learningGoal: 'Order a drink.',
+  estimatedMinutes: 8,
+  wordList: [word],
+  phraseList: [phrase],
+  sentenceList: [sentence],
+  scenePrompt: 'Prompt',
+};
+
+function createService(): SceneTrainingServicePort & {
+  createFlow: jest.Mock;
+  getContent: jest.Mock;
+  advanceStage: jest.Mock;
+  evaluateSentence: jest.Mock;
+} {
+  return {
+    createFlow: jest.fn(async () => ({
+      sceneId: 'scene-1',
+      stage: 'WORD_LEARNING' as const,
+      completed: false,
+    })),
+    getContent: jest.fn(async (_sceneId, stage) => {
+      if (stage === 'WORD_LEARNING') return [word];
+      if (stage === 'PHRASE_LEARNING') return [phrase];
+      return [sentence];
+    }),
+    advanceStage: jest.fn(async (_sceneId, stage) => ({
+      sceneId: 'scene-1',
+      stage: (
+        stage === 'WORD_LEARNING'
+          ? 'PHRASE_LEARNING'
+          : stage === 'PHRASE_LEARNING'
+            ? 'SENTENCE_LEARNING'
+            : 'DIALOGUE') as SceneFlowStage,
+      completed: false,
+    })),
+    evaluateSentence: jest.fn(async (): Promise<SentenceEvaluation> => ({
+      overallScore: 86,
+      passed: true,
+      words: [],
+    })),
+  };
+}
+
+describe('SceneTrainingController', () => {
+  it('starts the backend flow and exposes its real word content', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+
+    await controller.start(scene);
+
+    expect(service.createFlow).toHaveBeenCalledWith('scene-1');
+    expect(service.getContent).toHaveBeenCalledWith(
+      'scene-1',
+      'WORD_LEARNING',
+    );
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        status: 'ready',
+        stage: 'learn',
+        learningGroup: 'words',
+        currentItem: word,
+        index: 0,
+      }),
+    );
+  });
+
+  it('advances words to phrases and phrases to the reading stage', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+
+    await controller.next();
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        stage: 'learn',
+        learningGroup: 'phrases',
+        currentItem: phrase,
+      }),
+    );
+    await controller.next();
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        stage: 'read',
+        currentItem: sentence,
+        unlockedStage: 1,
+      }),
+    );
+    expect(service.advanceStage.mock.calls).toEqual([
+      ['scene-1', 'WORD_LEARNING'],
+      ['scene-1', 'PHRASE_LEARNING'],
+    ]);
+  });
+
+  it('scores the current WAV and unlocks dialogue only after a passing result', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+    await controller.next();
+
+    await controller.scoreReading('file:///sentence.wav');
+    expect(service.evaluateSentence).toHaveBeenCalledWith(
+      'scene-1',
+      'sentence-1',
+      'file:///sentence.wav',
+    );
+    expect(controller.getSnapshot().readingResult).toEqual(
+      expect.objectContaining({ overallScore: 86, passed: true }),
+    );
+
+    await expect(controller.next()).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ stage: 'speak', unlockedStage: 2 }),
+    );
+    expect(service.advanceStage).toHaveBeenLastCalledWith(
+      'scene-1',
+      'SENTENCE_LEARNING',
+    );
+  });
+});

--- a/frontend/mobile/src/infrastructure/auth/SecureTokenStore.ts
+++ b/frontend/mobile/src/infrastructure/auth/SecureTokenStore.ts
@@ -1,0 +1,34 @@
+import * as SecureStore from 'expo-secure-store';
+
+export interface TokenStore {
+  get(): Promise<string | null>;
+  set(token: string): Promise<void>;
+  clear(): Promise<void>;
+}
+
+export interface SecureStoragePort {
+  getItemAsync(key: string): Promise<string | null>;
+  setItemAsync(key: string, value: string): Promise<void>;
+  deleteItemAsync(key: string): Promise<void>;
+}
+
+export const accessTokenStorageKey = 'unispeaking.accessToken';
+
+export class SecureTokenStore implements TokenStore {
+  constructor(
+    private readonly storage: SecureStoragePort = SecureStore,
+    private readonly storageKey: string = accessTokenStorageKey,
+  ) {}
+
+  get() {
+    return this.storage.getItemAsync(this.storageKey);
+  }
+
+  set(token: string) {
+    return this.storage.setItemAsync(this.storageKey, token);
+  }
+
+  clear() {
+    return this.storage.deleteItemAsync(this.storageKey);
+  }
+}

--- a/frontend/mobile/src/infrastructure/auth/__tests__/SecureTokenStore.test.ts
+++ b/frontend/mobile/src/infrastructure/auth/__tests__/SecureTokenStore.test.ts
@@ -1,0 +1,42 @@
+import { SecureTokenStore } from '../SecureTokenStore';
+
+function createStorage(initialValue: string | null = null) {
+  let value = initialValue;
+  return {
+    getItemAsync: jest.fn(async () => value),
+    setItemAsync: jest.fn(async (_key: string, nextValue: string) => {
+      value = nextValue;
+    }),
+    deleteItemAsync: jest.fn(async () => {
+      value = null;
+    }),
+  };
+}
+
+describe('SecureTokenStore', () => {
+  it('reads the saved access token using the stable storage key', async () => {
+    const storage = createStorage('saved-token');
+    const tokenStore = new SecureTokenStore(storage);
+
+    await expect(tokenStore.get()).resolves.toBe('saved-token');
+    expect(storage.getItemAsync).toHaveBeenCalledWith('unispeaking.accessToken');
+  });
+
+  it('saves and clears the access token', async () => {
+    const storage = createStorage();
+    const tokenStore = new SecureTokenStore(storage);
+
+    await tokenStore.set('new-token');
+    await expect(tokenStore.get()).resolves.toBe('new-token');
+    await tokenStore.clear();
+    await expect(tokenStore.get()).resolves.toBeNull();
+
+    expect(storage.setItemAsync).toHaveBeenCalledWith(
+      'unispeaking.accessToken',
+      'new-token',
+    );
+    expect(storage.deleteItemAsync).toHaveBeenCalledWith(
+      'unispeaking.accessToken',
+    );
+  });
+});

--- a/frontend/mobile/src/infrastructure/config/__tests__/runtimeConfig.test.ts
+++ b/frontend/mobile/src/infrastructure/config/__tests__/runtimeConfig.test.ts
@@ -1,0 +1,27 @@
+import { getRuntimeConfig } from '../runtimeConfig';
+
+describe('getRuntimeConfig', () => {
+  it('removes trailing slashes from the configured backend URL', () => {
+    expect(
+      getRuntimeConfig({
+        EXPO_PUBLIC_BACKEND_URL: 'http://127.0.0.1:8080///',
+      }),
+    ).toEqual({
+      backendUrl: 'http://127.0.0.1:8080',
+    });
+  });
+
+  it('uses the USB-forwarded Android development URL when no URL is configured', () => {
+    expect(getRuntimeConfig({})).toEqual({
+      backendUrl: 'http://127.0.0.1:8080',
+    });
+  });
+
+  it('rejects a relative backend URL', () => {
+    expect(() =>
+      getRuntimeConfig({
+        EXPO_PUBLIC_BACKEND_URL: '/backend',
+      }),
+    ).toThrow('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
+  });
+});

--- a/frontend/mobile/src/infrastructure/config/runtimeConfig.ts
+++ b/frontend/mobile/src/infrastructure/config/runtimeConfig.ts
@@ -1,0 +1,33 @@
+export type RuntimeEnvironment = Readonly<{
+  EXPO_PUBLIC_BACKEND_URL?: string;
+}>;
+
+export type RuntimeConfig = Readonly<{
+  backendUrl: string;
+}>;
+
+const androidUsbDevelopmentUrl = 'http://127.0.0.1:8080';
+
+export function getRuntimeConfig(
+  environment: RuntimeEnvironment = {
+    EXPO_PUBLIC_BACKEND_URL: process.env.EXPO_PUBLIC_BACKEND_URL,
+  },
+): RuntimeConfig {
+  const configuredUrl = environment.EXPO_PUBLIC_BACKEND_URL?.trim();
+  const backendUrl = configuredUrl || androidUsbDevelopmentUrl;
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(backendUrl);
+  } catch {
+    throw new Error('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
+  }
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
+  }
+
+  return {
+    backendUrl: backendUrl.replace(/\/+$/, ''),
+  };
+}

--- a/frontend/mobile/src/infrastructure/http/ApiClient.ts
+++ b/frontend/mobile/src/infrastructure/http/ApiClient.ts
@@ -1,0 +1,128 @@
+import type { TokenStore } from '../auth/SecureTokenStore';
+
+type FetchLike = (input: string, init?: RequestInit) => Promise<Response>;
+
+type ApiEnvelope<T> = {
+  success: boolean;
+  data?: T;
+  code?: string;
+  message?: string;
+};
+
+export type ApiClientOptions = {
+  baseUrl: string;
+  tokenStore: TokenStore;
+  fetchImpl?: FetchLike;
+  onUnauthorized?: () => void | Promise<void>;
+};
+
+export type ApiRequestOptions = RequestInit & {
+  timeoutMs?: number;
+};
+
+export class ApiError extends Error {
+  constructor(
+    message: string,
+    public readonly status: number,
+    public readonly code?: string,
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+function toHeaderRecord(headers: HeadersInit | undefined): Record<string, string> {
+  if (!headers) return {};
+  if (Array.isArray(headers)) return Object.fromEntries(headers);
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+  return { ...headers } as Record<string, string>;
+}
+
+function isApiEnvelope<T>(body: unknown): body is ApiEnvelope<T> {
+  return Boolean(
+    body &&
+      typeof body === 'object' &&
+      'success' in body &&
+      typeof (body as { success?: unknown }).success === 'boolean',
+  );
+}
+
+export class ApiClient {
+  private readonly baseUrl: string;
+  private readonly tokenStore: TokenStore;
+  private readonly fetchImpl: FetchLike;
+  private readonly onUnauthorized?: () => void | Promise<void>;
+
+  constructor(options: ApiClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/+$/, '');
+    this.tokenStore = options.tokenStore;
+    this.fetchImpl = options.fetchImpl ?? fetch;
+    this.onUnauthorized = options.onUnauthorized;
+  }
+
+  async request<T>(path: string, options: ApiRequestOptions = {}): Promise<T> {
+    const { timeoutMs = 15_000, ...requestOptions } = options;
+    const token = await this.tokenStore.get();
+    const isFormData =
+      typeof FormData !== 'undefined' && requestOptions.body instanceof FormData;
+    const headers = {
+      ...(requestOptions.body && !isFormData ? { 'Content-Type': 'application/json' } : {}),
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...toHeaderRecord(requestOptions.headers),
+    };
+
+    const controller = new AbortController();
+    const externalSignal = requestOptions.signal;
+    const abortFromExternalSignal = () => controller.abort();
+    if (externalSignal?.aborted) controller.abort();
+    else externalSignal?.addEventListener('abort', abortFromExternalSignal, { once: true });
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+    let response: Response;
+    try {
+      response = await this.fetchImpl(
+        `${this.baseUrl}${path.startsWith('/') ? path : `/${path}`}`,
+        {
+          ...requestOptions,
+          headers,
+          signal: controller.signal,
+        },
+      );
+    } catch (error) {
+      if (controller.signal.aborted && !externalSignal?.aborted) {
+        throw new ApiError(
+          '请求超时，请检查网络后重试',
+          408,
+          'REQUEST_TIMEOUT',
+        );
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeout);
+      externalSignal?.removeEventListener('abort', abortFromExternalSignal);
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    const body: unknown = contentType.includes('application/json')
+      ? await response.json()
+      : await response.text();
+
+    if (response.status === 401 && !path.startsWith('/api/auth/')) {
+      await this.tokenStore.clear();
+      await this.onUnauthorized?.();
+    }
+
+    if (!response.ok || (isApiEnvelope(body) && !body.success)) {
+      const envelope = isApiEnvelope(body) ? body : undefined;
+      throw new ApiError(
+        envelope?.message ?? envelope?.code ?? `请求失败（${response.status}）`,
+        response.status,
+        envelope?.code,
+      );
+    }
+
+    return (isApiEnvelope<T>(body) ? body.data : body) as T;
+  }
+}

--- a/frontend/mobile/src/infrastructure/http/__tests__/ApiClient.test.ts
+++ b/frontend/mobile/src/infrastructure/http/__tests__/ApiClient.test.ts
@@ -1,0 +1,143 @@
+import { ApiClient, ApiError, type ApiRequestOptions } from '../ApiClient';
+import type { TokenStore } from '../../auth/SecureTokenStore';
+
+function createTokenStore(token: string | null): TokenStore & {
+  clear: jest.Mock<Promise<void>, []>;
+} {
+  return {
+    get: jest.fn(async () => token),
+    set: jest.fn(async () => undefined),
+    clear: jest.fn(async () => undefined),
+  };
+}
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) =>
+        name.toLowerCase() === 'content-type' ? 'application/json' : null,
+    },
+    json: jest.fn(async () => body),
+    text: jest.fn(async () => JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('ApiClient', () => {
+  it('adds the bearer token and unwraps a successful API envelope', async () => {
+    const tokenStore = createTokenStore('jwt-token');
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit?]>(
+      async () => jsonResponse({ success: true, data: { id: 'user-1' } }),
+    );
+    const client = new ApiClient({
+      baseUrl: 'http://127.0.0.1:8080/',
+      tokenStore,
+      fetchImpl,
+    });
+
+    await expect(client.request<{ id: string }>('/api/auth/me')).resolves.toEqual({
+      id: 'user-1',
+    });
+
+    expect(fetchImpl).toHaveBeenCalledWith(
+      'http://127.0.0.1:8080/api/auth/me',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer jwt-token' }),
+      }),
+    );
+  });
+
+  it('does not set JSON content type for FormData uploads', async () => {
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit?]>(
+      async () => jsonResponse({ success: true, data: { overallScore: 86 } }),
+    );
+    const client = new ApiClient({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: createTokenStore('jwt-token'),
+      fetchImpl,
+    });
+    const body = new FormData();
+    body.append('transcript', 'Hello');
+
+    await client.request('/api/custom-scenes/scene-1/evaluation', {
+      method: 'POST',
+      body,
+    });
+
+    const request = fetchImpl.mock.calls[0][1] as RequestInit;
+    expect(request.headers).toEqual({ Authorization: 'Bearer jwt-token' });
+  });
+
+  it('throws the backend error message and status', async () => {
+    const client = new ApiClient({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: createTokenStore(null),
+      fetchImpl: jest.fn(async () =>
+        jsonResponse({ success: false, code: 'SCENE_INVALID', message: '场景内容不完整' }, 400),
+      ),
+    });
+
+    await expect(client.request('/api/custom-scenes/generate')).rejects.toEqual(
+      expect.objectContaining({
+        message: '场景内容不完整',
+        status: 400,
+        code: 'SCENE_INVALID',
+      } satisfies Partial<ApiError>),
+    );
+  });
+
+  it('clears the token and notifies auth state after a protected 401', async () => {
+    const tokenStore = createTokenStore('expired-token');
+    const onUnauthorized = jest.fn(async () => undefined);
+    const client = new ApiClient({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore,
+      onUnauthorized,
+      fetchImpl: jest.fn(async () =>
+        jsonResponse({ success: false, message: '登录已过期' }, 401),
+      ),
+    });
+
+    await expect(client.request('/api/user-preferences')).rejects.toThrow('登录已过期');
+    expect(tokenStore.clear).toHaveBeenCalledTimes(1);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+  });
+
+  it('aborts a request after its configured timeout', async () => {
+    jest.useFakeTimers();
+    const fetchImpl = jest.fn<Promise<Response>, [string, RequestInit?]>(
+      async (_url, init) =>
+        new Promise<Response>((resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const error = new Error('aborted');
+            error.name = 'AbortError';
+            reject(error);
+          });
+          setTimeout(
+            () => resolve(jsonResponse({ success: true, data: { late: true } })),
+            1_000,
+          );
+        }),
+    );
+    const client = new ApiClient({
+      baseUrl: 'http://127.0.0.1:8080',
+      tokenStore: createTokenStore('jwt-token'),
+      fetchImpl,
+    });
+
+    const request = client.request('/api/slow', {
+      timeoutMs: 10,
+    } satisfies ApiRequestOptions);
+    const expectation = expect(request).rejects.toEqual(
+      expect.objectContaining({
+        message: '请求超时，请检查网络后重试',
+        status: 408,
+        code: 'REQUEST_TIMEOUT',
+      } satisfies Partial<ApiError>),
+    );
+    await jest.runAllTimersAsync();
+    await expectation;
+    jest.useRealTimers();
+  });
+});

--- a/frontend/mobile/src/model/AppModel.tsx
+++ b/frontend/mobile/src/model/AppModel.tsx
@@ -1,4 +1,3 @@
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import {
   createContext,
   type PropsWithChildren,
@@ -10,6 +9,18 @@ import {
 } from 'react';
 
 import {
+  AuthSessionController,
+  type AuthSessionState,
+} from '@/features/auth/AuthSessionController';
+import { AuthService, type UserPreference } from '@/features/auth/AuthService';
+import {
+  cefrLevelForLevel,
+  levelForCefrLevel,
+  speedLabelForCode,
+  teacherForVoice,
+  voiceForTeacher,
+} from '@/features/auth/preferenceMappings';
+import {
   initialIeltsLearningRecords,
   initialInterviewLearningRecords,
   initialSceneLearningRecords,
@@ -17,16 +28,40 @@ import {
   type InterviewLearningRecord,
   type SceneLearningRecord,
 } from '@/data/learningAssets';
-import { teachers, type Teacher } from '@/theme/tokens';
+import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
+import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
+import { ApiClient } from '@/infrastructure/http/ApiClient';
+import { levels, teachers, type Teacher } from '@/theme/tokens';
+
+export type AppModelAuthController = {
+  getSnapshot(): AuthSessionState;
+  subscribe(listener: (state: AuthSessionState) => void): () => void;
+  bootstrap(): Promise<void>;
+  login(input: { username: string; password: string }): Promise<void>;
+  register(input: {
+    username: string;
+    password: string;
+    nickname: string | null;
+  }): Promise<void>;
+  updatePreference(patch: Partial<UserPreference>): Promise<UserPreference>;
+  logout(): Promise<void>;
+  unauthorized(): Promise<void>;
+};
 
 type AppModelValue = {
   isModelReady: boolean;
   isAuthenticated: boolean;
   hasCompletedOnboarding: boolean;
-  signIn: () => void;
-  signUp: () => void;
-  completeOnboarding: () => void;
-  signOut: () => void;
+  authStatus: AuthSessionState['status'];
+  authError: string | null;
+  signIn: (input: { username: string; password: string }) => Promise<void>;
+  signUp: (input: {
+    username: string;
+    password: string;
+    nickname: string | null;
+  }) => Promise<void>;
+  completeOnboarding: () => Promise<void>;
+  signOut: () => Promise<void>;
   nickname: string;
   setNickname: (value: string) => void;
   speed: string;
@@ -47,12 +82,32 @@ type AppModelValue = {
 };
 
 const AppModelContext = createContext<AppModelValue | null>(null);
-const onboardingStorageKey = 'unispeaking.onboarding.v1';
 
-export function AppModelProvider({ children }: PropsWithChildren) {
-  const [isModelReady, setIsModelReady] = useState(false);
-  const [isAuthenticated, setIsAuthenticated] = useState(false);
-  const [hasCompletedOnboarding, setHasCompletedOnboarding] = useState(false);
+function createDefaultAuthController(): AppModelAuthController {
+  const tokenStore = new SecureTokenStore();
+  let controller: AuthSessionController;
+  const apiClient = new ApiClient({
+    baseUrl: getRuntimeConfig().backendUrl,
+    tokenStore,
+    onUnauthorized: () => controller.unauthorized(),
+  });
+  controller = new AuthSessionController({
+    tokenStore,
+    authService: new AuthService(apiClient),
+  });
+  return controller;
+}
+
+export function AppModelProvider({
+  children,
+  authController: injectedAuthController,
+}: PropsWithChildren<{ authController?: AppModelAuthController }>) {
+  const [authController] = useState<AppModelAuthController>(
+    () => injectedAuthController ?? createDefaultAuthController(),
+  );
+  const [authState, setAuthState] = useState<AuthSessionState>(
+    () => authController.getSnapshot(),
+  );
   const [nickname, setNickname] = useState('Yufan');
   const [speed, setSpeed] = useState('自然');
   const [level, setLevel] = useState('starter');
@@ -63,27 +118,19 @@ export function AppModelProvider({ children }: PropsWithChildren) {
   const [membership, setMembership] = useState('免费版');
 
   useEffect(() => {
-    let active = true;
-    const hydrateOnboarding = async () => {
-      try {
-        const saved = await AsyncStorage.getItem(onboardingStorageKey);
-        if (!saved || !active) return;
-        const preference = JSON.parse(saved) as { completed?: boolean; level?: string; teacherId?: string };
-        if (preference.completed) setHasCompletedOnboarding(true);
-        if (preference.level) setLevel(preference.level);
-        const savedTeacher = teachers.find((item) => item.id === preference.teacherId);
-        if (savedTeacher) setTeacher(savedTeacher);
-      } catch {
-        // A damaged local preference should never block sign-in.
-      } finally {
-        if (active) setIsModelReady(true);
-      }
-    };
-    void hydrateOnboarding();
-    return () => {
-      active = false;
-    };
-  }, []);
+    const unsubscribe = authController.subscribe(setAuthState);
+    setAuthState(authController.getSnapshot());
+    void authController.bootstrap();
+    return unsubscribe;
+  }, [authController]);
+
+  useEffect(() => {
+    if (authState.user?.nickname) setNickname(authState.user.nickname);
+    if (!authState.preference) return;
+    setLevel(levelForCefrLevel(authState.preference.cefrLevel, levels).id);
+    setTeacher(teacherForVoice(authState.preference.preferredVoice, teachers));
+    setSpeed(speedLabelForCode(authState.preference.preferredAiSpeechSpeed));
+  }, [authState.preference, authState.user]);
 
   const addSceneRecord = useCallback((record: SceneLearningRecord) => {
     setSceneRecords((current) => [record, ...current.filter((item) => item.id !== record.id)]);
@@ -101,32 +148,40 @@ export function AppModelProvider({ children }: PropsWithChildren) {
     setSceneRecords((current) => current.filter((item) => item.id !== id));
   }, []);
 
-  const signIn = useCallback(() => {
-    setIsAuthenticated(true);
-  }, []);
+  const signIn = useCallback(
+    (input: { username: string; password: string }) => authController.login(input),
+    [authController],
+  );
 
-  const signUp = useCallback(() => {
-    setIsAuthenticated(true);
-    setHasCompletedOnboarding(false);
-  }, []);
+  const signUp = useCallback(
+    (input: { username: string; password: string; nickname: string | null }) =>
+      authController.register(input),
+    [authController],
+  );
 
-  const completeOnboarding = useCallback(() => {
-    setHasCompletedOnboarding(true);
-    void AsyncStorage.setItem(
-      onboardingStorageKey,
-      JSON.stringify({ completed: true, level, teacherId: teacher.id }),
-    );
-  }, [level, teacher.id]);
+  const completeOnboarding = useCallback(async () => {
+    const selectedLevel = levels.find((option) => option.id === level) ?? levels[0];
+    await authController.updatePreference({
+      cefrLevel: cefrLevelForLevel(selectedLevel),
+      preferredVoice: voiceForTeacher(teacher),
+    });
+  }, [authController, level, teacher]);
 
-  const signOut = useCallback(() => {
-    setIsAuthenticated(false);
-  }, []);
+  const signOut = useCallback(() => authController.logout(), [authController]);
+
+  const isModelReady = authState.status !== 'booting';
+  const isAuthenticated = authState.status === 'authenticated';
+  const hasCompletedOnboarding = Boolean(
+    authState.preference?.cefrLevel && authState.preference?.preferredVoice,
+  );
 
   const value = useMemo(
     () => ({
       isModelReady,
       isAuthenticated,
       hasCompletedOnboarding,
+      authStatus: authState.status,
+      authError: authState.error,
       signIn,
       signUp,
       completeOnboarding,
@@ -157,6 +212,8 @@ export function AppModelProvider({ children }: PropsWithChildren) {
       hasCompletedOnboarding,
       isModelReady,
       isAuthenticated,
+      authState.error,
+      authState.status,
       level,
       membership,
       nickname,

--- a/frontend/mobile/src/model/__tests__/AppModel.test.tsx
+++ b/frontend/mobile/src/model/__tests__/AppModel.test.tsx
@@ -1,0 +1,188 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { Pressable, Text, View } from 'react-native';
+
+import type { AuthSessionState } from '@/features/auth/AuthSessionController';
+import type { UserPreference } from '@/features/auth/AuthService';
+import { teachers } from '@/theme/tokens';
+
+import {
+  AppModelProvider,
+  type AppModelAuthController,
+  useAppModel,
+} from '../AppModel';
+
+function createController(state: AuthSessionState): AppModelAuthController & {
+  emit(nextState: AuthSessionState): void;
+  login: jest.Mock;
+  updatePreference: jest.Mock;
+} {
+  let listener: ((nextState: AuthSessionState) => void) | null = null;
+  return {
+    getSnapshot: () => state,
+    subscribe: jest.fn((nextListener: (nextState: AuthSessionState) => void) => {
+      listener = nextListener;
+      return () => {
+        listener = null;
+      };
+    }),
+    bootstrap: jest.fn(async () => {
+      listener?.(state);
+    }),
+    login: jest.fn(async () => undefined),
+    register: jest.fn(async () => undefined),
+    updatePreference: jest.fn(async (patch: Partial<UserPreference>) => ({
+      userId: 'user-1',
+      preferredVoice: null,
+      preferredAiSpeechSpeed: null,
+      cefrLevel: null,
+      memoryText: null,
+      ...patch,
+    })),
+    logout: jest.fn(async () => undefined),
+    unauthorized: jest.fn(async () => undefined),
+    emit(nextState) {
+      state = nextState;
+      listener?.(nextState);
+    },
+  };
+}
+
+const authenticatedState: AuthSessionState = {
+  status: 'authenticated',
+  user: {
+    id: 'user-1',
+    username: 'learner@example.com',
+    nickname: 'Yufan',
+    role: 'USER',
+    status: 'ACTIVE',
+    lastLoginAt: null,
+    createdAt: '2026-08-05T00:00:00Z',
+  },
+  preference: {
+    userId: 'user-1',
+    preferredVoice: 'Harvey',
+    preferredAiSpeechSpeed: 'NATURAL',
+    cefrLevel: 'B',
+    memoryText: null,
+  },
+  error: null,
+};
+
+function SessionProbe() {
+  const model = useAppModel();
+  return (
+    <View>
+      <Text testID="session-state">
+        {JSON.stringify({
+          ready: model.isModelReady,
+          authenticated: model.isAuthenticated,
+          onboarded: model.hasCompletedOnboarding,
+          nickname: model.nickname,
+          level: model.level,
+          teacher: model.teacher.name,
+          speed: model.speed,
+        })}
+      </Text>
+      <Pressable
+        accessibilityLabel="test-login"
+        onPress={() =>
+          void model.signIn({
+            username: 'learner@example.com',
+            password: 'password123',
+          })
+        }
+      />
+    </View>
+  );
+}
+
+function OnboardingProbe() {
+  const model = useAppModel();
+  return (
+    <View>
+      <Pressable accessibilityLabel="choose-level" onPress={() => model.setLevel('basic')} />
+      <Pressable accessibilityLabel="choose-teacher" onPress={() => model.setTeacher(teachers[1])} />
+      <Pressable
+        accessibilityLabel="complete-onboarding"
+        onPress={() => void model.completeOnboarding()}
+      />
+    </View>
+  );
+}
+
+describe('AppModelProvider authentication binding', () => {
+  it('hydrates the finalized UI choices from the authenticated backend preference', async () => {
+    const controller = createController(authenticatedState);
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <SessionProbe />
+      </AppModelProvider>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByTestId('session-state').props.children).toBe(
+        JSON.stringify({
+          ready: true,
+          authenticated: true,
+          onboarded: true,
+          nickname: 'Yufan',
+          level: 'basic',
+          teacher: 'James',
+          speed: '自然',
+        }),
+      ),
+    );
+  });
+
+  it('passes credentials to the real authentication controller', async () => {
+    const controller = createController({
+      status: 'anonymous',
+      user: null,
+      preference: null,
+      error: null,
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <SessionProbe />
+      </AppModelProvider>,
+    );
+
+    await waitFor(() => expect(controller.subscribe).toHaveBeenCalledTimes(1));
+    await fireEvent.press(screen.getByLabelText('test-login'));
+
+    await waitFor(() =>
+      expect(controller.login).toHaveBeenCalledWith({
+        username: 'learner@example.com',
+        password: 'password123',
+      }),
+    );
+  });
+
+  it('persists the selected level and teacher when onboarding completes', async () => {
+    const controller = createController({
+      ...authenticatedState,
+      preference: {
+        ...authenticatedState.preference!,
+        preferredVoice: null,
+        cefrLevel: null,
+      },
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <OnboardingProbe />
+      </AppModelProvider>,
+    );
+
+    await waitFor(() => expect(controller.subscribe).toHaveBeenCalledTimes(1));
+    await fireEvent.press(screen.getByLabelText('choose-level'));
+    await fireEvent.press(screen.getByLabelText('choose-teacher'));
+    await fireEvent.press(screen.getByLabelText('complete-onboarding'));
+
+    await waitFor(() =>
+      expect(controller.updatePreference).toHaveBeenCalledWith({
+        cefrLevel: 'B',
+        preferredVoice: 'Harvey',
+      }),
+    );
+  });
+});

--- a/frontend/mobile/src/screens/AssetsScreen.tsx
+++ b/frontend/mobile/src/screens/AssetsScreen.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
 import { ArrowLeftIcon } from 'phosphor-react-native/src/icons/ArrowLeft';
 import { ArrowRightIcon } from 'phosphor-react-native/src/icons/ArrowRight';
@@ -14,8 +14,25 @@ import { TranslateIcon } from 'phosphor-react-native/src/icons/Translate';
 
 import { AppButton, AppScreen, Card, PageHeader, Pill, SectionTitle } from '@/components/ui';
 import type { LearningExpression, SceneLearningRecord } from '@/data/learningAssets';
-import { useAppModel } from '@/model/AppModel';
+import { LearningAssetService } from '@/features/scenes/LearningAssetService';
+import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
+import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
+import { ApiClient } from '@/infrastructure/http/ApiClient';
 import { colors } from '@/theme/tokens';
+
+type LearningAssetServicePort = Pick<
+  LearningAssetService,
+  'listRecords' | 'getRecord'
+>;
+
+function createLearningAssetService(): LearningAssetService {
+  return new LearningAssetService(
+    new ApiClient({
+      baseUrl: getRuntimeConfig().backendUrl,
+      tokenStore: new SecureTokenStore(),
+    }),
+  );
+}
 
 function AssetModuleMenu({ onIelts, onInterview }: { onIelts: () => void; onInterview: () => void }) {
   const [open, setOpen] = useState(false);
@@ -75,12 +92,44 @@ export function AssetsScreen({
   onOpenRecord,
   onOpenIelts,
   onOpenInterview,
+  assetService: injectedAssetService,
 }: {
   onOpenRecord: (record: SceneLearningRecord) => void;
   onOpenIelts: () => void;
   onOpenInterview: () => void;
+  assetService?: LearningAssetServicePort;
 }) {
-  const { sceneRecords } = useAppModel();
+  const [assetService] = useState<LearningAssetServicePort>(
+    () => injectedAssetService ?? createLearningAssetService(),
+  );
+  const [sceneRecords, setSceneRecords] = useState<SceneLearningRecord[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    void assetService.listRecords().then(
+      (records) => {
+        if (active) setSceneRecords(records);
+      },
+      (cause: unknown) => {
+        if (active) {
+          setError(cause instanceof Error ? cause.message : '学习资产加载失败');
+        }
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [assetService, reloadKey]);
+
+  const reload = () => {
+    setError(null);
+    setSceneRecords(null);
+    setReloadKey((current) => current + 1);
+  };
+
+  const count = sceneRecords?.length ?? 0;
   return (
     <AppScreen>
       <PageHeader
@@ -89,10 +138,23 @@ export function AssetsScreen({
         subtitle="把场景练习中真正用过的表达，留在这里继续复习。"
         action={<AssetModuleMenu onIelts={onOpenIelts} onInterview={onOpenInterview} />}
       />
-      <SectionTitle eyebrow="TRAINING HISTORY" title="场景训练记录" action={<Text style={styles.count}>{sceneRecords.length} 条</Text>} />
+      <SectionTitle eyebrow="TRAINING HISTORY" title="场景训练记录" action={<Text style={styles.count}>{count} 条</Text>} />
       <Card style={styles.recordsCard}>
-        {sceneRecords.map((record) => <SceneRecordRow key={record.id} record={record} onPress={() => onOpenRecord(record)} />)}
-        {!sceneRecords.length ? (
+        {sceneRecords?.map((record) => <SceneRecordRow key={record.id} record={record} onPress={() => onOpenRecord(record)} />)}
+        {sceneRecords === null && !error ? (
+          <View style={styles.empty}>
+            <BookOpenTextIcon color={colors.subtle} size={30} />
+            <Text style={styles.emptyTitle}>正在同步场景学习资产…</Text>
+          </View>
+        ) : null}
+        {error ? (
+          <View style={styles.empty}>
+            <Text style={styles.emptyTitle}>暂时无法加载</Text>
+            <Text style={styles.emptyText}>{error}</Text>
+            <AppButton title="重新加载" variant="soft" onPress={reload} />
+          </View>
+        ) : null}
+        {sceneRecords?.length === 0 ? (
           <View style={styles.empty}>
             <BookOpenTextIcon color={colors.subtle} size={30} />
             <Text style={styles.emptyTitle}>暂无场景学习资产</Text>
@@ -182,6 +244,77 @@ export function SceneAssetDetail({ record, onBack, onPractice, onDelete }: { rec
         </View>
       </Modal>
     </>
+  );
+}
+
+export function SceneAssetDetailLoader({
+  sceneId,
+  onBack,
+  onPractice,
+  onDelete,
+  assetService: injectedAssetService,
+}: {
+  sceneId: string;
+  onBack: () => void;
+  onPractice: () => void;
+  onDelete: () => void;
+  assetService?: LearningAssetServicePort;
+}) {
+  const [assetService] = useState<LearningAssetServicePort>(
+    () => injectedAssetService ?? createLearningAssetService(),
+  );
+  const [record, setRecord] = useState<SceneLearningRecord | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
+
+  useEffect(() => {
+    let active = true;
+    void assetService.getRecord(sceneId).then(
+      (nextRecord) => {
+        if (active) setRecord(nextRecord);
+      },
+      (cause: unknown) => {
+        if (active) {
+          setError(cause instanceof Error ? cause.message : '学习资产详情加载失败');
+        }
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [assetService, reloadKey, sceneId]);
+
+  const reload = () => {
+    setError(null);
+    setRecord(null);
+    setReloadKey((current) => current + 1);
+  };
+
+  if (record) {
+    return (
+      <SceneAssetDetail
+        record={record}
+        onBack={onBack}
+        onPractice={onPractice}
+        onDelete={onDelete}
+      />
+    );
+  }
+
+  return (
+    <AppScreen>
+      <View style={styles.detailBar}>
+        <Pressable accessibilityRole="button" accessibilityLabel="返回" onPress={onBack} style={styles.roundButton}><ArrowLeftIcon color={colors.ink} size={20} weight="bold" /></Pressable>
+      </View>
+      <Card style={styles.recordsCard}>
+        <View style={styles.empty}>
+          <BookOpenTextIcon color={colors.subtle} size={30} />
+          <Text style={styles.emptyTitle}>{error ? '暂时无法加载' : '正在加载学习资产…'}</Text>
+          {error ? <Text style={styles.emptyText}>{error}</Text> : null}
+          {error ? <AppButton title="重新加载" variant="soft" onPress={reload} /> : null}
+        </View>
+      </Card>
+    </AppScreen>
   );
 }
 

--- a/frontend/mobile/src/screens/AuthScreens.tsx
+++ b/frontend/mobile/src/screens/AuthScreens.tsx
@@ -184,7 +184,7 @@ export function AuthFormScreen({
   onBack: () => void;
   onSwitch: () => void;
 }) {
-  const { nickname, setNickname, signIn, signUp } = useAppModel();
+  const { authError, authStatus, nickname, setNickname, signIn, signUp } = useAppModel();
   const [draftNickname, setDraftNickname] = useState(nickname);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -194,15 +194,24 @@ export function AuthFormScreen({
   const nicknameValid = mode === 'login' || draftNickname.trim().length >= 2;
   const valid = emailValid && passwordValid && nicknameValid;
 
-  const submit = () => {
+  const submit = async () => {
     setSubmitted(true);
     if (!valid) return;
-    if (mode === 'signup') {
-      setNickname(draftNickname.trim());
-      signUp();
-      return;
+    try {
+      if (mode === 'signup') {
+        const nextNickname = draftNickname.trim();
+        setNickname(nextNickname);
+        await signUp({
+          username: email.trim(),
+          password,
+          nickname: nextNickname,
+        });
+        return;
+      }
+      await signIn({ username: email.trim(), password });
+    } catch {
+      // The controller publishes the backend-safe message through authError.
     }
-    signIn();
   };
 
   return (
@@ -260,15 +269,18 @@ export function AuthFormScreen({
             autoCapitalize="none"
             autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
             style={[styles.input, submitted && !passwordValid && styles.inputError]}
-            onSubmitEditing={submit}
+            onSubmitEditing={() => void submit()}
           />
           {submitted && !passwordValid ? <Text style={styles.errorText}>密码至少需要 8 位字符</Text> : null}
         </View>
       </View>
 
+      {authError ? <Text accessibilityRole="alert" style={styles.errorText}>{authError}</Text> : null}
+
       <AppButton
         title={mode === 'login' ? '登录' : '注册并继续'}
-        onPress={submit}
+        disabled={authStatus === 'authenticating'}
+        onPress={() => void submit()}
         style={styles.fullWidth}
       />
 
@@ -342,8 +354,7 @@ export function TeacherOnboardingScreen({ onComplete }: { onComplete: () => void
       <OnboardingFooter
         title="选择这位老师"
         onPress={() => {
-          completeOnboarding();
-          onComplete();
+          void completeOnboarding().then(onComplete);
         }}
       />
     </SafeAreaView>

--- a/frontend/mobile/src/screens/ConversationScreen.tsx
+++ b/frontend/mobile/src/screens/ConversationScreen.tsx
@@ -21,6 +21,9 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { ConversationSettings } from '@/components/ConversationSettings';
 import { AppButton, AppIcon, AppScreen, Brand } from '@/components/ui';
+import { speedCodeForLabel } from '@/features/auth/preferenceMappings';
+import { useFreeChatSession } from '@/features/conversation/useFreeChatSession';
+import type { RealtimeState } from '@/features/realtime/types';
 import { useAppModel } from '@/model/AppModel';
 import { colors } from '@/theme/tokens';
 
@@ -29,6 +32,35 @@ function formatDuration(total: number) {
 }
 
 const voiceWaveRestingLevels = [0.28, 0.52, 0.78, 1, 0.72, 0.48, 0.3];
+
+export function selectCallCaption(
+  session: {
+    state: RealtimeState;
+    error: string | null;
+    userTranscript: string;
+    assistantTranscript: string;
+  },
+  teacherName: string,
+  statusLabel: string,
+) {
+  if (session.error) return { speaker: '系统', text: session.error };
+  if (session.state === 'user_speaking') {
+    return { speaker: '你', text: session.userTranscript || statusLabel };
+  }
+  if (session.state === 'assistant_speaking') {
+    return {
+      speaker: teacherName,
+      text: session.assistantTranscript || statusLabel,
+    };
+  }
+  if (session.assistantTranscript) {
+    return { speaker: teacherName, text: session.assistantTranscript };
+  }
+  if (session.userTranscript) {
+    return { speaker: '你', text: session.userTranscript };
+  }
+  return { speaker: teacherName, text: statusLabel };
+}
 
 function VoiceWaveBar({ active, compact, index, level }: { active: boolean; compact: boolean; index: number; level: number }) {
   const scale = useSharedValue(level);
@@ -83,30 +115,49 @@ export function CallExperience({
   allowSubtitleToggle = true,
   compactTranscriptLayout = false,
   progressCollapsed = false,
+  transcriptSpeaker,
   transcriptEnglish = 'Hi there! How are you feeling today?',
   transcriptChinese = '嗨！你今天感觉怎么样？',
+  userTranscript = '',
+  elapsed: controlledElapsed,
+  muted: controlledMuted,
+  statusLabel,
+  onMutedChange,
 }: {
   onEnd: () => void;
   allowSubtitleToggle?: boolean;
   compactTranscriptLayout?: boolean;
   progressCollapsed?: boolean;
+  transcriptSpeaker?: string;
   transcriptEnglish?: string;
   transcriptChinese?: string;
+  userTranscript?: string;
+  elapsed?: number;
+  muted?: boolean;
+  statusLabel?: string;
+  onMutedChange?: (muted: boolean) => void;
 }) {
   const { teacher } = useAppModel();
-  const [elapsed, setElapsed] = useState(0);
-  const [muted, setMuted] = useState(false);
+  const [internalElapsed, setInternalElapsed] = useState(0);
+  const [internalMuted, setInternalMuted] = useState(false);
   const [subtitles, setSubtitles] = useState(true);
   const [translated, setTranslated] = useState(false);
   const subtitlesProgress = useSharedValue(1);
   const transcriptVisibility = useSharedValue(1);
   const compactLayoutProgress = useSharedValue(progressCollapsed ? 1 : 0);
+  const elapsed = controlledElapsed ?? internalElapsed;
+  const muted = controlledMuted ?? internalMuted;
+  const primaryDuplicatesUser =
+    transcriptSpeaker === '你' && transcriptEnglish === userTranscript;
 
   useEffect(() => {
-    if (muted) return;
-    const timer = setInterval(() => setElapsed((current) => current + 1), 1000);
+    if (controlledElapsed !== undefined || muted) return;
+    const timer = setInterval(
+      () => setInternalElapsed((current) => current + 1),
+      1000,
+    );
     return () => clearInterval(timer);
-  }, [muted]);
+  }, [controlledElapsed, muted]);
 
   useEffect(() => {
     subtitlesProgress.value = withTiming(subtitles ? 1 : 0, {
@@ -169,7 +220,7 @@ export function CallExperience({
           <Animated.View style={[styles.listeningState, listeningTransitionStyle]}>
             <VoiceWaveform active={!muted} compact={subtitles} />
             <Text style={styles.timer}>{muted ? `已暂停 · ${formatDuration(elapsed)}` : formatDuration(elapsed)}</Text>
-            {!subtitles ? <Text style={styles.callStatus}>{muted ? '会话已暂停' : '可以开始说了'}</Text> : null}
+            {!subtitles ? <Text style={styles.callStatus}>{statusLabel ?? (muted ? '会话已暂停' : '可以开始说了')}</Text> : null}
           </Animated.View>
         </Animated.View>
         <Animated.View
@@ -178,17 +229,36 @@ export function CallExperience({
           pointerEvents={subtitles ? 'auto' : 'none'}
           style={[styles.transcript, compactTranscriptLayout && styles.transcriptCompact, transcriptTransitionStyle]}
         >
-            <Text style={styles.speaker}>{teacher.name}</Text>
-            <Text style={[styles.transcriptEnglish, compactTranscriptLayout && styles.transcriptEnglishCompact]}>{transcriptEnglish}</Text>
-            <Pressable accessibilityRole="button" accessibilityLabel={translated ? '收起翻译' : '翻译'} onPress={() => setTranslated((current) => !current)} style={styles.translate}>
-              <AppIcon name="translate" size={14} color={colors.subtle} />
-              <Text style={styles.translateText}>{translated ? '收起翻译' : '翻译'}</Text>
-            </Pressable>
-            {translated ? <Text style={styles.translation}>{transcriptChinese}</Text> : null}
+            {userTranscript ? (
+              <View style={styles.userTranscriptBlock}>
+                <Text style={styles.speaker}>你</Text>
+                <Text style={[styles.userTranscriptText, compactTranscriptLayout && styles.userTranscriptTextCompact]}>{userTranscript}</Text>
+              </View>
+            ) : null}
+            {!primaryDuplicatesUser ? (
+              <View style={userTranscript ? styles.assistantTranscriptBlock : undefined}>
+                <Text style={styles.speaker}>{transcriptSpeaker ?? teacher.name}</Text>
+                <Text style={[styles.transcriptEnglish, compactTranscriptLayout && styles.transcriptEnglishCompact]}>{transcriptEnglish}</Text>
+                <Pressable accessibilityRole="button" accessibilityLabel={translated ? '收起翻译' : '翻译'} onPress={() => setTranslated((current) => !current)} style={styles.translate}>
+                  <AppIcon name="translate" size={14} color={colors.subtle} />
+                  <Text style={styles.translateText}>{translated ? '收起翻译' : '翻译'}</Text>
+                </Pressable>
+                {translated ? <Text style={styles.translation}>{transcriptChinese}</Text> : null}
+              </View>
+            ) : null}
         </Animated.View>
       </View>
       <View style={[styles.callControls, compactTranscriptLayout && styles.callControlsCompact]}>
-        <Pressable accessibilityRole="button" accessibilityLabel={muted ? '恢复会话' : '暂停会话'} onPress={() => setMuted((current) => !current)} style={[styles.callControl, muted && styles.callControlActive]}>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={muted ? '恢复会话' : '暂停会话'}
+          onPress={() => {
+            const nextMuted = !muted;
+            if (onMutedChange) onMutedChange(nextMuted);
+            else setInternalMuted(nextMuted);
+          }}
+          style={[styles.callControl, muted && styles.callControlActive]}
+        >
           {muted ? <MicrophoneSlashIcon size={24} color={colors.ink} /> : <MicrophoneIcon size={24} color={colors.ink} />}
         </Pressable>
         {allowSubtitleToggle ? (
@@ -205,9 +275,28 @@ export function CallExperience({
 }
 
 export function CallScreen({ onEnd }: { onEnd: () => void }) {
+  const { teacher, speed } = useAppModel();
+  const session = useFreeChatSession({
+    voice: teacher.voiceId,
+    model: 'qwen3.5-omni-flash-realtime',
+    speechSpeed: speedCodeForLabel(speed),
+  });
+  const caption = selectCallCaption(session, teacher.name, session.statusLabel);
+
   return (
     <SafeAreaView edges={['top', 'bottom']} style={styles.callScreen}>
-      <CallExperience onEnd={onEnd} />
+      <CallExperience
+        onEnd={() => {
+          void session.end().finally(onEnd);
+        }}
+        elapsed={session.elapsed}
+        muted={session.muted}
+        statusLabel={session.statusLabel}
+        transcriptSpeaker={caption.speaker}
+        transcriptEnglish={caption.text}
+        userTranscript={session.userTranscript}
+        onMutedChange={() => session.toggleMuted()}
+      />
     </SafeAreaView>
   );
 }
@@ -431,6 +520,10 @@ const styles = StyleSheet.create({
   transcript: { position: 'absolute', top: 220, left: 0, right: 0, bottom: 0, paddingHorizontal: 8, paddingTop: 12 },
   transcriptCompact: { top: 126, paddingHorizontal: 2, paddingTop: 18 },
   speaker: { color: colors.subtle, fontSize: 13, fontWeight: '300' },
+  userTranscriptBlock: { paddingBottom: 14, borderBottomWidth: 1, borderBottomColor: colors.line },
+  userTranscriptText: { marginTop: 6, color: colors.muted, fontSize: 18, lineHeight: 26, fontWeight: '300' },
+  userTranscriptTextCompact: { fontSize: 19, lineHeight: 27 },
+  assistantTranscriptBlock: { paddingTop: 14 },
   transcriptEnglish: { marginTop: 10, maxWidth: 350, color: colors.ink, fontSize: 24, lineHeight: 34, fontWeight: '300', letterSpacing: -0.6 },
   transcriptEnglishCompact: { maxWidth: 380, fontSize: 27, lineHeight: 38, letterSpacing: -0.8 },
   translate: { marginTop: 8, flexDirection: 'row', alignItems: 'center', gap: 5 },

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -18,14 +18,36 @@ import {
   recommendations,
   type ScenePromptExample,
 } from '@/data/content';
+import { SceneService, type GeneratedScene } from '@/features/scenes/SceneService';
+import { SceneTrainingController, type SceneTrainingSnapshot } from '@/features/scenes/SceneTrainingController';
+import { WavRecorder } from '@/features/audio/WavRecorder';
+import { SceneSpeechClient, TtsPlayer } from '@/features/audio/TtsPlayer';
+import {
+  useFreeChatSession,
+  type FreeChatConfig,
+  type FreeChatControllerPort,
+} from '@/features/conversation/useFreeChatSession';
+import { ReactNativeWebRTCTransport } from '@/features/realtime/ReactNativeWebRTCTransport';
+import { RealtimeSessionApi } from '@/features/realtime/RealtimeSessionApi';
+import { RealtimeSessionController } from '@/features/realtime/RealtimeSessionController';
+import { SessionMessageSocket } from '@/features/realtime/SessionMessageSocket';
+import {
+  SceneDialogueApi,
+  type DialogueCompletion,
+  type DialogueReport,
+} from '@/features/scenes/SceneDialogueApi';
+import { speedCodeForLabel } from '@/features/auth/preferenceMappings';
+import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
+import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
+import { ApiClient } from '@/infrastructure/http/ApiClient';
 import { useAppModel } from '@/model/AppModel';
 import { colors } from '@/theme/tokens';
-import { CallExperience } from './ConversationScreen';
+import { CallExperience, selectCallCaption } from './ConversationScreen';
 import { IeltsFlow, InterviewFlow } from './SpecialtyFlows';
 
 export type SceneRoute =
   | { name: 'home' }
-  | { name: 'training'; id: string }
+  | { name: 'training'; scene: GeneratedScene }
   | { name: 'ielts' }
   | { name: 'interview' };
 
@@ -146,6 +168,19 @@ const defaultSceneMetrics: readonly SceneMetric[] = [
   { label: '自然', value: 87 },
 ];
 
+export function sceneMetricsForReport(
+  report?: DialogueReport,
+): readonly SceneMetric[] {
+  if (!report) return defaultSceneMetrics;
+  return [
+    { label: '准确', value: report.accuracyScore },
+    { label: '流利', value: report.fluencyScore },
+    { label: '语法', value: report.grammarScore },
+    { label: '词汇', value: report.vocabularyScore },
+    { label: '自然', value: report.naturalnessScore },
+  ];
+}
+
 function SceneRadar({ metrics }: { metrics: readonly SceneMetric[] }) {
   const size = 208;
   const center = size / 2;
@@ -174,9 +209,91 @@ function SceneRadar({ metrics }: { metrics: readonly SceneMetric[] }) {
   );
 }
 
-export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id: string; initialStage?: TrainingStage; onBack: () => void; onFinish: () => void }) {
-  const { addSceneRecord } = useAppModel();
-  const scenario = recommendations.find((item) => item.id === id) ?? recommendations[0];
+type SceneControllerFactory = (
+  sceneId: string,
+  config: FreeChatConfig,
+) => FreeChatControllerPort;
+
+function createDefaultSceneController(
+  sceneId: string,
+  config: FreeChatConfig,
+): FreeChatControllerPort {
+  const tokenStore = new SecureTokenStore();
+  const { backendUrl } = getRuntimeConfig();
+  const apiClient = new ApiClient({ baseUrl: backendUrl, tokenStore });
+  return new RealtimeSessionController(
+    {
+      transport: new ReactNativeWebRTCTransport(),
+      sessionApi: new RealtimeSessionApi(apiClient),
+      sessionSocket: new SessionMessageSocket({ baseUrl: backendUrl, tokenStore }),
+      sceneDialogue: new SceneDialogueApi(apiClient, sceneId),
+    },
+    {
+      mode: 'scene',
+      sceneId,
+      ...config,
+    },
+  );
+}
+
+export function SceneCallStage({
+  scene,
+  progressCollapsed,
+  onComplete,
+  createController = createDefaultSceneController,
+}: {
+  scene: GeneratedScene;
+  progressCollapsed: boolean;
+  onComplete: (completion: DialogueCompletion) => void;
+  createController?: SceneControllerFactory;
+}) {
+  const { teacher, speed } = useAppModel();
+  const deliveredCompletion = useRef<DialogueCompletion | null>(null);
+  const session = useFreeChatSession(
+    {
+      voice: teacher.voiceId,
+      model: 'qwen3.5-omni-flash-realtime',
+      speechSpeed: speedCodeForLabel(speed),
+    },
+    (config) => createController(scene.sceneId, config),
+  );
+
+  useEffect(() => {
+    if (
+      session.completion &&
+      session.completion !== deliveredCompletion.current
+    ) {
+      deliveredCompletion.current = session.completion;
+      onComplete(session.completion);
+    }
+  }, [onComplete, session.completion]);
+
+  const caption = selectCallCaption(session, teacher.name, session.statusLabel);
+  return (
+    <CallExperience
+      allowSubtitleToggle={false}
+      compactTranscriptLayout
+      elapsed={session.elapsed}
+      muted={session.muted}
+      onEnd={() => {
+        void session.end().catch(() => undefined);
+      }}
+      onMutedChange={() => session.toggleMuted()}
+      progressCollapsed={progressCollapsed}
+      statusLabel={session.statusLabel}
+      transcriptSpeaker={caption.speaker}
+      transcriptEnglish={caption.text}
+      transcriptChinese=""
+      userTranscript={session.userTranscript}
+    />
+  );
+}
+
+export function Training({ id, scene, trainingController: injectedTrainingController, wavRecorder: injectedWavRecorder, ttsPlayer: injectedTtsPlayer, initialStage = 'learn', onBack, onFinish }: { id?: string; scene?: GeneratedScene; trainingController?: SceneTrainingController; wavRecorder?: Pick<WavRecorder, 'start' | 'stop' | 'cancel'>; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'>; initialStage?: TrainingStage; onBack: () => void; onFinish: () => void }) {
+  const sceneId = scene?.sceneId ?? id ?? recommendations[0].id;
+  const scenario = scene
+    ? { id: scene.sceneId, title: scene.title }
+    : recommendations.find((item) => item.id === sceneId) ?? recommendations[0];
   const wordItems = learningItems.filter((item) => item.type === '单词');
   const phraseItems = learningItems.filter((item) => item.type === '短语');
   const readItems = learningItems.filter((item) => item.type === '句子');
@@ -189,14 +306,102 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
   const [readFeedbackOpen, setReadFeedbackOpen] = useState(false);
   const [demoPlaying, setDemoPlaying] = useState(false);
   const [recording, setRecording] = useState(false);
+  const [audioError, setAudioError] = useState<string | null>(null);
   const [completionOpen, setCompletionOpen] = useState(false);
+  const [dialogueCompletion, setDialogueCompletion] = useState<DialogueCompletion | null>(null);
   const [progressCollapsed, setProgressCollapsed] = useState(false);
-  const learnItems = learningGroup === 'words' ? wordItems : phraseItems;
-  const learnItem = learnItems[learnIndex] ?? learnItems[0];
-  const readItem = readItems[readIndex] ?? readItems[0];
+  const readRecordingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [trainingController] = useState<SceneTrainingController | null>(() =>
+    scene
+      ? injectedTrainingController ?? new SceneTrainingController(createDefaultSceneService())
+      : null,
+  );
+  const [wavRecorder] = useState<Pick<WavRecorder, 'start' | 'stop' | 'cancel'> | null>(
+    () => (scene ? injectedWavRecorder ?? new WavRecorder() : null),
+  );
+  const [ttsPlayer] = useState<Pick<TtsPlayer, 'play' | 'stop'> | null>(
+    () => (scene ? injectedTtsPlayer ?? createDefaultTtsPlayer() : null),
+  );
+  const [trainingSnapshot, setTrainingSnapshot] = useState<SceneTrainingSnapshot | null>(
+    () => trainingController?.getSnapshot() ?? null,
+  );
+
+  useEffect(() => {
+    if (!scene || !trainingController) return;
+    const unsubscribe = trainingController.subscribe(setTrainingSnapshot);
+    void trainingController.start(scene).catch(() => undefined);
+    return unsubscribe;
+  }, [scene, trainingController]);
+
+  useEffect(
+    () => () => {
+      if (readRecordingTimer.current) {
+        clearTimeout(readRecordingTimer.current);
+        readRecordingTimer.current = null;
+      }
+      void wavRecorder?.cancel().catch(() => undefined);
+      ttsPlayer?.stop();
+    },
+    [ttsPlayer, wavRecorder],
+  );
+
+  const displayedStage = scene && trainingSnapshot ? trainingSnapshot.stage : stage;
+  const displayedLearningGroup = scene && trainingSnapshot
+    ? trainingSnapshot.learningGroup
+    : learningGroup;
+  const displayedUnlockedStage = scene && trainingSnapshot
+    ? trainingSnapshot.unlockedStage
+    : unlockedStage;
+  const displayedIndex = scene && trainingSnapshot ? trainingSnapshot.index : learnIndex;
+  const backendItems = trainingSnapshot?.items.map((item) => ({
+    type: displayedStage === 'read' ? '句子' : displayedLearningGroup === 'words' ? '单词' : '短语',
+    en: item.englishText,
+    zh: item.chineseText,
+    phonetic: item.phonetic ?? '',
+  })) ?? [];
+  const learnItems = scene && displayedStage === 'learn'
+    ? backendItems
+    : displayedLearningGroup === 'words' ? wordItems : phraseItems;
+  const displayedReadItems = scene && displayedStage === 'read' ? backendItems : readItems;
+  const learnItem = learnItems[displayedIndex] ?? learnItems[0] ?? learningItems[0];
+  const displayedReadIndex = scene && trainingSnapshot ? trainingSnapshot.index : readIndex;
+  const readItem = displayedReadItems[displayedReadIndex] ?? displayedReadItems[0] ?? learningItems[3];
+  const displayedReadPassed = scene && trainingSnapshot
+    ? Boolean(trainingSnapshot.readingResult?.passed)
+    : readPassed;
+  const isLastReadItem = displayedReadIndex >= displayedReadItems.length - 1;
+  const readingResult = trainingSnapshot?.readingResult;
+  const completionMetrics = sceneMetricsForReport(dialogueCompletion?.evaluation);
+
+  const toggleDemo = async (text: string) => {
+    if (!scene || !ttsPlayer) {
+      setDemoPlaying((current) => !current);
+      return;
+    }
+    if (demoPlaying) {
+      ttsPlayer.stop();
+      setDemoPlaying(false);
+      return;
+    }
+    setAudioError(null);
+    try {
+      await ttsPlayer.play(scene.sceneId, text);
+      setDemoPlaying(true);
+    } catch (error) {
+      setDemoPlaying(false);
+      setAudioError(
+        error instanceof Error ? error.message : '标准发音播放失败',
+      );
+    }
+  };
 
   const nextLearn = () => {
+    ttsPlayer?.stop();
     setDemoPlaying(false);
+    if (scene && trainingController) {
+      void trainingController.next();
+      return;
+    }
     if (learnIndex < learnItems.length - 1) setLearnIndex((current) => current + 1);
     else if (learningGroup === 'words' && phraseItems.length > 0) {
       setLearningGroup('phrases');
@@ -208,14 +413,58 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
     }
   };
   const previousLearn = () => {
+    ttsPlayer?.stop();
     setDemoPlaying(false);
+    if (scene && trainingController) {
+      trainingController.previous();
+      return;
+    }
     if (learnIndex > 0) setLearnIndex((current) => current - 1);
     else if (learningGroup === 'phrases' && wordItems.length > 0) {
       setLearningGroup('words');
       setLearnIndex(wordItems.length - 1);
     }
   };
-  const toggleReadRecording = () => {
+  const clearReadRecordingTimer = () => {
+    if (!readRecordingTimer.current) return;
+    clearTimeout(readRecordingTimer.current);
+    readRecordingTimer.current = null;
+  };
+  const submitReadRecording = async () => {
+    clearReadRecordingTimer();
+    setRecording(false);
+    if (!scene || !trainingController || !wavRecorder) return;
+    try {
+      const wavUri = await wavRecorder.stop();
+      await trainingController.scoreReading(wavUri);
+      setReadFeedbackOpen(true);
+    } catch (error) {
+      setAudioError(
+        error instanceof Error ? error.message : '朗读录音或评分失败',
+      );
+    }
+  };
+  const toggleReadRecording = async () => {
+    if (scene && trainingController && wavRecorder) {
+      setAudioError(null);
+      if (recording) {
+        await submitReadRecording();
+        return;
+      }
+      try {
+        await wavRecorder.start();
+        setRecording(true);
+        readRecordingTimer.current = setTimeout(() => {
+          void submitReadRecording();
+        }, 30_000);
+      } catch (error) {
+        setRecording(false);
+        setAudioError(
+          error instanceof Error ? error.message : '朗读录音或评分失败',
+        );
+      }
+      return;
+    }
     if (recording) {
       setRecording(false);
       setReadPassed(true);
@@ -226,34 +475,6 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
     }
   };
   const finishTraining = () => {
-    addSceneRecord({
-      id,
-      title: scenario.title,
-      date: '刚刚',
-      status: '已完成',
-      score: 86,
-      practiceCount: 1,
-      expressions: learningItems.map((item, index) => ({
-        id: `${id}-${index}`,
-        type: item.type === '短语' ? '词组' : item.type,
-        englishText: item.en,
-        chineseText: item.zh,
-        phonetic: item.phonetic,
-      })),
-      conversation: [
-        { id: `${id}-assistant`, role: 'assistant', speaker: 'James', text: 'Good morning! What can I get started for you today?' },
-        {
-          id: `${id}-user`,
-          role: 'user',
-          speaker: '你',
-          text: 'Could you recommend something less sweet?',
-          feedback: {
-            suggestedExpression: 'Could you recommend something that is not too sweet?',
-            feedbackSummary: '表达清楚自然；补充 “not too” 可以让甜度需求更具体。',
-          },
-        },
-      ],
-    });
     setCompletionOpen(false);
     onFinish();
   };
@@ -273,23 +494,26 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
       </View>
 
       <StageProgressRail
-        stage={stage}
-        unlockedStage={unlockedStage}
+        stage={displayedStage}
+        unlockedStage={displayedUnlockedStage}
         onCollapsedChange={setProgressCollapsed}
         onSelect={(nextStage) => {
           setRecording(false);
           setDemoPlaying(false);
+          if (scene) return;
           setStage(nextStage);
         }}
       />
 
-      {stage === 'learn' ? (
+      {trainingSnapshot?.error ? <Text style={styles.generationError}>{trainingSnapshot.error}</Text> : null}
+
+      {displayedStage === 'learn' ? (
         <View style={styles.stageShell}>
           <View style={styles.stageMetaRow}>
-            <Text style={styles.stageHeading}>{learningGroup === 'words' ? '场景单词' : '场景短语'}</Text>
+            <Text style={styles.stageHeading}>{displayedLearningGroup === 'words' ? '场景单词' : '场景短语'}</Text>
           </View>
           <View style={styles.languageCard}>
-            <Text style={styles.languageCount}>{learnIndex + 1} / {learnItems.length}</Text>
+            <Text style={styles.languageCount}>{displayedIndex + 1} / {learnItems.length}</Text>
             <Text style={styles.languageType}>{learnItem.type}</Text>
             <Text style={styles.languageEnglish}>{learnItem.en}</Text>
             <View style={styles.pronunciationRow}>
@@ -297,7 +521,7 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="播放发音"
-                onPress={() => setDemoPlaying((current) => !current)}
+                onPress={() => void toggleDemo(learnItem.en)}
                 style={({ pressed }) => [styles.speakerButton, (pressed || demoPlaying) && styles.speakerButtonActive]}
               >
                 <AppIcon name="volume" size={21} color={colors.subtle} />
@@ -309,15 +533,15 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="上一个表达"
-              disabled={learnIndex === 0 && learningGroup === 'words'}
+              disabled={displayedIndex === 0 && displayedLearningGroup === 'words'}
               onPress={previousLearn}
-              style={[styles.roundNavButton, learnIndex === 0 && learningGroup === 'words' && styles.roundNavDisabled]}
+              style={[styles.roundNavButton, displayedIndex === 0 && displayedLearningGroup === 'words' && styles.roundNavDisabled]}
             >
               <AppIcon name="arrow-left" size={20} />
             </Pressable>
             <Pressable accessibilityRole="button" onPress={nextLearn} style={styles.primaryPillButton}>
               <Text style={styles.primaryPillText}>
-                {learnIndex < learnItems.length - 1 ? '下一个' : learningGroup === 'words' && phraseItems.length > 0 ? '进入词组' : '进入朗读'}
+                {displayedIndex < learnItems.length - 1 ? '下一个' : displayedLearningGroup === 'words' ? '进入词组' : '进入朗读'}
               </Text>
               <AppIcon name="arrow-right" size={18} color={colors.white} />
             </Pressable>
@@ -325,24 +549,25 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
         </View>
       ) : null}
 
-      {stage === 'read' ? (
+      {displayedStage === 'read' ? (
         <View style={styles.stageShell}>
           <View style={styles.stageMetaRow}>
             <Text style={styles.stageHeading}>场景句子</Text>
-            <Text style={styles.stageCount}>{readIndex + 1} / {readItems.length}</Text>
+            <Text style={styles.stageCount}>{displayedReadIndex + 1} / {displayedReadItems.length}</Text>
           </View>
           <View style={styles.readCard}>
-            {readPassed ? <View style={styles.scoreBadge}><Text style={styles.scoreBadgeValue}>86</Text><Text style={styles.scoreBadgeMax}>/100</Text></View> : null}
+            {displayedReadPassed ? <View style={styles.scoreBadge}><Text style={styles.scoreBadgeValue}>{trainingSnapshot?.readingResult?.overallScore ?? 86}</Text><Text style={styles.scoreBadgeMax}>/100</Text></View> : null}
             <Text style={styles.readSentence}>
-              {readPassed ? <><Text style={styles.scoreCorrect}>Could you </Text><Text style={styles.scoreIncorrect}>recommend</Text><Text style={styles.scoreCorrect}> something less sweet?</Text></> : readItem.en}
+              {displayedReadPassed ? readItem.en : readItem.en}
             </Text>
             <Text style={styles.readTranslation}>{readItem.zh}</Text>
-            <Pressable accessibilityRole="button" accessibilityLabel={recording ? '结束朗读' : '开始朗读'} onPress={toggleReadRecording} style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}>
+            <Pressable accessibilityRole="button" accessibilityLabel={recording ? '结束朗读' : '开始朗读'} onPress={() => void toggleReadRecording()} style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}>
               <AppIcon name={recording ? 'microphone' : 'microphone-off'} size={28} color={recording ? '#B94D44' : colors.subtle} />
             </Pressable>
-            <Text style={styles.readStatus}>{recording ? '正在听你朗读' : readPassed ? '朗读通过' : '点击麦克风开始朗读'}</Text>
-            <Text style={styles.readInstruction}>{recording ? '再次点击麦克风结束录音并提交评分。' : readPassed ? '本句已达到 80 分，可以进入下一步。' : '再次点击麦克风结束录音并提交评分。'}</Text>
-            <Pressable accessibilityRole="button" accessibilityLabel="听标准示范" onPress={() => setDemoPlaying((current) => !current)} style={styles.readDemoButton}>
+            <Text style={styles.readStatus}>{recording ? '正在听你朗读' : displayedReadPassed ? '朗读通过' : '点击麦克风开始朗读'}</Text>
+            <Text style={styles.readInstruction}>{recording ? '再次点击麦克风结束录音并提交评分，最长录制 30 秒。' : displayedReadPassed ? '本句已达到通过标准，可以进入下一步。' : '再次点击麦克风结束录音并提交评分，最长录制 30 秒。'}</Text>
+            {audioError ? <Text style={styles.generationError}>{audioError}</Text> : null}
+            <Pressable accessibilityRole="button" accessibilityLabel="听标准示范" onPress={() => void toggleDemo(readItem.en)} style={styles.readDemoButton}>
               <Text style={styles.readDemoText}>{demoPlaying ? '正在播放' : '听标准示范'}</Text>
               <AppIcon name="volume" size={18} color={colors.subtle} />
             </Pressable>
@@ -353,39 +578,61 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
             </Pressable>
             <Pressable
               accessibilityRole="button"
-              disabled={!readPassed}
-              onPress={() => { setUnlockedStage(2); setStage('speak'); setRecording(false); setDemoPlaying(false); }}
-              style={[styles.primaryPillButton, !readPassed && styles.primaryPillDisabled]}
+              disabled={!displayedReadPassed}
+              onPress={() => {
+                if (scene && trainingController) void trainingController.next();
+                else { setUnlockedStage(2); setStage('speak'); }
+                setRecording(false);
+                setDemoPlaying(false);
+              }}
+              style={[styles.primaryPillButton, !displayedReadPassed && styles.primaryPillDisabled]}
             >
-              <Text style={styles.primaryPillText}>进入模拟</Text>
+              <Text style={styles.primaryPillText}>{isLastReadItem ? '进入模拟' : '下一句'}</Text>
               <AppIcon name="arrow-right" size={18} color={colors.white} />
             </Pressable>
           </View>
         </View>
       ) : null}
 
-      {stage === 'speak' ? (
+      {displayedStage === 'speak' ? (
         <View style={styles.sceneCallStage}>
-          <CallExperience
-            allowSubtitleToggle={false}
-            compactTranscriptLayout
-            onEnd={() => setCompletionOpen(true)}
-            progressCollapsed={progressCollapsed}
-            transcriptEnglish="Good morning! What can I get started for you today?"
-            transcriptChinese="早上好！今天想点些什么？"
-          />
+          {scene ? (
+            <SceneCallStage
+              scene={scene}
+              progressCollapsed={progressCollapsed}
+              onComplete={(completion) => {
+                setDialogueCompletion(completion);
+                setCompletionOpen(true);
+              }}
+            />
+          ) : (
+            <CallExperience
+              allowSubtitleToggle={false}
+              compactTranscriptLayout
+              onEnd={() => setCompletionOpen(true)}
+              progressCollapsed={progressCollapsed}
+              transcriptEnglish="Good morning! What can I get started for you today?"
+              transcriptChinese="早上好！今天想点些什么？"
+            />
+          )}
         </View>
       ) : null}
     </AppScreen>
     {readFeedbackOpen ? (
       <View style={styles.scoreModalBackdrop}>
         <View style={styles.scoreModal}>
-          <View style={styles.scoreModalValueRow}><Text style={styles.scoreModalValue}>86</Text><Text style={styles.scoreModalMax}>/100</Text></View>
+          <View style={styles.scoreModalValueRow}><Text style={styles.scoreModalValue}>{readingResult?.overallScore ?? 86}</Text><Text style={styles.scoreModalMax}>/100</Text></View>
           <Text style={styles.scoreModalTitle}>本句发音评估</Text>
-          <Text style={styles.scoreModalLead}>本句已达到 80 分，可以进入下一句；红色部分仍可继续练习。</Text>
+          <Text style={styles.scoreModalLead}>{readingResult?.passed ? `本句已达到通过标准，可以${isLastReadItem ? '进入模拟' : '进入下一句'}；低分词仍可继续练习。` : '本句尚未达到通过标准，请根据逐词结果再次朗读。'}</Text>
           <View style={styles.scoreFocusCard}>
             <Text style={styles.scoreFocusLabel}>逐词结果</Text>
-            <Text style={styles.scoreFocusSentence}><Text style={styles.scoreCorrect}>Could you </Text><Text style={styles.scoreIncorrect}>recommend</Text><Text style={styles.scoreCorrect}> something less sweet?</Text></Text>
+            <Text style={styles.scoreFocusSentence}>
+              {readingResult?.words.length
+                ? readingResult.words.map((word, index) => (
+                    <Text key={`${word.word}-${index}`} style={word.wordScore >= 80 ? styles.scoreCorrect : styles.scoreIncorrect}>{word.word}{index < readingResult.words.length - 1 ? ' ' : ''}</Text>
+                  ))
+                : <Text style={styles.scoreCorrect}>{readItem.en}</Text>}
+            </Text>
           </View>
           <Pressable accessibilityRole="button" onPress={() => setReadFeedbackOpen(false)} style={styles.scoreConfirmButton}>
             <Text style={styles.scoreConfirmText}>知道了</Text>
@@ -403,14 +650,14 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
               <Text style={styles.completionLead}>本次场景对话已结束，下面是你的五维表现。</Text>
             </View>
             <View style={styles.completionScoreRow}>
-              <Text style={styles.completionScore}>86</Text>
+              <Text style={styles.completionScore}>{dialogueCompletion?.evaluation?.finalScore ?? 86}</Text>
               <Text style={styles.completionScoreMax}>/100</Text>
             </View>
           </View>
           <View style={styles.completionOverview}>
-            <SceneRadar metrics={defaultSceneMetrics} />
+            <SceneRadar metrics={completionMetrics} />
             <View style={styles.completionMetrics}>
-              {defaultSceneMetrics.map((metric) => (
+              {completionMetrics.map((metric) => (
                 <View key={metric.label} style={styles.completionMetricRow}>
                   <Text style={styles.completionMetricLabel}>{metric.label}</Text>
                   <Text style={styles.completionMetricValue}>{metric.value}</Text>
@@ -429,68 +676,57 @@ export function Training({ id, initialStage = 'learn', onBack, onFinish }: { id:
   );
 }
 
-type ScenePreview = {
-  id: string;
-  title: string;
-  background: string;
-  aiRole: string;
-  userRole: string;
-  learningGoal: string;
-  duration: string;
-};
+function createDefaultSceneService() {
+  const tokenStore = new SecureTokenStore();
+  return new SceneService(
+    new ApiClient({
+      baseUrl: getRuntimeConfig().backendUrl,
+      tokenStore,
+    }),
+  );
+}
 
-const scenePreviewDetails: Record<string, Omit<ScenePreview, 'id'>> = {
-  coffee: {
-    title: '咖啡店点单',
-    background: '工作日早晨，一家繁忙的本地咖啡店。',
-    aiRole: '咖啡师',
-    userRole: '客户',
-    learningGoal: '成功下单一款带定制选项的咖啡饮品及一份食品，并完成支付流程。',
-    duration: '6 分钟',
-  },
-  hotel: {
-    title: '酒店入住',
-    background: '抵达酒店前台，确认预订信息并办理入住。',
-    aiRole: '酒店前台接待',
-    userRole: '住客',
-    learningGoal: '礼貌确认预订、房型、早餐和退房时间等入住细节。',
-    duration: '8 分钟',
-  },
-  pharmacy: {
-    title: '药店咨询',
-    background: '在当地药店向药剂师描述身体不适并寻求建议。',
-    aiRole: '药剂师',
-    userRole: '顾客',
-    learningGoal: '清晰描述症状，并确认药品用法、用量和注意事项。',
-    duration: '8 分钟',
-  },
-};
-
-function getScenePreview(id: string): ScenePreview {
-  return { id, ...(scenePreviewDetails[id] ?? scenePreviewDetails.coffee) };
+function createDefaultTtsPlayer() {
+  const tokenStore = new SecureTokenStore();
+  return new TtsPlayer({
+    speechClient: new SceneSpeechClient({
+      baseUrl: getRuntimeConfig().backendUrl,
+      tokenStore,
+    }),
+  });
 }
 
 export function ScenesHome({
   onOpen,
   promptExample = getDailyScenePromptExample(),
+  sceneService: injectedSceneService,
 }: {
   onOpen: (route: SceneRoute) => void;
   promptExample?: ScenePromptExample;
+  sceneService?: Pick<SceneService, 'generate'>;
 }) {
+  const [sceneService] = useState(
+    () => injectedSceneService ?? createDefaultSceneService(),
+  );
   const [prompt, setPrompt] = useState('');
   const [specialtyOpen, setSpecialtyOpen] = useState(false);
-  const [preview, setPreview] = useState<ScenePreview | null>(null);
-  const startCustomScene = () => {
-    if (!prompt.trim()) return;
-    setPreview({
-      id: 'coffee',
-      title: '自定义练习场景',
-      background: prompt.trim(),
-      aiRole: '英语对话伙伴',
-      userRole: '学习者',
-      learningGoal: '围绕设定情境完成自然、清晰的英语交流。',
-      duration: '8 分钟',
-    });
+  const [preview, setPreview] = useState<GeneratedScene | null>(null);
+  const [generating, setGenerating] = useState(false);
+  const [generationError, setGenerationError] = useState<string | null>(null);
+  const generatePreview = async (sceneInput: string) => {
+    if (!sceneInput.trim() || generating) return;
+    setGenerating(true);
+    setGenerationError(null);
+    try {
+      setPreview(await sceneService.generate(sceneInput.trim()));
+    } catch (error) {
+      setPreview(null);
+      setGenerationError(
+        error instanceof Error ? error.message : '场景生成失败，请重试',
+      );
+    } finally {
+      setGenerating(false);
+    }
   };
 
   return (
@@ -572,18 +808,19 @@ export function ScenesHome({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="生成练习场景"
-              disabled={!prompt.trim()}
-              onPress={startCustomScene}
+            disabled={!prompt.trim()}
+              onPress={() => void generatePreview(prompt)}
               style={({ pressed }) => [
                 styles.generateButton,
                 !prompt.trim() && styles.generateButtonDisabled,
                 pressed && prompt.trim() && styles.compactPressed,
               ]}
             >
-              <Text style={[styles.generateButtonText, !prompt.trim() && styles.generateButtonTextDisabled]}>生成练习场景</Text>
+              <Text style={[styles.generateButtonText, !prompt.trim() && styles.generateButtonTextDisabled]}>{generating ? '正在生成…' : '生成练习场景'}</Text>
               <AppIcon name="arrow-right" size={18} color={colors.white} />
             </Pressable>
           </View>
+          {generationError ? <Text style={styles.generationError}>{generationError}</Text> : null}
         </View>
 
         <View style={styles.recommendationHeader}>
@@ -597,7 +834,7 @@ export function ScenesHome({
             <Pressable
               accessibilityRole="button"
               key={item.id}
-              onPress={() => setPreview(getScenePreview(item.id))}
+              onPress={() => void generatePreview(`${item.title}：${item.goal}`)}
               style={({ pressed }) => [styles.recommendation, pressed && styles.compactPressed]}
             >
               <Text style={styles.number}>0{index + 1}</Text>
@@ -631,7 +868,7 @@ export function ScenesHome({
                 ['AI 扮演', preview.aiRole],
                 ['你将扮演', preview.userRole],
                 ['练习重点', preview.learningGoal],
-                ['预计用时', preview.duration],
+                ['预计用时', `${preview.estimatedMinutes} 分钟`],
               ].map(([label, value]) => (
                 <View key={label} style={styles.previewSummaryRow}>
                   <Text style={styles.previewSummaryLabel}>{label}</Text>
@@ -645,7 +882,7 @@ export function ScenesHome({
               </Pressable>
               <Pressable
                 accessibilityRole="button"
-                onPress={() => onOpen({ name: 'training', id: preview.id })}
+                onPress={() => onOpen({ name: 'training', scene: preview })}
                 style={[styles.previewButton, styles.previewButtonPrimary]}
               >
                 <Text style={styles.previewButtonPrimaryText}>确认进入</Text>
@@ -662,7 +899,7 @@ export function ScenesHome({
 export function ScenesScreen() {
   const [route, setRoute] = useState<SceneRoute>({ name: 'home' });
   if (route.name === 'training') {
-    return <Training id={route.id} onBack={() => setRoute({ name: 'home' })} onFinish={() => setRoute({ name: 'home' })} />;
+    return <Training scene={route.scene} onBack={() => setRoute({ name: 'home' })} onFinish={() => setRoute({ name: 'home' })} />;
   }
   if (route.name === 'ielts') return <IeltsFlow onExit={() => setRoute({ name: 'home' })} />;
   if (route.name === 'interview') return <InterviewFlow onExit={() => setRoute({ name: 'home' })} />;
@@ -765,6 +1002,7 @@ const styles = StyleSheet.create({
   generateButtonDisabled: { backgroundColor: '#A7A7A2' },
   generateButtonText: { color: colors.white, fontSize: 14, fontWeight: '600' },
   generateButtonTextDisabled: { color: colors.white },
+  generationError: { marginTop: 6, color: '#B94D44', fontSize: 11, lineHeight: 16 },
   compactPressed: { opacity: 0.72, transform: [{ scale: 0.98 }] },
   recommendationHeader: { marginTop: 28, marginBottom: 9, flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'space-between' },
   recommendationHeading: { marginTop: 3, color: colors.ink, fontSize: 23, fontWeight: '600', letterSpacing: -0.7 },

--- a/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import type { SceneLearningRecord } from '@/data/learningAssets';
+
+import { AssetsScreen, SceneAssetDetailLoader } from '../AssetsScreen';
+
+const summaryRecord: SceneLearningRecord = {
+  id: 'scene/airport',
+  title: '机场行李托运',
+  date: '2026-08-05',
+  status: '已完成',
+  score: 88,
+  practiceCount: 2,
+  expressions: [],
+  conversation: [],
+};
+
+const detailRecord: SceneLearningRecord = {
+  ...summaryRecord,
+  expressions: [
+    {
+      id: 'word-1',
+      type: '单词',
+      englishText: 'baggage',
+      chineseText: '行李',
+    },
+  ],
+  conversation: [],
+};
+
+describe('AssetsScreen backend binding', () => {
+  it('renders backend records instead of seeded local demo records', async () => {
+    const onOpenRecord = jest.fn();
+    let resolveRecords: (records: SceneLearningRecord[]) => void = () => undefined;
+    const recordsPromise = new Promise<SceneLearningRecord[]>((resolve) => {
+      resolveRecords = resolve;
+    });
+    const service = {
+      listRecords: jest.fn(() => recordsPromise),
+      getRecord: jest.fn(async () => detailRecord),
+    };
+    const screen = await render(
+      <AssetsScreen
+        assetService={service}
+        onOpenRecord={onOpenRecord}
+        onOpenIelts={jest.fn()}
+        onOpenInterview={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByText('正在同步场景学习资产…')).toBeTruthy();
+    resolveRecords([summaryRecord]);
+    await waitFor(() => expect(screen.getByText('机场行李托运')).toBeTruthy());
+    expect(screen.queryByText('咖啡店点单')).toBeNull();
+    await fireEvent.press(screen.getByText('机场行李托运'));
+    expect(onOpenRecord).toHaveBeenCalledWith(summaryRecord);
+  });
+
+  it('shows a recoverable backend list failure', async () => {
+    const service = {
+      listRecords: jest.fn(async () => {
+        throw new Error('资产服务暂时不可用');
+      }),
+      getRecord: jest.fn(async () => detailRecord),
+    };
+    const screen = await render(
+      <AssetsScreen
+        assetService={service}
+        onOpenRecord={jest.fn()}
+        onOpenIelts={jest.fn()}
+        onOpenInterview={jest.fn()}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('资产服务暂时不可用')).toBeTruthy(),
+    );
+    expect(screen.getByText('重新加载')).toBeTruthy();
+  });
+});
+
+describe('SceneAssetDetailLoader', () => {
+  it('loads the backend detail by scene id before showing expressions', async () => {
+    const service = {
+      listRecords: jest.fn(async () => []),
+      getRecord: jest.fn(async () => detailRecord),
+    };
+    const screen = await render(
+      <SceneAssetDetailLoader
+        assetService={service}
+        sceneId="scene/airport"
+        onBack={jest.fn()}
+        onPractice={jest.fn()}
+        onDelete={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('baggage')).toBeTruthy());
+    expect(service.getRecord).toHaveBeenCalledWith('scene/airport');
+    expect(screen.getByText('行李')).toBeTruthy();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/AuthScreens.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AuthScreens.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import type { AuthSessionState } from '@/features/auth/AuthSessionController';
+import type { AppModelAuthController } from '@/model/AppModel';
+import { AppModelProvider } from '@/model/AppModel';
+
+jest.mock('@/components/TeacherSwipeStack', () => ({
+  TeacherSwipeStack: () => null,
+}));
+
+import { AuthFormScreen } from '../AuthScreens';
+
+function createController(state: AuthSessionState): AppModelAuthController & {
+  login: jest.Mock;
+  register: jest.Mock;
+} {
+  let listener: ((nextState: AuthSessionState) => void) | null = null;
+  return {
+    getSnapshot: () => state,
+    subscribe: jest.fn((nextListener) => {
+      listener = nextListener;
+      return () => {
+        listener = null;
+      };
+    }),
+    bootstrap: jest.fn(async () => {
+      listener?.(state);
+    }),
+    login: jest.fn(async () => undefined),
+    register: jest.fn(async () => undefined),
+    updatePreference: jest.fn(async () => ({
+      userId: 'user-1',
+      preferredVoice: null,
+      preferredAiSpeechSpeed: null,
+      cefrLevel: null,
+      memoryText: null,
+    })),
+    logout: jest.fn(async () => undefined),
+    unauthorized: jest.fn(async () => undefined),
+  };
+}
+
+describe('AuthFormScreen backend binding', () => {
+  it('submits the entered login credentials', async () => {
+    const controller = createController({
+      status: 'anonymous',
+      user: null,
+      preference: null,
+      error: null,
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <AuthFormScreen mode="login" onBack={jest.fn()} onSwitch={jest.fn()} />
+      </AppModelProvider>,
+    );
+
+    await fireEvent.changeText(
+      screen.getByPlaceholderText('name@example.com'),
+      'learner@example.com',
+    );
+    await fireEvent.changeText(screen.getByPlaceholderText('至少 8 位字符'), 'password123');
+    await fireEvent.press(screen.getByRole('button', { name: '登录' }));
+
+    await waitFor(() =>
+      expect(controller.login).toHaveBeenCalledWith({
+        username: 'learner@example.com',
+        password: 'password123',
+      }),
+    );
+  });
+
+  it('shows the backend authentication error without changing the layout flow', async () => {
+    const controller = createController({
+      status: 'anonymous',
+      user: null,
+      preference: null,
+      error: '邮箱或密码错误',
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <AuthFormScreen mode="login" onBack={jest.fn()} onSwitch={jest.fn()} />
+      </AppModelProvider>,
+    );
+
+    expect(screen.getByText('邮箱或密码错误')).toBeTruthy();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/ConversationScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ConversationScreen.test.tsx
@@ -1,0 +1,115 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View },
+    cancelAnimation: jest.fn(),
+    Easing: {
+      cubic: jest.fn(),
+      ease: jest.fn(),
+      linear: jest.fn(),
+      inOut: (value: unknown) => value,
+      out: (value: unknown) => value,
+    },
+    interpolate: (_value: number, _input: number[], output: number[]) => output[0],
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useSharedValue: (value: unknown) => ({ value }),
+    withDelay: (_delay: number, value: unknown) => value,
+    withRepeat: (value: unknown) => value,
+    withTiming: (value: unknown) => value,
+  };
+});
+
+jest.mock('@/model/AppModel', () => ({
+  useAppModel: () => ({
+    teacher: {
+      id: 'james',
+      name: 'James',
+      accent: 'American English',
+      voiceId: 'Harvey',
+      image: 1,
+    },
+  }),
+}));
+
+import { CallExperience, selectCallCaption } from '../ConversationScreen';
+
+describe('selectCallCaption', () => {
+  it('shows the learner transcript after their turn instead of an empty or stale AI transcript', () => {
+    expect(
+      selectCallCaption(
+        {
+          state: 'ready',
+          error: null,
+          userTranscript: 'I would like a latte.',
+          assistantTranscript: '',
+        },
+        'James',
+        '可以开始说了',
+      ),
+    ).toEqual({ speaker: '你', text: 'I would like a latte.' });
+  });
+
+  it('shows the current AI transcript while the assistant is speaking', () => {
+    expect(
+      selectCallCaption(
+        {
+          state: 'assistant_speaking',
+          error: null,
+          userTranscript: 'I would like a latte.',
+          assistantTranscript: 'Would you like oat milk?',
+        },
+        'James',
+        'AI 正在回答',
+      ),
+    ).toEqual({ speaker: 'James', text: 'Would you like oat milk?' });
+  });
+});
+
+describe('CallExperience realtime binding', () => {
+  it('keeps the learner subtitle visible when the AI response has already started', async () => {
+    const screen = await render(
+      <CallExperience
+        onEnd={jest.fn()}
+        transcriptSpeaker="James"
+        transcriptEnglish="Would you like to keep practicing?"
+        userTranscript="I would like to practice English today."
+      />,
+    );
+
+    expect(screen.getByText('你')).toBeTruthy();
+    expect(
+      screen.getByText('I would like to practice English today.'),
+    ).toBeTruthy();
+    expect(screen.getByText('James')).toBeTruthy();
+    expect(
+      screen.getByText('Would you like to keep practicing?'),
+    ).toBeTruthy();
+  });
+
+  it('renders controlled elapsed/transcript state and delegates mute/end actions', async () => {
+    const onMutedChange = jest.fn();
+    const onEnd = jest.fn();
+    const screen = await render(
+      <CallExperience
+        onEnd={onEnd}
+        elapsed={42}
+        muted
+        statusLabel="正在连接 AI"
+        transcriptEnglish="Live assistant transcript."
+        onMutedChange={onMutedChange}
+      />,
+    );
+
+    expect(screen.getByText('已暂停 · 00:42')).toBeTruthy();
+    expect(screen.getByText('Live assistant transcript.')).toBeTruthy();
+    await fireEvent.press(screen.getByLabelText('恢复会话'));
+    await fireEvent.press(screen.getByLabelText('结束当前会话'));
+
+    expect(onMutedChange).toHaveBeenCalledWith(false);
+    expect(onEnd).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -1,0 +1,336 @@
+import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import type { GeneratedScene, SceneFlowStage } from '@/features/scenes/SceneService';
+import { SceneTrainingController } from '@/features/scenes/SceneTrainingController';
+import type {
+  RealtimeSessionSnapshot,
+  RealtimeSessionOptions,
+} from '@/features/realtime/RealtimeSessionController';
+import type { FreeChatControllerPort } from '@/features/conversation/useFreeChatSession';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View },
+    cancelAnimation: jest.fn(),
+    Easing: {
+      cubic: jest.fn(),
+      ease: jest.fn(),
+      linear: jest.fn(),
+      inOut: (value: unknown) => value,
+      out: (value: unknown) => value,
+    },
+    interpolate: (_value: number, _input: number[], output: number[]) => output[0],
+    runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(),
+    useSharedValue: (value: unknown) => ({ value }),
+    withDelay: (_delay: number, value: unknown) => value,
+    withRepeat: (value: unknown) => value,
+    withTiming: (value: unknown) => value,
+  };
+});
+
+jest.mock('@/model/AppModel', () => ({
+  useAppModel: () => ({
+    addSceneRecord: jest.fn(),
+    teacher: {
+      id: 'james',
+      name: 'James',
+      accent: 'American English',
+      voiceId: 'Harvey',
+      image: 1,
+    },
+  }),
+}));
+
+const scene: GeneratedScene = {
+  sceneId: 'generated-scene-1',
+  title: '机场行李托运',
+  background: '在机场柜台办理行李托运。',
+  aiRole: '航空公司工作人员',
+  userRole: '乘客',
+  learningGoal: '确认行李重量和登机信息。',
+  estimatedMinutes: 8,
+  wordList: [
+    {
+      contentId: 'word-1',
+      englishText: 'baggage',
+      chineseText: '行李',
+      phonetic: '/ˈbæɡɪdʒ/',
+    },
+  ],
+  phraseList: [
+    {
+      contentId: 'phrase-1',
+      englishText: 'check in',
+      chineseText: '办理托运',
+      phonetic: null,
+    },
+  ],
+  sentenceList: [
+    {
+      contentId: 'sentence-1',
+      englishText: 'I would like to check in this bag.',
+      chineseText: '我想托运这个行李。',
+      phonetic: null,
+    },
+    {
+      contentId: 'sentence-2',
+      englishText: 'Is this bag within the weight limit?',
+      chineseText: '这个行李在限重内吗？',
+      phonetic: null,
+    },
+  ],
+  scenePrompt: 'Prompt',
+};
+
+import {
+  sceneMetricsForReport,
+  SceneCallStage,
+  ScenesHome,
+  Training,
+} from '../ScenesScreen';
+
+describe('scene completion report mapping', () => {
+  it('uses the five dimensions returned by the Java backend', () => {
+    expect(
+      sceneMetricsForReport({
+        accuracyScore: 91,
+        fluencyScore: 82,
+        grammarScore: 73,
+        vocabularyScore: 64,
+        naturalnessScore: 55,
+        finalScore: 77,
+        summary: 'Done',
+        strengths: [],
+        improvements: [],
+      }),
+    ).toEqual([
+      { label: '准确', value: 91 },
+      { label: '流利', value: 82 },
+      { label: '语法', value: 73 },
+      { label: '词汇', value: 64 },
+      { label: '自然', value: 55 },
+    ]);
+  });
+});
+
+describe('ScenesHome backend generation binding', () => {
+  it('shows the generated backend preview and opens that exact scene', async () => {
+    const onOpen = jest.fn();
+    const sceneService = {
+      generate: jest.fn(async () => scene),
+    };
+    const screen = await render(
+      <ScenesHome
+        onOpen={onOpen}
+        promptExample={{ id: 'airport', prompt: '机场托运行李' }}
+        sceneService={sceneService}
+      />,
+    );
+
+    await fireEvent.changeText(
+      screen.getByLabelText('描述想练习的场景'),
+      '  我想练习机场托运行李  ',
+    );
+    await fireEvent.press(screen.getByLabelText('生成练习场景'));
+
+    await waitFor(() => expect(screen.getByText('机场行李托运')).toBeTruthy());
+    expect(sceneService.generate).toHaveBeenCalledWith('我想练习机场托运行李');
+    expect(screen.getByText('航空公司工作人员')).toBeTruthy();
+    await fireEvent.press(screen.getByText('确认进入'));
+    expect(onOpen).toHaveBeenCalledWith({ name: 'training', scene });
+  });
+
+  it('shows a generation error without opening a fake preview', async () => {
+    const sceneService = {
+      generate: jest.fn(async () => {
+        throw new Error('模型生成超时');
+      }),
+    };
+    const screen = await render(
+      <ScenesHome
+        onOpen={jest.fn()}
+        promptExample={{ id: 'airport', prompt: '机场托运行李' }}
+        sceneService={sceneService}
+      />,
+    );
+    await fireEvent.changeText(
+      screen.getByLabelText('描述想练习的场景'),
+      '机场托运行李',
+    );
+    await fireEvent.press(screen.getByLabelText('生成练习场景'));
+
+    await waitFor(() => expect(screen.getByText('模型生成超时')).toBeTruthy());
+    expect(screen.queryByText('确认进入')).toBeNull();
+  });
+});
+
+describe('Training backend content binding', () => {
+  it('renders and advances through generated words, phrases and sentences', async () => {
+    const service = {
+      createFlow: jest.fn(async () => ({
+        sceneId: scene.sceneId,
+        stage: 'WORD_LEARNING' as const,
+        completed: false,
+      })),
+      getContent: jest.fn(async (_sceneId: string, stage?: string) => {
+        if (stage === 'WORD_LEARNING') return scene.wordList;
+        if (stage === 'PHRASE_LEARNING') return scene.phraseList;
+        return scene.sentenceList;
+      }),
+      advanceStage: jest.fn(async (_sceneId: string, stage: SceneFlowStage) => ({
+        sceneId: scene.sceneId,
+        stage: (
+          stage === 'WORD_LEARNING'
+            ? 'PHRASE_LEARNING'
+            : stage === 'PHRASE_LEARNING'
+              ? 'SENTENCE_LEARNING'
+              : 'DIALOGUE') as SceneFlowStage,
+        completed: false,
+      })),
+      evaluateSentence: jest.fn(async () => ({
+        overallScore: 86,
+        passed: true,
+        words: [],
+      })),
+    };
+    const controller = new SceneTrainingController(service);
+    const wavRecorder = {
+      start: jest.fn(async () => undefined),
+      stop: jest.fn(async () => 'file:///sentence.wav'),
+      cancel: jest.fn(async () => undefined),
+    };
+    const ttsPlayer = {
+      play: jest.fn(async () => undefined),
+      stop: jest.fn(),
+    };
+    const screen = await render(
+      <Training
+        scene={scene}
+        trainingController={controller}
+        wavRecorder={wavRecorder}
+        ttsPlayer={ttsPlayer}
+        onBack={jest.fn()}
+        onFinish={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('baggage')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('播放发音'));
+    await waitFor(() =>
+      expect(ttsPlayer.play).toHaveBeenCalledWith(scene.sceneId, 'baggage'),
+    );
+    await fireEvent.press(screen.getByText('进入词组'));
+    await waitFor(() => expect(screen.getByText('check in')).toBeTruthy());
+    await fireEvent.press(screen.getByText('进入朗读'));
+    await waitFor(() =>
+      expect(screen.getByText('I would like to check in this bag.')).toBeTruthy(),
+    );
+    await fireEvent.press(screen.getByLabelText('开始朗读'));
+    await waitFor(() => expect(wavRecorder.start).toHaveBeenCalledTimes(1));
+    await fireEvent.press(screen.getByLabelText('结束朗读'));
+    await waitFor(() => expect(screen.getByText('朗读通过')).toBeTruthy());
+    expect(service.evaluateSentence).toHaveBeenCalledWith(
+      scene.sceneId,
+      'sentence-1',
+      'file:///sentence.wav',
+    );
+    await fireEvent.press(screen.getByText('知道了'));
+    expect(screen.getByText('下一句')).toBeTruthy();
+    await fireEvent.press(screen.getByText('下一句'));
+    await waitFor(() =>
+      expect(screen.getByText('Is this bag within the weight limit?')).toBeTruthy(),
+    );
+    expect(screen.getByText('进入模拟')).toBeTruthy();
+    expect(screen.getByText('点击麦克风开始朗读')).toBeTruthy();
+
+    jest.useFakeTimers();
+    await fireEvent.press(screen.getByLabelText('开始朗读'));
+    await act(async () => {
+      jest.advanceTimersByTime(30_000);
+      await Promise.resolve();
+    });
+    expect(wavRecorder.stop).toHaveBeenCalledTimes(2);
+    jest.useRealTimers();
+  });
+});
+
+describe('SceneCallStage realtime binding', () => {
+  it('starts scene WebRTC, renders live transcript and returns backend completion', async () => {
+    let snapshot: RealtimeSessionSnapshot = {
+      state: 'idle',
+      muted: false,
+      sessionId: null,
+      userTranscript: '',
+      assistantTranscript: '',
+      error: null,
+    };
+    let listener: ((value: RealtimeSessionSnapshot) => void) | null = null;
+    const completion = {
+      sceneId: scene.sceneId,
+      sessionId: 'session-1',
+      stopTime: '2026-08-05T10:00:00Z',
+      evaluation: {
+        accuracyScore: 88,
+        fluencyScore: 87,
+        grammarScore: 86,
+        vocabularyScore: 85,
+        naturalnessScore: 89,
+        finalScore: 87,
+        summary: 'Good work.',
+        strengths: ['Clear intent'],
+        improvements: ['Use more detail'],
+      },
+    };
+    const controller: FreeChatControllerPort = {
+      getSnapshot: () => snapshot,
+      subscribe: jest.fn((nextListener) => {
+        listener = nextListener;
+        listener(snapshot);
+        return () => {
+          listener = null;
+        };
+      }),
+      start: jest.fn(async () => {
+        snapshot = {
+          ...snapshot,
+          state: 'ready',
+          sessionId: 'session-1',
+          assistantTranscript: 'May I see your passport?',
+        };
+        listener?.(snapshot);
+      }),
+      setMuted: jest.fn(),
+      interrupt: jest.fn(),
+      end: jest.fn(async () => {
+        snapshot = { ...snapshot, state: 'ended', completion };
+        listener?.(snapshot);
+        return completion;
+      }),
+    };
+    const createController = jest.fn(
+      (_sceneId: string, _config: Pick<RealtimeSessionOptions, 'voice' | 'model' | 'speechSpeed'>) => controller,
+    );
+    const onComplete = jest.fn();
+    const screen = await render(
+      <SceneCallStage
+        scene={scene}
+        progressCollapsed={false}
+        createController={createController}
+        onComplete={onComplete}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByText('May I see your passport?')).toBeTruthy(),
+    );
+    expect(createController).toHaveBeenCalledWith(
+      scene.sceneId,
+      expect.objectContaining({ voice: 'Harvey' }),
+    );
+    await fireEvent.press(screen.getByLabelText('结束当前会话'));
+    await waitFor(() => expect(onComplete).toHaveBeenCalledWith(completion));
+  });
+});

--- a/frontend/mobile/src/theme/tokens.ts
+++ b/frontend/mobile/src/theme/tokens.ts
@@ -28,6 +28,7 @@ export type Teacher = {
   name: string;
   accent: string;
   personality: string;
+  voiceId: 'Katerina' | 'Aiden' | 'Raymond' | 'Tina' | 'Harvey' | 'Dolce';
   image: ImageSourcePropType;
 };
 
@@ -37,6 +38,7 @@ export const teachers: Teacher[] = [
     name: 'Clara',
     accent: '美式口音',
     personality: '温柔耐心',
+    voiceId: 'Katerina',
     image: require('../../assets/images/unispeaking/teachers/clara.png'),
   },
   {
@@ -44,6 +46,7 @@ export const teachers: Teacher[] = [
     name: 'James',
     accent: '英式口音',
     personality: '清晰理性',
+    voiceId: 'Harvey',
     image: require('../../assets/images/unispeaking/teachers/james.png'),
   },
   {
@@ -51,6 +54,7 @@ export const teachers: Teacher[] = [
     name: 'Leo',
     accent: '美式口音',
     personality: '开朗活力',
+    voiceId: 'Raymond',
     image: require('../../assets/images/unispeaking/teachers/leo.png'),
   },
   {
@@ -58,6 +62,7 @@ export const teachers: Teacher[] = [
     name: 'David',
     accent: '美式口音',
     personality: '沉稳直接',
+    voiceId: 'Aiden',
     image: require('../../assets/images/unispeaking/teachers/david.png'),
   },
   {
@@ -65,6 +70,7 @@ export const teachers: Teacher[] = [
     name: 'Emily',
     accent: '英式口音',
     personality: '自然亲切',
+    voiceId: 'Tina',
     image: require('../../assets/images/unispeaking/teachers/emily.png'),
   },
   {
@@ -72,15 +78,16 @@ export const teachers: Teacher[] = [
     name: 'Arthur',
     accent: '英式口音',
     personality: '睿智从容',
+    voiceId: 'Dolce',
     image: require('../../assets/images/unispeaking/teachers/arthur.png'),
   },
 ];
 
 export const levels = [
-  { id: 'starter', title: '刚开始学', note: '能听懂或说出少量单词' },
-  { id: 'basic', title: '可以简单交流', note: '能用简单句表达基本需求' },
-  { id: 'independent', title: '可以连续表达', note: '能围绕熟悉话题说一段话' },
-  { id: 'fluent', title: '表达比较流利', note: '能自然参与大多数日常交流' },
+  { id: 'starter', cefrLevel: 'A', title: '刚开始学', note: '能听懂或说出少量单词' },
+  { id: 'basic', cefrLevel: 'B', title: '可以简单交流', note: '能用简单句表达基本需求' },
+  { id: 'independent', cefrLevel: 'C', title: '可以连续表达', note: '能围绕熟悉话题说一段话' },
+  { id: 'fluent', cefrLevel: 'D', title: '表达比较流利', note: '能自然参与大多数日常交流' },
 ] as const;
 
 export const speedOptions = ['慢一些', '适中', '自然', '快一些'] as const;

--- a/frontend/mobile/tsconfig.json
+++ b/frontend/mobile/tsconfig.json
@@ -2,6 +2,10 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    "types": [
+      "jest",
+      "node"
+    ],
     "paths": {
       "@/*": [
         "./src/*"


### PR DESCRIPTION
## 概要

本 PR 提交 UniSpeaking 移动端核心适配代码，重点覆盖自由对话和场景练习两个核心功能。

主要改动：
- 新增 React Native 移动端服务层，包括认证、API 请求、安全 Token 存储、Realtime 会话控制、WebRTC 传输、录音、TTS 播放和场景练习逻辑。
- 将移动端自由对话接入统一后端的 Realtime Session API。
- 实现场景练习移动端流程，覆盖“学 / 读 / 说”三个阶段。
- 增加 Qwen Realtime 事件归一化，避免移动端 UI 直接依赖原始供应商 JSON。
- 增加移动端实时对话中的用户字幕和 AI 字幕状态。
- 新增 Jest 配置和测试，覆盖认证、Realtime、音频、场景服务、App Model 和主要页面。

## 范围

本 PR 只包含移动端前端代码。

包含：
- `frontend/mobile`

不包含：
- 后端代码改动
- Web 前端代码改动
- 本地 planning 过程文件
- 本地环境配置或密钥文件

## 验证

已通过：
- `npm run test:ci`
  - 24 个 test suites 通过
  - 90 个测试通过
- `npx tsc --noEmit`
- 已确认后端和 Web 前端无改动：
  - `git diff --exit-code -- backend frontend/web frontend/Unispeaking_fronted`

已知问题：
- `npm run lint` 仍存在 React Compiler / Reanimated 相关 lint 规则报错，主要集中在已有移动端 UI 组件中。
- 当前不影响 POC 运行测试，但如果 CI 要求 lint 通过，合并前需要单独清理。

## 说明

本 PR 作为移动端核心适配的第一阶段 checkpoint。移动端继续复用统一 Java 后端；模型供应商密钥和环境配置不进入移动端代码，仅保留在服务端或本地环境中。