### PR TITLE
fix: require captcha verification before authentication

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/auth/EmailAuthService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/auth/EmailAuthService.java
@@ -104,6 +104,13 @@ public class EmailAuthService {
         return new LoginResult(token, new UserView(user.id(), user.email()));
     }
 
+    public LoginResult login(String rawEmail, String password, String humanVerificationToken) {
+        if (!humanVerificationGateway.verify(humanVerificationToken)) {
+            throw new AuthException("HUMAN_VERIFICATION_REQUIRED");
+        }
+        return login(rawEmail, password);
+    }
+
     @Transactional
     public void resetPassword(String rawEmail, String rawPassword, UUID challengeId, String code) {
         var email = normalizeEmail(rawEmail);

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/auth/UserAuthController.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/auth/UserAuthController.java
@@ -40,7 +40,10 @@ public final class UserAuthController {
             @NotBlank @Pattern(regexp = "[0-9]{6}") String code) {
     }
 
-    public record LoginRequest(@NotBlank @Email String email, @NotBlank String password) {
+    public record LoginRequest(
+            @NotBlank @Email String email,
+            @NotBlank String password,
+            @NotBlank String humanVerificationToken) {
     }
 
     public record ResetPasswordRequest(
@@ -101,7 +104,8 @@ public final class UserAuthController {
     public ResponseEntity<ApiResponse<EmailAuthService.UserView>> login(
             @Valid @RequestBody LoginRequest request,
             HttpServletResponse response) {
-        var login = authService.login(request.email(), request.password());
+        var login = authService.login(
+                request.email(), request.password(), request.humanVerificationToken());
         addSessionCookie(response, login.rawToken());
         return ResponseEntity.ok(ApiResponse.success(login.user()));
     }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/controller/AuthController.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.unispeaking.controller;
 
+import com.unispeaking.auth.EmailAuthService;
+import com.unispeaking.auth.UserAuthController;
 import com.unispeaking.domain.dto.auth.AuthResponse;
 import com.unispeaking.domain.dto.auth.ChangePasswordRequest;
 import com.unispeaking.domain.dto.auth.ChangePasswordResponse;
@@ -8,7 +10,9 @@ import com.unispeaking.domain.dto.auth.RegisterRequest;
 import com.unispeaking.domain.dto.auth.UserAccountResponse;
 import com.unispeaking.common.response.ApiResponse;
 import com.unispeaking.service.auth.AuthService;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -21,19 +25,46 @@ import org.springframework.web.bind.annotation.RestController;
 public class AuthController {
 
 	private final AuthService authService;
+	private final EmailAuthService emailAuthService;
 
-	public AuthController(AuthService authService) {
+	public AuthController(AuthService authService, EmailAuthService emailAuthService) {
 		this.authService = authService;
+		this.emailAuthService = emailAuthService;
 	}
 
 	@PostMapping("/register")
-	public ApiResponse<AuthResponse> register(@Valid @RequestBody RegisterRequest request) {
+	public ApiResponse<AuthResponse> register(
+			@Valid @RequestBody RegisterRequest request,
+			HttpServletRequest servletRequest) {
+		requireVerifiedEmail(request.username(), servletRequest);
 		return ApiResponse.success(authService.register(request));
 	}
 
 	@PostMapping("/login")
-	public ApiResponse<AuthResponse> login(@Valid @RequestBody LoginRequest request) {
+	public ApiResponse<AuthResponse> login(
+			@Valid @RequestBody LoginRequest request,
+			HttpServletRequest servletRequest) {
+		requireVerifiedEmail(request.username(), servletRequest);
 		return ApiResponse.success(authService.login(request));
+	}
+
+	private void requireVerifiedEmail(String username, HttpServletRequest request) {
+		var verifiedUser = emailAuthService.currentUser(readEmailSession(request));
+		if (!verifiedUser.email().equalsIgnoreCase(username.trim())) {
+			throw new EmailAuthService.AuthException("HUMAN_VERIFICATION_REQUIRED");
+		}
+	}
+
+	private static String readEmailSession(HttpServletRequest request) {
+		if (request.getCookies() != null) {
+			for (var cookie : request.getCookies()) {
+				if (UserAuthController.COOKIE_NAME.equals(cookie.getName())
+						&& StringUtils.hasText(cookie.getValue())) {
+					return cookie.getValue();
+				}
+			}
+		}
+		throw new EmailAuthService.AuthException("HUMAN_VERIFICATION_REQUIRED");
 	}
 
 	@GetMapping("/me")

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/auth/EmailAuthServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/auth/EmailAuthServiceTest.java
@@ -61,6 +61,16 @@ class EmailAuthServiceTest {
     }
 
     @Test
+    void humanVerificationIsRequiredBeforePasswordLoginCreatesSession() {
+        var challenge = service.issueChallenge("person@example.com", "verified-human");
+        service.register("person@example.com", "correct-password", challenge.challengeId(), emailSender.lastCode());
+
+        assertThatThrownBy(() -> service.login("person@example.com", "correct-password", "invalid"))
+                .isInstanceOf(EmailAuthService.AuthException.class)
+                .hasMessage("HUMAN_VERIFICATION_REQUIRED");
+    }
+
+    @Test
     void rejectsChallengeBeforeEmailDeliveryWhenHumanVerificationFails() {
         assertThatThrownBy(() -> service.issueChallenge("person@example.com", "invalid"))
                 .isInstanceOf(EmailAuthService.AuthException.class)

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/auth/UserAuthControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/auth/UserAuthControllerTest.java
@@ -94,11 +94,13 @@ class UserAuthControllerTest {
 
         mvc.perform(post("/api/auth/email/password/login")
                         .contentType("application/json")
-                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-old-password\"}"))
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-old-password\","
+                                + "\"humanVerificationToken\":\"local-human-verified\"}"))
                 .andExpect(status().isUnauthorized());
         mvc.perform(post("/api/auth/email/password/login")
                         .contentType("application/json")
-                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-new-password\"}"))
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-new-password\","
+                                + "\"humanVerificationToken\":\"local-human-verified\"}"))
                 .andExpect(status().isOk())
                 .andExpect(cookie().exists("us-user-session"));
     }
@@ -112,6 +114,35 @@ class UserAuthControllerTest {
                                 + "\"code\":\"123456\"}"))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", equalTo("VALIDATION_ERROR")));
+    }
+
+    @Test
+    void rejectsPasswordLoginWhenHumanVerificationFails() throws Exception {
+        var registrationChallenge = issueChallenge("/api/auth/email/challenges");
+        mvc.perform(post("/api/auth/email/register")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\","
+                                + "\"challengeId\":\"" + registrationChallenge + "\",\"code\":\""
+                                + emailSender.code + "\"}"))
+                .andExpect(status().isOk());
+
+        mvc.perform(post("/api/auth/email/password/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\","
+                                + "\"humanVerificationToken\":\"invalid\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", equalTo("HUMAN_VERIFICATION_REQUIRED")))
+                .andExpect(cookie().doesNotExist("us-user-session"));
+    }
+
+    @Test
+    void rejectsPasswordLoginWhenHumanVerificationTokenIsMissing() throws Exception {
+        mvc.perform(post("/api/auth/email/password/login")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", equalTo("VALIDATION_ERROR")))
+                .andExpect(cookie().doesNotExist("us-user-session"));
     }
 
     private UUID issueChallenge(String path) throws Exception {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/AuthControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/AuthControllerTest.java
@@ -1,0 +1,116 @@
+package com.unispeaking.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.unispeaking.auth.EmailAuthService;
+import com.unispeaking.common.exception.GlobalExceptionHandler;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.domain.dto.auth.LoginRequest;
+import com.unispeaking.domain.dto.auth.RegisterRequest;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class AuthControllerTest {
+
+    @Test
+    void rejectsBusinessJwtLoginWithoutVerifiedEmailSession() throws Exception {
+        var authService = mock(AuthService.class);
+        var emailAuthService = mock(EmailAuthService.class);
+        var mvc = MockMvcBuilders.standaloneSetup(new AuthController(authService, emailAuthService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        mvc.perform(post("/api/auth/login")
+                        .contentType("application/json")
+                        .content("{\"username\":\"person@example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", equalTo("HUMAN_VERIFICATION_REQUIRED")));
+
+        verifyNoInteractions(authService, emailAuthService);
+    }
+
+    @Test
+    void rejectsBusinessJwtLoginWhenVerifiedEmailDoesNotMatch() throws Exception {
+        var authService = mock(AuthService.class);
+        var emailAuthService = mock(EmailAuthService.class);
+        when(emailAuthService.currentUser("verified-session"))
+                .thenReturn(new EmailAuthService.UserView(
+                        java.util.UUID.randomUUID(), "other@example.com"));
+        var mvc = MockMvcBuilders.standaloneSetup(new AuthController(authService, emailAuthService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        mvc.perform(post("/api/auth/login")
+                        .cookie(new jakarta.servlet.http.Cookie("us-user-session", "verified-session"))
+                        .contentType("application/json")
+                        .content("{\"username\":\"person@example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", equalTo("HUMAN_VERIFICATION_REQUIRED")));
+
+        verifyNoInteractions(authService);
+    }
+
+    @Test
+    void allowsBusinessJwtLoginForTheVerifiedEmailSession() throws Exception {
+        var authService = mock(AuthService.class);
+        var emailAuthService = mock(EmailAuthService.class);
+        when(emailAuthService.currentUser("verified-session"))
+                .thenReturn(new EmailAuthService.UserView(
+                        java.util.UUID.randomUUID(), "person@example.com"));
+        var mvc = MockMvcBuilders.standaloneSetup(new AuthController(authService, emailAuthService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        mvc.perform(post("/api/auth/login")
+                        .cookie(new jakarta.servlet.http.Cookie("us-user-session", "verified-session"))
+                        .contentType("application/json")
+                        .content("{\"username\":\"Person@Example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isOk());
+
+        verify(authService).login(new LoginRequest("Person@Example.com", "correct-password"));
+    }
+
+    @Test
+    void rejectsBusinessRegistrationWithoutVerifiedEmailSession() throws Exception {
+        var authService = mock(AuthService.class);
+        var emailAuthService = mock(EmailAuthService.class);
+        var mvc = MockMvcBuilders.standaloneSetup(new AuthController(authService, emailAuthService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        mvc.perform(post("/api/auth/register")
+                        .contentType("application/json")
+                        .content("{\"username\":\"person@example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code", equalTo("HUMAN_VERIFICATION_REQUIRED")));
+
+        verifyNoInteractions(authService, emailAuthService);
+    }
+
+    @Test
+    void allowsBusinessRegistrationForTheVerifiedEmailSession() throws Exception {
+        var authService = mock(AuthService.class);
+        var emailAuthService = mock(EmailAuthService.class);
+        when(emailAuthService.currentUser("verified-session"))
+                .thenReturn(new EmailAuthService.UserView(
+                        java.util.UUID.randomUUID(), "person@example.com"));
+        var mvc = MockMvcBuilders.standaloneSetup(new AuthController(authService, emailAuthService))
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+
+        mvc.perform(post("/api/auth/register")
+                        .cookie(new jakarta.servlet.http.Cookie("us-user-session", "verified-session"))
+                        .contentType("application/json")
+                        .content("{\"username\":\"person@example.com\",\"password\":\"correct-password\"}"))
+                .andExpect(status().isOk());
+
+        verify(authService).register(new RegisterRequest("person@example.com", "correct-password", null));
+    }
+}

--- a/frontend/web/scripts/check-auth-contract.mjs
+++ b/frontend/web/scripts/check-auth-contract.mjs
@@ -5,6 +5,7 @@ import {
   buildAuthApiUrl,
   issueEmailChallenge,
   issuePasswordResetChallenge,
+  loginWithPassword,
   registerWithEmail,
   resetPasswordWithEmail,
   validateRegistrationCredentials,
@@ -33,50 +34,26 @@ test("turns backend password validation into a user-facing message", async () =>
   }
 });
 
-test("recovers a completed registration when the one-time challenge is submitted again", async () => {
+test("does not turn an invalid registration challenge into a password login", async () => {
   const previousFetch = globalThis.fetch;
-  const previousWindow = globalThis.window;
-  const storage = new Map();
-  globalThis.window = {
-    localStorage: {
-      setItem: (key, value) => storage.set(key, value),
-      removeItem: (key) => storage.delete(key),
-      getItem: (key) => storage.get(key) || null,
-    },
-  };
+  const requests = [];
   globalThis.fetch = async (path) => {
-    if (path === "/api/auth/email/register") {
-      return new Response(JSON.stringify({ success: false, code: "CHALLENGE_INVALID", message: "CHALLENGE_INVALID" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    if (path === "/api/auth/email/password/login") {
-      return new Response(JSON.stringify({ success: true, data: { email: "person@example.com" } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    if (path === "/api/auth/login") {
-      return new Response(JSON.stringify({ success: true, data: { accessToken: "legacy-token", user: { email: "person@example.com" } } }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" },
-      });
-    }
-    throw new Error(`unexpected request ${path}`);
+    requests.push(path);
+    return new Response(JSON.stringify({ success: false, code: "CHALLENGE_INVALID", message: "CHALLENGE_INVALID" }), {
+      status: 400,
+      headers: { "Content-Type": "application/json" },
+    });
   };
   try {
-    const result = await registerWithEmail({
+    await assert.rejects(() => registerWithEmail({
       email: "person@example.com",
       password: "correct-password",
       challengeId: "00000000-0000-0000-0000-000000000001",
       code: "123456",
-    });
-    assert.equal(result.user.email, "person@example.com");
-    assert.equal(storage.get("unispeaking.accessToken"), "legacy-token");
+    }));
+    assert.deepEqual(requests, ["/api/auth/email/register"]);
   } finally {
     globalThis.fetch = previousFetch;
-    globalThis.window = previousWindow;
   }
 });
 
@@ -96,6 +73,35 @@ test("email challenge uses the real auth endpoint and same-origin credentials", 
     assert.equal(request.options.credentials, "include");
     assert.match(request.options.body, /humanVerificationToken/);
     assert.equal(result.challengeId, "00000000-0000-0000-0000-000000000001");
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("password login sends the human verification token", async () => {
+  const previousFetch = globalThis.fetch;
+  let loginRequest;
+  globalThis.fetch = async (path, options) => {
+    if (path === "/api/auth/email/password/login") {
+      loginRequest = { path, options };
+      return new Response(JSON.stringify({ success: false, code: "INVALID_CREDENTIALS" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+    throw new Error(`unexpected request ${path}`);
+  };
+  try {
+    await assert.rejects(() => loginWithPassword(
+      "person@example.com",
+      "correct-password",
+      "aliyun-login-token",
+    ));
+    assert.deepEqual(JSON.parse(loginRequest.options.body), {
+      email: "person@example.com",
+      password: "correct-password",
+      humanVerificationToken: "aliyun-login-token",
+    });
   } finally {
     globalThis.fetch = previousFetch;
   }
@@ -190,4 +196,10 @@ test("login UI exposes the verified email password reset flow", async () => {
   ]) {
     assert.match(source, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   }
+});
+
+test("login UI routes password login through human verification", async () => {
+  const source = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
+  assert.match(source, /<HumanVerification buttonId=\{captchaButtonId\} onVerify=\{verifyAndIssueChallenge\} \/>/);
+  assert.match(source, /loginWithPassword\(normalizedEmail, password, captchaVerifyParam\)/);
 });

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -587,7 +587,11 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
   const registrationDraftRef = useRef({ email: "", password: "" });
-  const captchaButtonId = mode === "reset" ? "reset-email-challenge" : "signup-email-challenge";
+  const captchaButtonId = mode === "login"
+    ? "login-email-auth"
+    : mode === "reset"
+      ? "reset-email-challenge"
+      : "signup-email-challenge";
 
   const clearChallenge = () => {
     setStep("credentials");
@@ -622,18 +626,6 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
 
   const submitCredentials = async (event) => {
     event.preventDefault();
-    if (mode !== "login") return;
-    setSubmitting(true);
-    setError("");
-    setNotice("");
-    try {
-      const auth = await loginWithPassword(email.trim(), password);
-      await onSuccess(auth, "login");
-    } catch (requestError) {
-      setError(requestError instanceof Error ? requestError.message : "认证请求失败");
-    } finally {
-      setSubmitting(false);
-    }
   };
 
   const verifyAndIssueChallenge = async (captchaVerifyParam) => {
@@ -644,6 +636,22 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
     if (!emailIsValid) {
       setError("请输入有效邮箱地址。");
       return { captchaResult: true, bizResult: false };
+    }
+    if (mode === "login") {
+      setSubmitting(true);
+      try {
+        const auth = await loginWithPassword(normalizedEmail, password, captchaVerifyParam);
+        await onSuccess(auth, "login");
+        return { captchaResult: true, bizResult: true };
+      } catch (requestError) {
+        setError(requestError instanceof Error ? requestError.message : "认证请求失败");
+        return {
+          captchaResult: requestError?.code !== "HUMAN_VERIFICATION_REQUIRED",
+          bizResult: false,
+        };
+      } finally {
+        setSubmitting(false);
+      }
     }
     const validationCode = mode === "signup"
       ? validateRegistrationCredentials(normalizedEmail, password)
@@ -767,11 +775,11 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
         <form onSubmit={submitCredentials}>
           <label>邮箱<input type="email" value={email} onChange={(event) => { const nextEmail = event.target.value; setEmail(nextEmail); registrationDraftRef.current.email = nextEmail.trim(); }} placeholder="name@example.com" autoComplete="email" maxLength="254" required disabled={submitting} /></label>
           {mode !== "reset" && <label>密码<span className="password-field"><input type={showPassword ? "text" : "password"} value={password} onChange={(event) => { const nextPassword = event.target.value; setPassword(nextPassword); registrationDraftRef.current.password = nextPassword; }} placeholder="至少 12 位字符" autoComplete={mode === "signup" ? "new-password" : "current-password"} minLength="12" maxLength="200" required disabled={submitting} /><button type="button" aria-label={showPassword ? "隐藏密码" : "显示密码"} onClick={() => setShowPassword(!showPassword)}>{showPassword ? <EyeSlash /> : <Eye />}</button></span></label>}
-          {mode !== "login" && <HumanVerification buttonId={captchaButtonId} onVerify={verifyAndIssueChallenge} />}
+          <HumanVerification buttonId={captchaButtonId} onVerify={verifyAndIssueChallenge} />
           {mode === "login" && <button type="button" className="forgot-link" onClick={beginPasswordReset}>忘记密码？</button>}
           {notice && <p className="auth-notice" role="status">{notice}</p>}
           {error && <p className="auth-error" role="alert">{error}</p>}
-          <Button id={mode !== "login" ? captchaButtonId : undefined} className="auth-submit" type="submit" disabled={submitting}>{submitting ? "正在处理…" : mode === "login" ? "登录" : "发送邮箱验证码"}</Button>
+          <Button id={captchaButtonId} className="auth-submit" type="submit" disabled={submitting}>{submitting ? "正在处理…" : mode === "login" ? "登录" : "发送邮箱验证码"}</Button>
         </form>
         {mode === "reset"
           ? <p className="auth-switch">想起密码了？<button onClick={returnToLogin}>返回登录</button></p>

--- a/frontend/web/src/userAuthApi.js
+++ b/frontend/web/src/userAuthApi.js
@@ -98,30 +98,17 @@ async function syncBusinessIdentity(email, password) {
 }
 
 export async function registerWithEmail({ email, password, challengeId, code }) {
-  try {
-    await request("/api/auth/email/register", {
-      method: "POST",
-      body: JSON.stringify({ email, password, challengeId, code }),
-    });
-  } catch (registrationError) {
-    // A one-time challenge can be submitted twice when the first request
-    // already created the account but the browser stayed on a stale tab.
-    // Recover only when the same credentials can perform a real password login;
-    // a wrong code or password still returns the original challenge error.
-    if (registrationError?.code !== "CHALLENGE_INVALID") throw registrationError;
-    try {
-      return await loginWithPassword(email, password);
-    } catch {
-      throw registrationError;
-    }
-  }
+  await request("/api/auth/email/register", {
+    method: "POST",
+    body: JSON.stringify({ email, password, challengeId, code }),
+  });
   return syncBusinessIdentity(email, password);
 }
 
-export async function loginWithPassword(email, password) {
+export async function loginWithPassword(email, password, humanVerificationToken) {
   await request("/api/auth/email/password/login", {
     method: "POST",
-    body: JSON.stringify({ email, password }),
+    body: JSON.stringify({ email, password, humanVerificationToken }),
   });
   return syncBusinessIdentity(email, password);
 }


### PR DESCRIPTION
## 变更说明

- 登录按钮先触发阿里云 CAPTCHA，验证成功后才发送密码登录请求
- 服务端强制复验 CAPTCHA，失败不签发会话 Cookie
- 业务登录/注册签发 JWT 前要求有效且邮箱一致的 `us-user-session`
- 移除无效注册挑战直接同步业务 JWT 的旁路
- 补充完整回归测试

## 根因

登录页和邮箱密码端点未强制 CAPTCHA，公开的业务登录/注册端点还能直接签发 Web App 使用的 JWT，导致验证码可被绕过。

## 验证

- 前端认证测试 17/17
- 前端生产构建通过
- 路由检查 66 项通过
- Realtime 检查通过
- 后端安全测试 15/15
- 后端完整测试 25/25，0 failures，0 errors
- Playwright 验收确认点击登录只弹出阿里云验证码
- 最终代码审查无 Critical/Important
