### PR TITLE
fix(web): 避免场景结束语重复播放

### DIFF
--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   buildResponseCreateEvent,
+  buildScenarioResponseRequest,
   buildRealtimeSessionConfig,
   buildRealtimeStartPayload,
   createTurnAudioCaptureController,
@@ -81,6 +82,27 @@ assert.deepEqual(
       instructions: "Ask exactly: Where do you live?",
       modalities: ["text", "audio"],
     },
+  },
+);
+
+assert.deepEqual(
+  buildScenarioResponseRequest({
+    completed: false,
+    controlInstruction: "Ask for the payment method.",
+  }),
+  {
+    closing: false,
+    instructions: "Ask for the payment method.",
+  },
+);
+assert.deepEqual(
+  buildScenarioResponseRequest({
+    completed: true,
+    controlInstruction: "Give one concise closing response.",
+  }),
+  {
+    closing: true,
+    instructions: "Give one concise closing response.",
   },
 );
 

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -103,6 +103,14 @@ export function buildResponseCreateEvent({ id, instructions = "" } = {}) {
   };
 }
 
+export function buildScenarioResponseRequest(state) {
+  if (!state) return { closing: false, instructions: "" };
+  return {
+    closing: Boolean(state.completed),
+    instructions: String(state.controlInstruction || "").trim(),
+  };
+}
+
 export function normalizeBaseUrl(baseUrl) {
   if (!baseUrl) return "";
   const value = String(baseUrl).trim().replace(/\/$/, "");
@@ -850,14 +858,13 @@ export function createRealtimeClient({
       };
       sendSessionUpdate();
     }
-    if (!state.completed) return;
-    scenarioCompletionPending = true;
-    inputReady = false;
-    setTrackEnabled();
-    turnAudioCapture?.stop();
-    if (!responsePending) {
-      requestTurnResponse({ closing: true });
+    if (state.completed) {
+      scenarioCompletionPending = true;
+      inputReady = false;
+      setTrackEnabled();
+      turnAudioCapture?.stop();
     }
+    requestTurnResponse(buildScenarioResponseRequest(state));
   }
 
   async function postStart({ offerSdp, voice }) {
@@ -1008,9 +1015,6 @@ export function createRealtimeClient({
         transcript,
         event.item_id || event.item?.id || event.event_id,
       );
-      if (customSceneId) {
-        requestTurnResponse();
-      }
       const ieltsTurnNo = ieltsSceneId
         ? timedOutTurn?.turnNo || learnerTurnNo + 1
         : null;
@@ -1144,6 +1148,7 @@ export function createRealtimeClient({
             turnNo,
             message: error instanceof Error ? error.message : "场景状态推进失败",
           });
+          requestTurnResponse();
         } finally {
           pendingOperations.delete(stateOperation);
         }


### PR DESCRIPTION
## 变更
- 等待场景状态推进完成后再请求下一轮响应，避免结束语被重复触发
- 增加实时事件构造与场景结束状态回归检查

## 验证
- `npm run check:realtime-events`