### PR TITLE
fix(interview): 面试状态机结束判定重做 + 结束前播放收尾语

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/prompt/interview/InterviewPromptBuilder.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/prompt/interview/InterviewPromptBuilder.java
@@ -42,6 +42,8 @@ public class InterviewPromptBuilder {
 				Conversation boundaries:
 				- Keep the interview natural and spoken. Ask one question at a time and pause for the answer.
 				- Follow up on the candidate's answers only within the current topic; do not jump ahead.
+				- Once a topic has been covered with its allowed follow-ups, move to the next topic; do not keep asking about a covered topic.
+				- The application will tell you when to move on and when the interview is complete. Follow those instructions promptly.
 				- Never evaluate, score, grade, or comment on the candidate's language ability.
 				- Never invent facts about the candidate, their experience, the company, or the role.
 				- Use only the background above as the source of truth about the candidate and role.

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/InterviewTopicStateMachine.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/InterviewTopicStateMachine.java
@@ -36,6 +36,11 @@ public class InterviewTopicStateMachine {
 
 	private final Map<String, State> states = new ConcurrentHashMap<>();
 
+	/** 面试结束时的收尾指令：让模型自然生成一句致谢收尾，不再追问。 */
+	private static final String CLOSING_INSTRUCTION =
+			"The interview is complete. Give a brief, natural closing and thank the "
+					+ "candidate for their time. Do not ask more questions.";
+
 	/** 初始化一个会话的主题状态。 */
 	public InterviewTopicState start(
 			String sessionId,
@@ -259,16 +264,15 @@ public class InterviewTopicStateMachine {
 
 		/** 下一轮 realtime 指令：开场、推进、收尾或结束，由状态机统一生成。 */
 		private String buildControlInstruction() {
+			if (shouldEnd) {
+				return CLOSING_INSTRUCTION;
+			}
 			if (currentTopic == null) {
 				return "Begin the interview. Open with the first topic: "
 						+ topics.get(0) + ".";
 			}
-			if (shouldEnd) {
-				return "";
-			}
 			if (coveredTopics.size() >= topics.size() && lastTopicSatisfied) {
-				return "The interview is complete. Give a brief, natural closing and thank "
-						+ "the candidate for their time. Do not ask more questions.";
+				return CLOSING_INSTRUCTION;
 			}
 			if (currentTopicSatisfied()
 					&& topics.indexOf(currentTopic) < topics.size() - 1) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/InterviewTopicStateMachine.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/InterviewTopicStateMachine.java
@@ -22,10 +22,11 @@ import org.springframework.stereotype.Component;
  * 不实现 {@code SceneFlowService}（无场景级阶段）。</p>
  *
  * <p>终止规则（优先级高→低）：① 连续 3 次 UNKNOWN → 结束；② 第 5 主题硬顶：已覆盖
- * ≥N-1 个不同主题 ∧ 当前为最后一个主题且已判完成 → 强制结束；③ 自然结束：全部主题已
- * 覆盖 ∧ 两必选已覆盖 ∧ 当前主题完成 → 结束；④ 否则继续。切题不隐式完成上一主题，
- * 只有 LLM 明确 {@code topicCompleted=true} 才计入已完成；空/空白转录 no-op（不计
- * UNKNOWN、不切题）。</p>
+ * ≥N-1 个不同主题 ∧ 当前为最后一个主题且已满足（完成或追问预算耗尽）→ 强制结束；
+ * ③ 自然结束：全部主题已覆盖 ∧ 两必选已覆盖 ∧ 最后一个主题已满足（锁存）→ 结束；
+ * ④ 最大轮次兜底（每主题 1 问 + maxFollowUps 追问 + 3 轮缓冲）→ 强制结束。切题不隐式
+ * 完成上一主题；"满足"以追问预算耗尽为主信号，{@code topicCompleted} 只是提前信号；
+ * 空/空白转录 no-op（不计 UNKNOWN、不切题）。</p>
  *
  * <p>生成主题数为硬顶（来自 {@code InterviewContext.interviewTopics}），状态机不自行增长；
  * 识别到列表外的主题视为 UNKNOWN，防 LLM 幻觉越界。难度只约束每主题追问次数上限。</p>
@@ -102,6 +103,7 @@ public class InterviewTopicStateMachine {
 		private int unknownStreak;
 		private int followUpCount;
 		private boolean currentTopicCompleted;
+		private boolean lastTopicSatisfied;
 		private boolean shouldEnd;
 		private int lastProcessedTurnNo;
 
@@ -139,7 +141,8 @@ public class InterviewTopicStateMachine {
 					unknownStreak,
 					followUpCount,
 					completedMandatoryTopics.size() >= 2,
-					shouldEnd);
+					shouldEnd,
+					buildControlInstruction());
 		}
 
 		private void apply(InterviewTopicEvent event) {
@@ -177,7 +180,22 @@ public class InterviewTopicStateMachine {
 					completeCurrentTopic();
 				}
 			}
+			latchLastTopicSatisfied();
 			checkTermination();
+		}
+
+		/** 当前主题是否"已满足"：LLM 明确完成，或追问预算耗尽（预算是主信号）。 */
+		private boolean currentTopicSatisfied() {
+			return currentTopicCompleted || followUpCount >= maxFollowUps;
+		}
+
+		/** 当前主题为最后一个主题且已满足时锁存，防止模型收尾时切回旧主题导致永不结束。 */
+		private void latchLastTopicSatisfied() {
+			if (currentTopic != null
+					&& topics.indexOf(currentTopic) == topics.size() - 1
+					&& currentTopicSatisfied()) {
+				lastTopicSatisfied = true;
+			}
 		}
 
 		private void recordCovered(String topic) {
@@ -213,20 +231,54 @@ public class InterviewTopicStateMachine {
 			if (shouldEnd) {
 				return;
 			}
-			// ② 第 5 主题硬顶：须已覆盖 ≥N-1 个不同主题才允许强制结束
+			// ② 第 5 主题硬顶：已覆盖 ≥N-1 个不同主题 ∧ 当前为最后一个主题 ∧ 已满足（完成或追问预算耗尽）
 			if (topics.size() >= 5
 					&& coveredTopics.size() >= topics.size() - 1
 					&& topics.indexOf(currentTopic) == topics.size() - 1
-					&& currentTopicCompleted) {
+					&& currentTopicSatisfied()) {
 				shouldEnd = true;
 				return;
 			}
-			// ③ 自然结束：全部主题已覆盖 ∧ 两必选已覆盖 ∧ 当前主题完成
+			// ③ 自然结束：全部主题已覆盖 ∧ 两必选已覆盖 ∧ 最后一个主题已满足（锁存，不依赖当前轮主题）
 			if (coveredTopics.size() >= topics.size()
 					&& coveredMandatoryTopics.size() >= 2
-					&& currentTopicCompleted) {
+					&& lastTopicSatisfied) {
+				shouldEnd = true;
+				return;
+			}
+			// ④ 最大轮次兜底：防模型/识别退化导致永不结束
+			if (lastProcessedTurnNo >= maxInterviewTurns()) {
 				shouldEnd = true;
 			}
+		}
+
+		/** 每主题 1 问 + maxFollowUps 个追问，加 3 轮缓冲；STANDARD 5 主题=18，HARD 5 主题=23。 */
+		private int maxInterviewTurns() {
+			return topics.size() * (maxFollowUps + 2) + 3;
+		}
+
+		/** 下一轮 realtime 指令：开场、推进、收尾或结束，由状态机统一生成。 */
+		private String buildControlInstruction() {
+			if (currentTopic == null) {
+				return "Begin the interview. Open with the first topic: "
+						+ topics.get(0) + ".";
+			}
+			if (shouldEnd) {
+				return "";
+			}
+			if (coveredTopics.size() >= topics.size() && lastTopicSatisfied) {
+				return "The interview is complete. Give a brief, natural closing and thank "
+						+ "the candidate for their time. Do not ask more questions.";
+			}
+			if (currentTopicSatisfied()
+					&& topics.indexOf(currentTopic) < topics.size() - 1) {
+				return "You have covered the topic: " + currentTopic
+						+ ". Move on to the NEXT topic in the interview flow now. "
+						+ "Do not ask further follow-ups on this topic.";
+			}
+			return "Current interview topic: " + currentTopic
+					+ ". Ask a focused follow-up within this topic, then transition to the "
+					+ "NEXT topic when it is covered. Do not skip topics.";
 		}
 
 		private String matchTopic(String topic) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/session/InterviewTurnStateResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/session/InterviewTurnStateResponse.java
@@ -1,11 +1,13 @@
 package com.unispeaking.domain.dto.session;
 
 /**
- * 本轮状态快照：{@code shouldEnd=true} 时前端负责停止录音并关闭实时连接（后端不主动断开）。
+ * 本轮状态快照：{@code shouldEnd=true} 时前端负责停止录音并关闭实时连接（后端不主动断开）；
+ * {@code controlInstruction} 为下一轮 realtime 指令（结束或空会话时为空）。
  */
 public record InterviewTurnStateResponse(
 		boolean shouldEnd,
 		int completedTopicCount,
 		int coveredTopicCount,
-		String currentTopic) {
+		String currentTopic,
+		String controlInstruction) {
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/session/InterviewTurnStateResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/session/InterviewTurnStateResponse.java
@@ -2,7 +2,7 @@ package com.unispeaking.domain.dto.session;
 
 /**
  * 本轮状态快照：{@code shouldEnd=true} 时前端负责停止录音并关闭实时连接（后端不主动断开）；
- * {@code controlInstruction} 为下一轮 realtime 指令（结束或空会话时为空）。
+ * {@code controlInstruction} 为下一轮 realtime 指令（结束时为收尾指令）。
  */
 public record InterviewTurnStateResponse(
 		boolean shouldEnd,

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewTopicState.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewTopicState.java
@@ -10,7 +10,7 @@ package com.unispeaking.domain.vo.scene;
  * @param followUpCount           当前主题追问次数（受难度上限约束）
  * @param mandatoryTopicsCompleted 两个必选主题（自我介绍/经历项目）是否均已完成
  * @param shouldEnd               状态机是否判定面试结束
- * @param controlInstruction      下一轮 realtime 指令（开场/推进/收尾；结束时为空）
+ * @param controlInstruction      下一轮 realtime 指令（开场/推进/收尾；结束时为收尾指令）
  */
 public record InterviewTopicState(
 		String currentTopic,

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewTopicState.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/InterviewTopicState.java
@@ -10,6 +10,7 @@ package com.unispeaking.domain.vo.scene;
  * @param followUpCount           当前主题追问次数（受难度上限约束）
  * @param mandatoryTopicsCompleted 两个必选主题（自我介绍/经历项目）是否均已完成
  * @param shouldEnd               状态机是否判定面试结束
+ * @param controlInstruction      下一轮 realtime 指令（开场/推进/收尾；结束时为空）
  */
 public record InterviewTopicState(
 		String currentTopic,
@@ -18,5 +19,6 @@ public record InterviewTopicState(
 		int unknownStreak,
 		int followUpCount,
 		boolean mandatoryTopicsCompleted,
-		boolean shouldEnd) {
+		boolean shouldEnd,
+		String controlInstruction) {
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/session/impl/InterviewSessionServiceImpl.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/session/impl/InterviewSessionServiceImpl.java
@@ -206,7 +206,8 @@ public class InterviewSessionServiceImpl implements InterviewSessionService {
 							true,
 							state.completedTopicCount(),
 							state.coveredTopicCount(),
-							state.currentTopic()),
+							state.currentTopic(),
+							state.controlInstruction()),
 					end.reportStatus());
 		}
 		return toTurnResult(state);
@@ -395,7 +396,8 @@ public class InterviewSessionServiceImpl implements InterviewSessionService {
 						state.shouldEnd(),
 						state.completedTopicCount(),
 						state.coveredTopicCount(),
-						state.currentTopic()),
+						state.currentTopic(),
+						state.controlInstruction()),
 				state.shouldEnd() ? ReportStatus.PROCESSING : null);
 	}
 
@@ -445,8 +447,10 @@ public class InterviewSessionServiceImpl implements InterviewSessionService {
 
 				Rules:
 				- topic MUST be one of the candidate topics verbatim, or "UNKNOWN". Do not invent new topics.
-				- topicCompleted MUST be false unless the candidate has fully finished and explicitly closed this topic.
-				  It MUST be false for a first or only answer, a short or interrupted answer, or a partial answer on that topic.
+				- topicCompleted may be true when the candidate gives a comprehensive answer that substantially covers
+				  the whole topic, or explicitly signals they are done with it.
+				- topicCompleted MUST still be false for a first brief answer, a short or interrupted answer,
+				  or a partial answer on that topic.
 				- Choose UNKNOWN when the answer is too short, ambiguous, cut off, or does not clearly belong to any topic.
 				""".formatted(
 						jsonValue(candidateTopics == null ? List.of() : candidateTopics),

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/InterviewTopicStateMachineTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/InterviewTopicStateMachineTest.java
@@ -344,6 +344,117 @@ class InterviewTopicStateMachineTest {
 		assertNull(state.currentTopic());
 	}
 
+	@Test
+	void naturalEndFiresAfterAllTopicsCoveredAndLastTopicFollowedUp() {
+		List<String> topics = topics(
+				"自我介绍", "项目经历", "技术栈", "团队协作", "高并发问题解决");
+		stateMachine.start("session-1", topics, InterviewDifficulty.STANDARD);
+
+		InterviewTopicState last = null;
+		int turnNo = 1;
+		for (String topic : topics) {
+			stateMachine.advance(
+					"session-1",
+					turnNo++,
+					new InterviewTopicEvent(topic, false));
+			last = stateMachine.advance(
+					"session-1",
+					turnNo++,
+					new InterviewTopicEvent(topic, false));
+		}
+
+		assertEquals(10, turnNo - 1);
+		assertTrue(last.shouldEnd());
+		assertEquals(5, last.coveredTopicCount());
+	}
+
+	@Test
+	void singleAnswerPerTopicDoesNotEnd() {
+		List<String> topics = topics(
+				"自我介绍", "项目经历", "技术栈", "团队协作", "高并发问题解决");
+		stateMachine.start("session-1", topics, InterviewDifficulty.STANDARD);
+
+		InterviewTopicState last = null;
+		for (int turnNo = 1; turnNo <= topics.size(); turnNo++) {
+			last = stateMachine.advance(
+					"session-1",
+					turnNo,
+					new InterviewTopicEvent(topics.get(turnNo - 1), false));
+		}
+
+		assertFalse(last.shouldEnd());
+		assertEquals(5, last.coveredTopicCount());
+		assertTrue(last.controlInstruction().contains("Current interview topic"));
+		assertFalse(last.controlInstruction().contains("Move on to the NEXT topic"));
+	}
+
+	@Test
+	void maxTurnBackstopForcesEnd() {
+		List<String> topics = topics(
+				"自我介绍", "项目经历", "技术栈", "团队协作", "高并发问题解决");
+		stateMachine.start("session-1", topics, InterviewDifficulty.STANDARD);
+
+		InterviewTopicState before = null;
+		for (int turnNo = 1; turnNo <= 17; turnNo++) {
+			before = stateMachine.advance(
+					"session-1",
+					turnNo,
+					new InterviewTopicEvent("自我介绍", false));
+		}
+		assertFalse(before.shouldEnd());
+
+		InterviewTopicState last = stateMachine.advance(
+				"session-1",
+				18,
+				new InterviewTopicEvent("自我介绍", false));
+
+		assertTrue(last.shouldEnd());
+	}
+
+	@Test
+	void controlInstructionTracksSatisfiedTopic() {
+		List<String> topics = topics(
+				"自我介绍", "项目经历", "技术栈", "团队协作", "高并发问题解决");
+		stateMachine.start("session-1", topics, InterviewDifficulty.STANDARD);
+
+		InterviewTopicState first = stateMachine.advance(
+				"session-1",
+				1,
+				new InterviewTopicEvent("自我介绍", false));
+		assertTrue(first.controlInstruction().contains("Current interview topic"));
+		assertFalse(first.controlInstruction().contains("Move on to the NEXT topic"));
+
+		InterviewTopicState satisfied = stateMachine.advance(
+				"session-1",
+				2,
+				new InterviewTopicEvent("自我介绍", false));
+		assertTrue(satisfied.controlInstruction().contains("Move on to the NEXT topic"));
+	}
+
+	@Test
+	void closingInstructionAfterAllCoveredButMandatoryNotSatisfied() {
+		// 4 主题中仅"自我介绍"为必选：全部覆盖且最后主题满足后规则③不触发，进入收尾指令而非结束
+		List<String> topics = topics("自我介绍", "技术栈", "职业规划", "薪资期望");
+		stateMachine.start("session-1", topics, InterviewDifficulty.STANDARD);
+
+		InterviewTopicState last = null;
+		int turnNo = 1;
+		for (String topic : topics) {
+			stateMachine.advance(
+					"session-1",
+					turnNo++,
+					new InterviewTopicEvent(topic, false));
+			last = stateMachine.advance(
+					"session-1",
+					turnNo++,
+					new InterviewTopicEvent(topic, false));
+		}
+
+		assertFalse(last.shouldEnd());
+		assertTrue(last.controlInstruction().contains("The interview is complete"));
+		assertTrue(last.controlInstruction().contains("thank the candidate"));
+	}
+
 	private List<String> topics(String... values) {
 		return List.of(values);
 	}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/InterviewTopicStateMachineTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/InterviewTopicStateMachineTest.java
@@ -79,6 +79,25 @@ class InterviewTopicStateMachineTest {
 	}
 
 	@Test
+	void shouldEndReturnsClosingInstruction() {
+		stateMachine.start(
+				"session-1",
+				topics("自我介绍", "项目经历"),
+				InterviewDifficulty.STANDARD);
+
+		stateMachine.advance("session-1", 1, InterviewTopicEvent.unknown());
+		stateMachine.advance("session-1", 2, InterviewTopicEvent.unknown());
+		InterviewTopicState state = stateMachine.advance(
+				"session-1",
+				3,
+				InterviewTopicEvent.unknown());
+
+		assertTrue(state.shouldEnd());
+		assertTrue(state.controlInstruction().contains("The interview is complete"));
+		assertTrue(state.controlInstruction().contains("thank the candidate"));
+	}
+
+	@Test
 	void unknownStreakResetsOnRealTopic() {
 		stateMachine.start(
 				"session-1",
@@ -366,6 +385,8 @@ class InterviewTopicStateMachineTest {
 		assertEquals(10, turnNo - 1);
 		assertTrue(last.shouldEnd());
 		assertEquals(5, last.coveredTopicCount());
+		assertTrue(last.controlInstruction().contains("The interview is complete"));
+		assertTrue(last.controlInstruction().contains("thank the candidate"));
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/InterviewSceneControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/InterviewSceneControllerTest.java
@@ -196,7 +196,7 @@ class InterviewSceneControllerTest {
 		when(sessions.submitTurn(any(), any(), anyInt(), any(), any()))
 				.thenReturn(new com.unispeaking.domain.dto.session.InterviewTurnResult(
 						new com.unispeaking.domain.dto.session.InterviewTurnStateResponse(
-								false, 1, 1, "自我介绍"),
+								false, 1, 1, "自我介绍", ""),
 						null));
 		MockMvc mvc = MockMvcBuilders
 				.standaloneSetup(new InterviewSceneController(

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/InterviewSessionServiceImplTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/InterviewSessionServiceImplTest.java
@@ -305,7 +305,7 @@ class InterviewSessionServiceImplTest {
 		when(scenes.advanceTopicState(
 				eq(sceneId), eq("session-1"), eq(1), any(InterviewTopicEvent.class)))
 				.thenReturn(new InterviewTopicState(
-						"自我介绍", 0, 0, 0, 0, false, false));
+						"自我介绍", 0, 0, 0, 0, false, false, ""));
 
 		InterviewTurnResult result =
 				service.submitTurn(sceneId, "session-1", 1, "recorded transcript", null);

--- a/docs/API接口文档.md
+++ b/docs/API接口文档.md
@@ -508,7 +508,7 @@ Interview（英文面试，第 4 场景，逐步实现中）：
    - 失败码：`INTERVIEW_SCENE_NOT_FOUND`→404、`INTERVIEW_SCENE_ACCESS_DENIED`→403、`INTERVIEW_DAILY_LIMIT_REACHED`→429。
 4. `POST /api/interview-scenes/{sceneId}/sessions/{sessionId}/turns/{turnNo}` — 逐轮提交（multipart：`transcript` 必填 + `audio` 可空）
    - 幂等粒度 `(sessionId, turnNo)`：重复请求返回已记录状态；同轮内容不一致 → 409 `INTERVIEW_TURN_CONTENT_MISMATCH`；WS 消息在途 → 409 `INTERVIEW_TURN_MESSAGE_PENDING`（可重试）；轮次空洞/非正 → 400 `INTERVIEW_TURN_OUT_OF_ORDER`；会话已结束 → 409 `INTERVIEW_SESSION_ENDED`。
-   - 返回 `{state: {shouldEnd, completedTopicCount, coveredTopicCount, currentTopic}, reportStatus}`；`shouldEnd=true` 时前端停录音关连接，`reportStatus=PROCESSING`。
+   - 返回 `{state: {shouldEnd, completedTopicCount, coveredTopicCount, currentTopic, controlInstruction}, reportStatus}`；`shouldEnd=true` 时前端停录音关连接，`reportStatus=PROCESSING`；`controlInstruction` 为下一轮实时指令（开场/推进/收尾，结束时为空）。
 5. `POST /api/interview-scenes/{sceneId}/sessions/{sessionId}/end` — 用户主动结束（幂等结束编排，自动/手动只允许一次 end + 一次报告任务）→ `{sessionId, reportStatus}`。
 6. `GET /api/interview-scenes/{sceneId}/sessions/{sessionId}/report` — 轮询报告：`{sessionId, sceneId, status: PROCESSING/COMPLETED/FAILED, report, failureReason}`（PROCESSING 时 report 为空）。
 7. `POST /api/interview-scenes/{sceneId}/sessions/{sessionId}/report/retry` — FAILED→PROCESSING 重试（CAS 幂等；瞬时失败自动重试 1 次后留手动）。

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -449,6 +449,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
   const [error, setError] = useState("");
   const [paused, setPaused] = useState(false);
   const [ending, setEnding] = useState(false);
+  const [closing, setClosing] = useState(false);
   const [lines, setLines] = useState([]);
   const [currentTopic, setCurrentTopic] = useState("");
   const [completedTopicCount, setCompletedTopicCount] = useState(0);
@@ -527,10 +528,12 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     } else if (event.type === "local.interview_closing") {
       endingRef.current = true;
       setEnding(true);
+      setClosing(true);
       setStatus("面试官正在做本次面试的收尾…");
     } else if (event.type === "local.interview_end_requested") {
       endingRef.current = true;
       setEnding(true);
+      setClosing(false);
       setStatus("面试已结束，正在生成报告");
       onEndInterviewRef.current?.(sceneId, sessionIdRef.current, event.reportStatus || null);
     } else if (event.type === "local.interview_end_error") {
@@ -630,7 +633,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     <main className="conversation call call--subtitles interview-call">
       <audio ref={remoteAudioRef} autoPlay />
       <div className="conversation__top interview-call-top">
-        <div><button className="ielts-back" onClick={() => setExitOpen(true)}><ArrowLeft />返回场景广场</button><strong>模拟面试</strong><span>{ending ? "面试计时已停止，正在生成报告" : currentTopic ? `当前主题：${currentTopic}` : status}</span></div>
+        <div><button className="ielts-back" onClick={() => setExitOpen(true)}><ArrowLeft />返回场景广场</button><strong>模拟面试</strong><span>{closing ? "面试收尾中…" : ending ? "面试计时已停止，正在生成报告" : currentTopic ? `当前主题：${currentTopic}` : status}</span></div>
         <div className="interview-call-progress"><span>已覆盖 {completedTopicCount} 个主题</span><button className="round-control interview-call-exit" disabled={ending} onClick={() => setExitOpen(true)} aria-label="退出面试"><X /></button></div>
       </div>
       <section className="call__stage">
@@ -639,7 +642,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
           <div className="listening-state listening-state--compact">
             <InterviewWaveform active={!ending && !paused && !error} compact />
             <InterviewTimer paused={paused} state={ending || error ? "ended" : "active"} />
-            {!ending && <span>{status}</span>}
+            {(!ending || closing) && <span>{status}</span>}
           </div>
         </div>
         <InterviewTranscript lines={lines} status={status} transcriptRef={transcriptRef} />

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -518,12 +518,16 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
       if (endingRef.current) {
         // Report recovery carries only reportStatus; keep the ending status.
       } else if (state?.shouldEnd) {
-        setStatus("面试已完成，正在生成报告");
+        setStatus("面试已完成，准备收尾…");
       } else if (state?.currentTopic) {
         setStatus(`正在面试 · ${state.currentTopic}`);
       } else {
         setStatus("面试官正在提问");
       }
+    } else if (event.type === "local.interview_closing") {
+      endingRef.current = true;
+      setEnding(true);
+      setStatus("面试官正在做本次面试的收尾…");
     } else if (event.type === "local.interview_end_requested") {
       endingRef.current = true;
       setEnding(true);

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -1078,9 +1078,11 @@ export function createRealtimeClient({
             });
           } else {
             requestTurnResponse({
-              instructions: state?.currentTopic
-                ? `Current interview topic: ${state.currentTopic}. Continue the interview naturally — ask a focused follow-up within this topic, or transition to the NEXT topic in the interview flow when this one is covered. Do not skip topics.`
-                : "",
+              instructions:
+                state?.controlInstruction ||
+                (state?.currentTopic
+                  ? `Current interview topic: ${state.currentTopic}. Continue the interview naturally — ask a focused follow-up within this topic, or transition to the NEXT topic in the interview flow when this one is covered. Do not skip topics.`
+                  : ""),
             });
           }
         } catch (error) {

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -23,6 +23,7 @@ const SCENARIO_AUDIO_DRAIN_MS = 1_200;
 const SESSION_UPDATE_TIMEOUT_MS = 5_000;
 const IELTS_STATE_TIMEOUT_MS = 5_000;
 const IELTS_INPUT_RECOVERY_MS = 2_500;
+const DEFAULT_INTERVIEW_CLOSING = "The interview is complete. Give a brief, natural closing and thank the candidate for their time. Do not ask more questions.";
 const SPEECH_SPEED_INSTRUCTIONS = {
   SLOWER: "Voice delivery rule: speak distinctly and very slowly, around 70 English words per minute, with clear pauses between short phrases.",
   MODERATE: "Voice delivery rule: speak at a calm moderate pace, around 120 English words per minute, with clear pauses between ideas.",
@@ -331,6 +332,8 @@ export function createRealtimeClient({
   let instructionUpdateQueue = Promise.resolve(true);
   let activeInputItemId = null;
   let ieltsTimedOutTurn = null;
+  let closingInstructions = "";
+  let pendingInterviewReportStatus = null;
 
   const emit = (event) => onEvent(event);
 
@@ -627,11 +630,16 @@ export function createRealtimeClient({
       scenarioAudioDrainTimer = null;
     }
     scenarioCompletionEmitted = true;
-    emit({ type: "local.scenario_completed" });
+    if (interviewSceneId) {
+      emit({ type: "local.interview_end_requested", reportStatus: pendingInterviewReportStatus });
+    } else {
+      emit({ type: "local.scenario_completed" });
+    }
     void stop({ reason: "state_machine" }).catch((error) => {
       emit({
-        type: "local.scenario_completion_error",
-        message: error instanceof Error ? error.message : "场景自动结束失败",
+        type: interviewSceneId ? "local.interview_end_error" : "local.scenario_completion_error",
+        message: error instanceof Error ? error.message
+          : interviewSceneId ? "面试自动结束失败" : "场景自动结束失败",
       });
     });
   }
@@ -1066,16 +1074,18 @@ export function createRealtimeClient({
             reportStatus,
           });
           if (state?.shouldEnd) {
+            pendingInterviewReportStatus = reportStatus ?? null;
+            closingInstructions = String(state.controlInstruction || "").trim()
+              || DEFAULT_INTERVIEW_CLOSING;
+            scenarioCompletionPending = true;
             inputReady = false;
             setTrackEnabled();
             turnAudioCapture?.stop();
-            emit({ type: "local.interview_end_requested", reportStatus });
-            void stop({ reason: "state_machine" }).catch((error) => {
-              emit({
-                type: "local.interview_end_error",
-                message: error instanceof Error ? error.message : "面试自动结束失败",
-              });
-            });
+            armScenarioCompletionTimeout();
+            emit({ type: "local.interview_closing" });
+            if (!responsePending) {
+              requestTurnResponse({ closing: true, instructions: closingInstructions });
+            }
           } else {
             requestTurnResponse({
               instructions:
@@ -1122,7 +1132,7 @@ export function createRealtimeClient({
           }
           scheduleScenarioCompletionAfterAudioDrain();
         } else {
-          requestTurnResponse({ closing: true });
+          requestTurnResponse({ closing: true, instructions: closingInstructions });
         }
       } else if (manualTurnResponses) {
         if (isDeterministicIeltsPart()) {
@@ -1471,6 +1481,8 @@ export function createRealtimeClient({
       scenarioAudioDrainTimer = null;
       responsePending = false;
       closingResponseRequested = false;
+      closingInstructions = "";
+      pendingInterviewReportStatus = null;
       statePipeline = Promise.resolve();
       ieltsActivePart = null;
       ieltsPreparedQuestions = [];

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -1111,11 +1111,24 @@ export function createRealtimeClient({
     const completedAssistantMessage = extractCompletedAssistantMessage(event);
     if (completedAssistantMessage) {
       scheduleIeltsInputRecovery();
-      await addSessionMessage(
-        0,
-        completedAssistantMessage.text,
-        completedAssistantMessage.id,
-      );
+      if (scenarioCompletionPending && interviewSceneId) {
+        // 收尾期间会话已被后端终态化：跳过 WS 落库（否则 Session not found），仅展示收尾语
+        const closingText = String(completedAssistantMessage.text || "").trim();
+        if (closingText) {
+          emit({
+            type: "local.transcript.final",
+            owner: 0,
+            itemId: completedAssistantMessage.id || eventId("transcript"),
+            text: closingText,
+          });
+        }
+      } else {
+        await addSessionMessage(
+          0,
+          completedAssistantMessage.text,
+          completedAssistantMessage.id,
+        );
+      }
     }
     if (event.type === "response.done") {
       responsePending = false;


### PR DESCRIPTION
### Summary
重做英文面试（Interview）状态机的结束判定——用"可累积的满足度 + 轮次兜底"替代脆弱的逐轮完成信号，使面试**必然在合理轮次结束且不会过早结束**；并在结束前让面试官播放一句自然收尾语再跳报告，结束不再突兀。

### 背景问题
英文面试此前存在"摆锤"问题：先因 `topicCompleted` 判定过松而 **1~2 轮就过早结束**；上一轮收紧判定后又走向另一端 **聊 14~15 轮都不结束**；且 `shouldEnd`（状态机判定应结束）后立即停录音跳报告，面试官没有任何收尾。本 PR 解决这三个问题。

### Changes

**1. 状态机结束判定重做（`ae9c675`）**

根因：结束规则②③都要求"当前主题已完成"，但识别提示词收紧后（只有完整讲完并明确收尾才算完成），候选人 1~3 句短答几乎每轮判未完成 → 规则②③结构性触发不了；每轮回传指令"锁死"当前主题 → `coveredTopics`（已覆盖主题数，与"已完成"不同，问到即算）停滞；无轮次上限兜底。

改动（`component/statemachine/InterviewTopicStateMachine.java`）：
- `currentTopicSatisfied()` = `topicCompleted` **或** 追问预算耗尽（`followUpCount >= maxFollowUps`）——主信号是"追问预算耗尽"这一确定性事实；
- `lastTopicSatisfied` 锁存（最后主题满足后不再放开，容忍收尾切题）；
- 规则②③改用满足度；新增**规则④轮次兜底**（每主题 1 首问 + 追问 + 1 过渡 + 3 缓冲，标准 5 主题 = 18 轮强制结束）；
- `buildControlInstruction()`（`controlInstruction` = 下一轮喂给实时模型的指令）：满足 → "进入下一主题"；全部覆盖 → "收尾致谢"；
- `InterviewTopicState`/`InterviewTurnStateResponse` 新增 `controlInstruction`（`coveredTopicCount` 沿用上一提交）；
- `InterviewSessionServiceImpl`：空转录 `ignored()` 沿用既有契约（新增单测固化）；识别提示词适度放宽 `topicCompleted`（短答仍判未完成）；
- `common/prompt/interview/InterviewPromptBuilder` 追加"服从应用推进/结束指令"；前端采用后端指令（有 fallback）；已同步 API 文档。

**防回归**：规则②③仍要求覆盖 ≥N-1/N 且最后主题满足——正常情况下最早 N+1 轮（末题首答即判完成可提前到 N 轮），不会回到 1~2 轮结束。

**2. 结束前播放收尾语（`3b347ab` + `53dc4b9`）**
- 后端：`shouldEnd` 时返回收尾指令（原为空）；`shouldEnd` 判断提到最前。
- 前端 `realtimeClient.js`：`shouldEnd` 后接入既有 `scenarioCompletionPending` 收尾机制（关麦/20s 超时/`response.done`+1.2s 排空）再结束；**收尾句跳过 WS 落库**（会话已终态化，仅实时展示，避免 `Session not found` 横幅）。
- `InterviewModule.jsx`：新增 `local.interview_closing`（"面试收尾中…"），收尾中/已结束文案解耦。

**设计取舍**：自动结束播收尾语、手动结束不播；收尾句不进历史转写/报告（有意取舍）；后端 `shouldEnd` 时同步终态化+提交报告任务，收尾播放与报告生成并行，未加"收尾中间态"；收尾文案后端为主 + 前端 fallback。

### 契约 / 兼容 / 迁移
- `submitTurn` 响应新增 `controlInstruction`（增量字段，前端同 PR 消费；新前端对旧后端有本地模板 fallback，混合部署兼容）。
- **无 Flyway 迁移**（状态机进程内）；**回滚 = 撤销三个提交**。

### How to verify
**后端**：`./mvnw test` → 578 全绿。新增用例：`naturalEndFiresAfterAllTopicsCovered`（第 10 轮结束）/ `singleAnswerPerTopicDoesNotEnd`（防过早）/ `maxTurnBackstopForcesEnd`（18 轮兜底）/ `shouldEndReturnsClosingInstruction`。
**前端**：`check-routes`(58) / `check-realtime-events` / `build` 全过（Custom/IELTS 零变化）。
**端到端**：①完整面试约 10 轮 → 先听到收尾语 → 再跳报告，无错误横幅；②只答短句 → ~10~18 轮结束；③反复说无法识别的内容 → 18 轮兜底结束；④手动结束立即结束无收尾；⑤冒烟 Custom/IELTS。**说明：纯静默无兜底**（前端空转写直接跳过提交，不产生轮次，面试挂起等开口或手动结束——既有行为，本 PR 未改变）。

Close #64 