### PR TITLE
feat(web): 添加练习后反馈邀请

### DIFF
--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "test:auth": "node --test scripts/check-auth-contract.mjs scripts/check-captcha-config.mjs scripts/check-api-client-auth.mjs",
+    "check:feedback-invitation": "node scripts/check-feedback-invitation.mjs",
     "check:realtime-events": "node scripts/check-realtime-events.mjs",
     "check:routes": "node scripts/check-routes.mjs",
     "generate:teacher-previews": "node scripts/generate-teacher-previews.mjs",

--- a/frontend/web/scripts/check-feedback-invitation.mjs
+++ b/frontend/web/scripts/check-feedback-invitation.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { markFeedbackStarted, recordFeedbackPractice } from "../src/component/help/feedbackInvitation.js";
+
+function memoryStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+  };
+}
+
+const freeStorage = memoryStorage();
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: "free-1" }), false);
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: "free-2" }), false);
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: "free-3" }), true);
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: "free-4" }), false);
+for (let index = 5; index < 13; index += 1) {
+  assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: index % 2 ? "free" : "scene", sessionId: `follow-up-${index}` }), false);
+}
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "scene", sessionId: "follow-up-13" }), true);
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: "follow-up-14" }), false);
+for (let index = 15; index < 23; index += 1) {
+  assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "free", sessionId: `follow-up-${index}` }), false);
+}
+assert.equal(recordFeedbackPractice(freeStorage, { userId: "user-1", practiceType: "scene", sessionId: "follow-up-23" }), true);
+
+const sceneStorage = memoryStorage();
+assert.equal(recordFeedbackPractice(sceneStorage, { userId: "user-2", practiceType: "scene", sessionId: "scene-1" }), false);
+assert.equal(recordFeedbackPractice(sceneStorage, { userId: "user-2", practiceType: "scene", sessionId: "scene-1" }), false);
+assert.equal(recordFeedbackPractice(sceneStorage, { userId: "user-2", practiceType: "scene", sessionId: "scene-2" }), false);
+assert.equal(recordFeedbackPractice(sceneStorage, { userId: "user-2", practiceType: "scene", sessionId: "scene-3" }), true);
+assert.equal(markFeedbackStarted(sceneStorage, "user-2"), true);
+for (let index = 4; index <= 15; index += 1) {
+  assert.equal(recordFeedbackPractice(sceneStorage, { userId: "user-2", practiceType: "scene", sessionId: `scene-${index}` }), false);
+}
+
+const mixedStorage = memoryStorage();
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-3", practiceType: "free", sessionId: "mixed-1" }), false);
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-3", practiceType: "scene", sessionId: "mixed-2" }), false);
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-3", practiceType: "free", sessionId: "mixed-3" }), false);
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-3", practiceType: "scene", sessionId: "mixed-4" }), false);
+
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-4", practiceType: "free", sessionId: "other-1" }), false);
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-4", practiceType: "free", sessionId: "other-2" }), false);
+assert.equal(recordFeedbackPractice(mixedStorage, { userId: "user-4", practiceType: "free", sessionId: "other-3" }), true);
+
+console.log("Feedback invitation contract passed: 47 assertions");

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -603,6 +603,11 @@ svg { display: block; }
 .learning-complete-note { display: flex; align-items: center; gap: 8px; color: #317653; }
 .learning-complete-note svg { width: 20px; height: 20px; }
 .modal-actions { display: flex; justify-content: flex-end; gap: 10px; margin-top: 25px; }
+.feedback-invitation { width: min(520px, 90vw); }
+.feedback-invitation__icon { width: 54px; height: 54px; margin-bottom: 24px; display: grid; place-items: center; border-radius: 8px; color: #395e66; background: #e4eff0; }
+.feedback-invitation__icon svg { width: 27px; height: 27px; }
+.feedback-invitation .modal-lead { max-width: 410px; margin-bottom: 0; }
+.feedback-invitation .button { text-decoration: none; }
 
 .training-page { height: 100%; min-height: 760px; display: grid; grid-template-rows: 78px 92px 1fr; overflow: hidden; }
 .training-page--standalone { grid-template-rows: 78px minmax(0, 1fr); }
@@ -1380,6 +1385,8 @@ svg { display: block; }
 }
 
 @media (max-width: 560px) {
+  .feedback-invitation .modal-actions { align-items: stretch; flex-direction: column-reverse; }
+  .feedback-invitation .button { width: 100%; }
   .account-security-header { min-height: 170px; padding-bottom: 30px; }
   .account-security-header__icon { width: 48px; height: 48px; margin-bottom: 24px; }
   .account-security-header h1 { font-size: 32px; }

--- a/frontend/web/src/component/help/feedbackInvitation.js
+++ b/frontend/web/src/component/help/feedbackInvitation.js
@@ -1,0 +1,81 @@
+const feedbackInvitationStoragePrefix = "unispeaking.feedbackInvitation.v1";
+const initialInvitationThreshold = 3;
+const followUpInvitationThreshold = 10;
+const sessionHistoryLimit = followUpInvitationThreshold * 2;
+
+function emptyProgress() {
+  return {
+    freeConversationCount: 0,
+    scenePracticeCount: 0,
+    invitationCount: 0,
+    practicesSinceLastInvitation: 0,
+    recordedSessionIds: [],
+    feedbackStarted: false,
+  };
+}
+
+function storageKey(userId) {
+  return `${feedbackInvitationStoragePrefix}.${encodeURIComponent(String(userId))}`;
+}
+
+function readProgress(storage, userId) {
+  if (!storage || !userId) return emptyProgress();
+  try {
+    const stored = JSON.parse(storage.getItem(storageKey(userId)) || "null");
+    return {
+      freeConversationCount: Math.max(0, Number(stored?.freeConversationCount) || 0),
+      scenePracticeCount: Math.max(0, Number(stored?.scenePracticeCount) || 0),
+      invitationCount: Math.max(0, Number(stored?.invitationCount) || (stored?.prompted ? 1 : 0)),
+      practicesSinceLastInvitation: Math.max(0, Number(stored?.practicesSinceLastInvitation) || 0),
+      recordedSessionIds: Array.isArray(stored?.recordedSessionIds)
+        ? stored.recordedSessionIds.filter((item) => typeof item === "string").slice(-sessionHistoryLimit)
+        : [],
+      feedbackStarted: Boolean(stored?.feedbackStarted),
+    };
+  } catch {
+    return emptyProgress();
+  }
+}
+
+export function recordFeedbackPractice(storage, { userId, practiceType, sessionId }) {
+  if (!storage || !userId || !sessionId || !["free", "scene"].includes(practiceType)) return false;
+  const progress = readProgress(storage, userId);
+  const recordedSessionId = `${practiceType}:${sessionId}`;
+  if (progress.feedbackStarted || progress.recordedSessionIds.includes(recordedSessionId)) return false;
+
+  const countKey = practiceType === "free" ? "freeConversationCount" : "scenePracticeCount";
+  progress[countKey] += 1;
+  progress.recordedSessionIds = [...progress.recordedSessionIds, recordedSessionId].slice(-sessionHistoryLimit);
+
+  let shouldInvite = false;
+  if (progress.invitationCount === 0) {
+    shouldInvite = progress.freeConversationCount >= initialInvitationThreshold
+      || progress.scenePracticeCount >= initialInvitationThreshold;
+  } else {
+    progress.practicesSinceLastInvitation += 1;
+    shouldInvite = progress.practicesSinceLastInvitation >= followUpInvitationThreshold;
+  }
+  if (shouldInvite) {
+    progress.invitationCount += 1;
+    progress.practicesSinceLastInvitation = 0;
+  }
+
+  try {
+    storage.setItem(storageKey(userId), JSON.stringify(progress));
+  } catch {
+    return false;
+  }
+  return shouldInvite;
+}
+
+export function markFeedbackStarted(storage, userId) {
+  if (!storage || !userId) return false;
+  const progress = readProgress(storage, userId);
+  progress.feedbackStarted = true;
+  try {
+    storage.setItem(storageKey(userId), JSON.stringify(progress));
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -86,6 +86,8 @@ import { IeltsAssets, IeltsTrainingCenter } from "../component/ielts/IeltsModule
 import { InterviewAssets, InterviewModule } from "../component/interview/InterviewModule.jsx";
 import { HelpCenter } from "../component/help/HelpCenter.jsx";
 import { HelpLayout } from "../component/help/HelpLayout.jsx";
+import { feedbackUrl } from "../component/help/ExternalFeedbackLink.jsx";
+import { markFeedbackStarted, recordFeedbackPractice } from "../component/help/feedbackInvitation.js";
 import { LandingPage } from "../component/landing/LandingPage.jsx";
 import { NewtonsCradle } from "../component/common/NewtonsCradle.jsx";
 import { Modal } from "../component/common/Modal.jsx";
@@ -1139,13 +1141,15 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
       return;
     }
     if (event.type === "local.ended") {
+      const completedSessionId = sessionIdRef.current;
       setInCall(false);
       setSubtitles(false);
       setPaused(false);
       setCallState("idle");
       setCallStatus("准备开始");
       clientRef.current = null;
-      onSessionEnded?.();
+      sessionIdRef.current = "";
+      onSessionEnded?.(completedSessionId);
       return;
     }
     if (event.type === "local.mic_error") {
@@ -1224,6 +1228,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
 
   const stopConversation = async () => {
     const client = clientRef.current;
+    const completedSessionId = sessionIdRef.current;
     clientRef.current = null;
     sessionIdRef.current = "";
     clientGenerationRef.current += 1;
@@ -1233,7 +1238,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
     setCallState("idle");
     setCallStatus("准备开始");
     await client?.stop({ reason: "user_stop" });
-    onSessionEnded?.();
+    onSessionEnded?.(completedSessionId);
   };
 
   useEffect(() => () => {
@@ -2698,6 +2703,23 @@ function Paywall({ title, onClose, onMembership }) {
   return <Modal onClose={onClose}><div className="paywall-icon"><LockKey /></div><p className="eyebrow">SPECIAL TRAINING</p><h2>开始“{title}”需要特训版</h2><p className="modal-lead">你可以自由查看介绍；只有正式开始训练时才会检查权益。</p><ul className="paywall-list"><li><Check />IELTS 全真模拟与预估分数</li><li><Check />上传 PDF / DOCX 或粘贴面试材料</li><li><Check />雅思与面试共用 5 次/天</li></ul><div className="modal-actions"><Button variant="secondary" onClick={onClose}>稍后再说</Button><Button onClick={onMembership}>查看特训版</Button></div></Modal>;
 }
 
+function FeedbackInvitation({ onDismiss, onAccept }) {
+  return (
+    <Modal onClose={onDismiss} className="feedback-invitation">
+      <div className="feedback-invitation__icon"><MessagesSquare /></div>
+      <p className="eyebrow">HELP US IMPROVE</p>
+      <h2>愿意和我们聊聊使用感受吗？</h2>
+      <p className="modal-lead">你的真实反馈会帮助我们把对话和场景练习做得更好。问卷大约需要 2 分钟。</p>
+      <div className="modal-actions">
+        <Button variant="secondary" onClick={onDismiss}>暂时不用</Button>
+        {feedbackUrl
+          ? <a className="button button--primary" href={feedbackUrl} target="_blank" rel="noreferrer" onClick={onAccept}><span>愿意，去填写</span><ArrowRight /></a>
+          : <Button disabled>问卷暂不可用</Button>}
+      </div>
+    </Modal>
+  );
+}
+
 export function App() {
   const initialRoute = useMemo(() => resolveRoute(window.location), []);
   const {
@@ -2727,6 +2749,7 @@ export function App() {
   const [helpRoute, setHelpRoute] = useState(initialRoute.helpRoute || null);
   const [aboutRoute, setAboutRoute] = useState(initialRoute.aboutRoute || null);
   const [paywall, setPaywall] = useState(null);
+  const [feedbackInvitationOpen, setFeedbackInvitationOpen] = useState(false);
   const preferenceWriteChainRef = useRef(Promise.resolve());
   const preferenceWriteVersionRef = useRef(0);
 
@@ -3125,6 +3148,26 @@ export function App() {
     }
     void synchronizeAchievements({ revealNotifications: true });
   };
+  const recordCompletedPractice = (practiceType, sessionId) => {
+    const userId = user?.id || profileOverview?.account?.userId;
+    if (!userId || !sessionId) return;
+    try {
+      if (recordFeedbackPractice(window.localStorage, { userId, practiceType, sessionId })) {
+        setFeedbackInvitationOpen(true);
+      }
+    } catch {
+      // Feedback invitations should never interrupt practice completion.
+    }
+  };
+  const completeScenePractice = (completed, evaluation = null, completedSessionId = null) => {
+    showResult(completed, evaluation, completedSessionId);
+    recordCompletedPractice("scene", completedSessionId || training?.sessionId);
+  };
+  const acceptFeedbackInvitation = () => {
+    const userId = user?.id || profileOverview?.account?.userId;
+    if (userId) markFeedbackStarted(window.localStorage, userId);
+    setFeedbackInvitationOpen(false);
+  };
   const setMainPage = (next) => navigate(hrefForPage(next), { page: next, authMode, training: null, result: null });
   const navigateIelts = (path) => navigate(path, { authMode });
   const navigateInterview = (path) => navigate(path, { authMode });
@@ -3160,8 +3203,8 @@ export function App() {
     );
   }
   let content;
-  if (training) content = <Training sceneId={training.sceneId} sessionId={training.sessionId} sceneTitle={sceneTitle} sceneContent={generatedScene} teacher={teacher} speed={conversationSpeed} initialStep={training.initialStep} initialStage={training.stage} standaloneSpeak={training.standaloneSpeak} result={result} onExit={() => setMainPage(training.returnPage || "scenes")} onComplete={showResult} onBack={() => setMainPage(training.returnPage || "scenes")} onAssets={openCompletedAssetDetail} onStageChange={navigateSceneStage} />;
-  else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={() => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); void synchronizeAchievements({ revealNotifications: true }); }} />;
+  if (training) content = <Training sceneId={training.sceneId} sessionId={training.sessionId} sceneTitle={sceneTitle} sceneContent={generatedScene} teacher={teacher} speed={conversationSpeed} initialStep={training.initialStep} initialStage={training.stage} standaloneSpeak={training.standaloneSpeak} result={result} onExit={() => setMainPage(training.returnPage || "scenes")} onComplete={completeScenePractice} onBack={() => setMainPage(training.returnPage || "scenes")} onAssets={openCompletedAssetDetail} onStageChange={navigateSceneStage} />;
+  else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={(sessionId) => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); recordCompletedPractice("free", sessionId); void synchronizeAchievements({ revealNotifications: true }); }} />;
   else if (page === "scenes") content = <Scenes onStartTraining={startTraining} onLocked={setPaywall} onIelts={() => setMainPage("ielts")} onInterview={() => setMainPage("interview")} />;
   else if (page === "assets") content = <Assets sceneId={assetSceneId} initialView={assetView} initialRecordTitle={sceneTitle} onOpenRecord={openCompletedAssetDetail} onCloseRecord={() => navigate(paths.assets.root, { assetView: "home", assetSceneId: null, authMode })} onIelts={() => setMainPage("ielts-assets")} onInterview={() => setMainPage("interview-assets")} onPractice={(scene) => startTraining(scene, "speak", { standaloneSpeak: true, returnPage: "assets" })} onRestart={(scene) => startTraining(scene, "learn", { returnPage: "assets" })} />;
   else if (page === "ielts") content = <IeltsTrainingCenter route={ieltsRoute} onNavigate={navigateIelts} onExit={() => setMainPage("scenes")} onAssets={() => navigateIelts(paths.ielts.assets.root)} />;
@@ -3169,5 +3212,5 @@ export function App() {
   else if (page === "interview") content = <InterviewModule route={interviewRoute} teacher={teacher} speed={conversationSpeed} onNavigate={navigateInterview} onBack={() => setMainPage("scenes")} />;
   else if (page === "interview-assets") content = <InterviewAssets route={interviewRoute} onNavigate={navigateInterview} onBack={() => setMainPage("scenes")} onBackToAssets={() => setMainPage("assets")} onBackToIelts={() => setMainPage("ielts-assets")} onTraining={() => navigateInterview(paths.interview.root)} onPractice={(sceneId) => navigateInterview(paths.interview.session(sceneId))} />;
   else content = <Profile section={page} setSection={setMainPage} helpRoute={helpRoute} aboutRoute={aboutRoute} onHelpNavigate={navigateHelp} onAboutNavigate={navigateAbout} user={user} profile={profileOverview} teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onMonthChange={loadProfileMonth} onNicknameChange={updateNickname} onAvatarChange={updateAvatar} onPasswordChange={updatePassword} onAssets={() => setMainPage("assets")} onLogout={logout} />;
-  return <AppShell page={page} setPage={setMainPage} teacher={teacher} avatarUrl={profileOverview?.account?.avatarUrl}>{content}{paywall && <Paywall title={paywall} onClose={() => setPaywall(null)} onMembership={() => { setPaywall(null); setMainPage("membership"); }} />}</AppShell>;
+  return <AppShell page={page} setPage={setMainPage} teacher={teacher} avatarUrl={profileOverview?.account?.avatarUrl}>{content}{paywall && <Paywall title={paywall} onClose={() => setPaywall(null)} onMembership={() => { setPaywall(null); setMainPage("membership"); }} />}{feedbackInvitationOpen && <FeedbackInvitation onDismiss={() => setFeedbackInvitationOpen(false)} onAccept={acceptFeedbackInvitation} />}</AppShell>;
 }


### PR DESCRIPTION
## 修改说明

为自由对话和普通场景练习增加基于真实使用次数的问卷反馈邀请：

- 用户累计完成 3 次自由对话，或累计完成 3 次场景练习后显示反馈弹窗
- 点击“暂时不用”或直接关闭后，自由对话与场景练习合并累计，再完成 10 次时重新询问
- 用户再次拒绝后，每累计 10 次继续询问
- 点击“愿意，去填写”后打开现有腾讯问卷，并永久停止后续邀请
- 按用户账号在浏览器本地隔离状态，通过 sessionId 去重，避免重复结束事件重复计数
- 本地存储不可用时不影响正常练习结束流程
- 补充桌面和移动端响应式弹窗样式

## 验证

- npm run check:feedback-invitation（47 条断言通过）
- npm run check:routes（69 条断言通过）
- npm run check:realtime-events
- npm run test:auth（15 条测试通过）
- npm run build