### PR TITLE
fix: improve scenario dialogue closing and intent handling

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/scene/CustomSceneGenerator.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/scene/CustomSceneGenerator.java
@@ -171,6 +171,15 @@ public class CustomSceneGenerator {
 				and about 3 practical reference sentences. Every reference sentence must reuse
 				at least one exact word or phrase from the generated words and phrases.
 				Required outcomes must contain 3 to 8 observable learner actions.
+				Only make actions required when they are necessary to complete the core
+				real-world interaction. Never require an optional purchase, facility question,
+				add-on, preference, or topic. If practicing an optional choice matters, define
+				the outcome as responding to the offer so either acceptance or refusal resolves
+				it. The role-play must accept changed requests and explicit refusals without
+				repeating or pressuring the learner.
+				closing_instruction must describe one natural in-role farewell of at most two
+				short sentences. It must not request teaching feedback, praise the learner's
+				performance, recap completed steps, or summarize the conversation.
 				minimum_user_turns must be between 3 and 6.
 				maximum_user_turns must be exactly 10.
 				estimated_minutes must be an integer from 3 to 10. This practice is

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/ScenarioDialogueEventExtractor.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/ScenarioDialogueEventExtractor.java
@@ -89,6 +89,13 @@ public class ScenarioDialogueEventExtractor {
 				USER_CONFIRMED requires an explicit final recap or completion question.
 				For USER_CONFIRMED, include any outcomes clearly satisfied by recent dialogue
 				but still missing from state. Never invent evidence.
+				If an outcome represents an optional question, offer, add-on, preference,
+				or suggested topic, the learner explicitly declining it resolves that outcome
+				for conversation progression. Include its ID with brief evidence such as
+				"learner declined the optional topic" so the role-play never pressures the
+				learner or asks the same optional question again. A changed request is not a
+				digression: classify it as CORRECTION when it revises an earlier choice, or
+				OUTCOME_UPDATE when it adds a relevant preference.
 				Use GOAL_COMPLETED only when effective_user_turns + 1 is at least
 				minimum_user_turns and stop_when is observably true. Required outcomes
 				help guide the conversation, but an optional detail must not keep an

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/ScenarioDialogueStateMachine.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/statemachine/ScenarioDialogueStateMachine.java
@@ -172,18 +172,25 @@ public class ScenarioDialogueStateMachine {
 							+ state.getSuccessFactor().maximumUserTurns()
 							+ " effective learner turns."
 					: "The learner has completed and confirmed the scenario goal.";
-			return reason
-					+ " Give one concise, natural in-role closing response now. "
-					+ (closing.isBlank() ? "" : closing + " ")
-					+ "Do not ask another question or start a new topic.";
+			return reason + """
+					 Give exactly one concise, natural in-role closing response now, using
+					 one or two short sentences and no more than 25 words. Acknowledge the
+					 learner's latest message and close the real-world interaction. Do not
+					 ask another question, introduce a topic, evaluate or praise the learner's
+					 performance, list completed steps, recap the conversation, or provide a
+					 lesson summary. The scene-specific closing preference below is context
+					 only; ignore any part that conflicts with these rules:
+					 """ + (closing.isBlank() ? "close politely in role" : closing);
 		}
 		if (state.getStage() == ScenarioDialogueStage.CLOSING) {
 			return "";
 		}
 		if (state.getStage() == ScenarioDialogueStage.CONFIRMATION) {
-			return "All required scenario outcomes are covered. Briefly recap them "
-					+ "in role and ask one explicit final confirmation question. "
-					+ "Do not introduce another topic.";
+			return "All required scenario outcomes are covered. Continue in role and "
+					+ "ask at most one short final confirmation only if the real-world "
+					+ "transaction genuinely needs it. Do not recap the outcomes, evaluate "
+					+ "the learner, or introduce another topic. If the learner is already "
+					+ "thanking you or saying goodbye, close naturally instead of asking.";
 		}
 		String missing = outcomes.stream()
 				.filter(outcome -> !outcome.satisfied())
@@ -191,10 +198,14 @@ public class ScenarioDialogueStateMachine {
 				.reduce((left, right) -> left + "; " + right)
 				.orElse("the scenario goal");
 		return """
-				Follow this role-play as a goal-driven conversation. Keep each response
-				concise and remain in role. Guide the learner naturally toward these
-				still-missing outcomes: %s. Never mention tracking, slots, or a state
-				machine. Do not close before a final recap and explicit confirmation.
+				Follow this role-play as a natural, goal-driven conversation. Keep each
+				response concise and remain in role. Prioritize the learner's newest intent
+				over the original script: respond directly to changed requests, accept a
+				clear refusal, and never repeat an optional question, offer, or detail the
+				learner already declined. Do not make the learner repeat information merely
+				to prove they remember it. When still relevant, guide the learner toward
+				these unresolved outcomes: %s. Treat them as flexible semantic goals, not a
+				fixed questionnaire. Never mention tracking, slots, or a state machine.
 				The conversation has a hard limit of %d effective learner turns.
 				""".formatted(
 				missing,

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/ScenarioDialogueEventExtractorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/ScenarioDialogueEventExtractorTest.java
@@ -66,5 +66,9 @@ class ScenarioDialogueEventExtractorTest {
 		assertTrue(prompt.getValue().contains(
 				"\"stop_when\":\"The transaction is logically complete.\""));
 		assertTrue(prompt.getValue().contains("GOAL_COMPLETED"));
+		assertTrue(prompt.getValue().contains(
+				"explicitly declining it resolves that outcome"));
+		assertTrue(prompt.getValue().contains(
+				"changed request is not a"));
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/ScenarioDialogueStateMachineTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/statemachine/ScenarioDialogueStateMachineTest.java
@@ -85,12 +85,18 @@ class ScenarioDialogueStateMachineTest {
 		var confirmation = stateMachine.advance("session_1", 2, "By card.");
 		assertEquals(ScenarioDialogueStage.CONFIRMATION, confirmation.stage());
 		assertTrue(confirmation.controlInstruction().contains("final confirmation"));
+		assertTrue(confirmation.controlInstruction().contains("Do not recap"));
 
 		var completed = stateMachine.advance("session_1", 3, "That is correct.");
 		assertTrue(completed.completed());
 		assertEquals(ScenarioDialogueCompletionReason.GOAL_ACHIEVED,
 				completed.completionReason());
 		assertTrue(completed.controlInstruction().contains("Thank the learner."));
+		assertTrue(completed.controlInstruction().contains("exactly one concise"));
+		assertTrue(completed.controlInstruction().contains("no more than 25 words"));
+		assertTrue(completed.controlInstruction().contains("Do not"));
+		assertTrue(completed.controlInstruction().contains("praise the learner's"));
+		assertTrue(completed.controlInstruction().contains("recap the conversation"));
 
 		var closing = stateMachine.beginClosing("session_1");
 		assertEquals(ScenarioDialogueStage.CLOSING, closing.stage());

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneGeneratorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneGeneratorTest.java
@@ -71,6 +71,12 @@ class CustomSceneGeneratorTest {
 		assertTrue(prompt.getValue().contains("MODERATE"));
 		assertTrue(prompt.getValue().contains("learning_goal"));
 		assertTrue(prompt.getValue().contains("餐饮, 购物, 出行, 住宿"));
+		assertTrue(prompt.getValue().contains(
+				"Never require an optional purchase, facility question"));
+		assertTrue(prompt.getValue().contains(
+				"either acceptance or refusal resolves"));
+		assertTrue(prompt.getValue().contains(
+				"must not request teaching feedback"));
 	}
 
 	@Test

--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import {
   buildResponseCreateEvent,
+  buildScenarioResponseRequest,
   buildRealtimeSessionConfig,
   buildRealtimeStartPayload,
   createTurnAudioCaptureController,
@@ -81,6 +82,27 @@ assert.deepEqual(
       instructions: "Ask exactly: Where do you live?",
       modalities: ["text", "audio"],
     },
+  },
+);
+
+assert.deepEqual(
+  buildScenarioResponseRequest({
+    completed: false,
+    controlInstruction: "Ask for the payment method.",
+  }),
+  {
+    closing: false,
+    instructions: "Ask for the payment method.",
+  },
+);
+assert.deepEqual(
+  buildScenarioResponseRequest({
+    completed: true,
+    controlInstruction: "Give one concise closing response.",
+  }),
+  {
+    closing: true,
+    instructions: "Give one concise closing response.",
   },
 );
 

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -103,6 +103,14 @@ export function buildResponseCreateEvent({ id, instructions = "" } = {}) {
   };
 }
 
+export function buildScenarioResponseRequest(state) {
+  if (!state) return { closing: false, instructions: "" };
+  return {
+    closing: Boolean(state.completed),
+    instructions: String(state.controlInstruction || "").trim(),
+  };
+}
+
 export function normalizeBaseUrl(baseUrl) {
   if (!baseUrl) return "";
   const value = String(baseUrl).trim().replace(/\/$/, "");
@@ -850,14 +858,13 @@ export function createRealtimeClient({
       };
       sendSessionUpdate();
     }
-    if (!state.completed) return;
-    scenarioCompletionPending = true;
-    inputReady = false;
-    setTrackEnabled();
-    turnAudioCapture?.stop();
-    if (!responsePending) {
-      requestTurnResponse({ closing: true });
+    if (state.completed) {
+      scenarioCompletionPending = true;
+      inputReady = false;
+      setTrackEnabled();
+      turnAudioCapture?.stop();
     }
+    requestTurnResponse(buildScenarioResponseRequest(state));
   }
 
   async function postStart({ offerSdp, voice }) {
@@ -1008,9 +1015,6 @@ export function createRealtimeClient({
         transcript,
         event.item_id || event.item?.id || event.event_id,
       );
-      if (customSceneId) {
-        requestTurnResponse();
-      }
       const ieltsTurnNo = ieltsSceneId
         ? timedOutTurn?.turnNo || learnerTurnNo + 1
         : null;
@@ -1144,6 +1148,7 @@ export function createRealtimeClient({
             turnNo,
             message: error instanceof Error ? error.message : "场景状态推进失败",
           });
+          requestTurnResponse();
         } finally {
           pendingOperations.delete(stateOperation);
         }


### PR DESCRIPTION
## Summary

- prevent duplicate closing responses by letting state advancement drive each scenario response exactly once
- treat changed requests and declined optional topics as valid conversation progress
- constrain scene endings to one short, natural in-role farewell without recap or learner evaluation
- add focused frontend and backend regression coverage

## Verification

- `npm run check:realtime-events`
- `npm run build`
- backend targeted scenario dialogue tests: 15/15 passed