### PR TITLE
feat(auth): improve web and mobile signup flow

### DIFF
--- a/frontend/mobile/src/model/AppModel.tsx
+++ b/frontend/mobile/src/model/AppModel.tsx
@@ -105,7 +105,7 @@ export function AppModelProvider({
     () => injectedAuthController ?? createDefaultAuthController(),
   );
   const [authState, setAuthState] = useState<AuthSessionState>(() => authController.getSnapshot());
-  const [nickname, setNickname] = useState('Yufan');
+  const [nickname, setNickname] = useState('');
   const [speed, setSpeed] = useState('自然');
   const [level, setLevel] = useState('starter');
   const [teacher, setTeacher] = useState(teachers[0]);

--- a/frontend/mobile/src/model/__tests__/AppModel.test.tsx
+++ b/frontend/mobile/src/model/__tests__/AppModel.test.tsx
@@ -120,7 +120,28 @@ function ProfileSettingsProbe() {
   );
 }
 
+function NicknameProbe() {
+  const model = useAppModel();
+  return <Text testID="nickname">{model.nickname}</Text>;
+}
+
 describe('AppModelProvider authentication binding', () => {
+  it('starts without a default nickname for an anonymous session', async () => {
+    const controller = createController({
+      status: 'anonymous',
+      user: null,
+      preference: null,
+      error: null,
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <NicknameProbe />
+      </AppModelProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByTestId('nickname').props.children).toBe(''));
+  });
+
   it('hydrates the finalized UI choices from the authenticated backend preference', async () => {
     const controller = createController(authenticatedState);
     const screen = await render(

--- a/frontend/mobile/src/screens/AuthScreens.tsx
+++ b/frontend/mobile/src/screens/AuthScreens.tsx
@@ -1,5 +1,6 @@
 import { ArrowRightIcon } from 'phosphor-react-native/src/icons/ArrowRight';
 import { ArrowLeftIcon } from 'phosphor-react-native/src/icons/ArrowLeft';
+import MaterialIcons from '@expo/vector-icons/MaterialIcons';
 import { type ReactNode, useEffect, useState } from 'react';
 import {
   AccessibilityInfo,
@@ -190,6 +191,9 @@ export function AuthFormScreen({
   const [draftNickname, setDraftNickname] = useState(nickname);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordVisible, setPasswordVisible] = useState(false);
+  const [confirmPasswordVisible, setConfirmPasswordVisible] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [step, setStep] = useState<'credentials' | 'verification'>('credentials');
   const [challengeId, setChallengeId] = useState('');
@@ -200,7 +204,8 @@ export function AuthFormScreen({
   const emailValid = /^\S+@\S+\.\S+$/.test(email.trim());
   const passwordValid = mode === 'signup' ? password.length >= 12 : password.length >= 6;
   const nicknameValid = mode === 'login' || draftNickname.trim().length >= 2;
-  const valid = emailValid && passwordValid && nicknameValid;
+  const confirmPasswordValid = mode === 'login' || confirmPassword === password;
+  const valid = emailValid && passwordValid && nicknameValid && confirmPasswordValid;
 
   useEffect(() => {
     if (resendSeconds <= 0) return;
@@ -354,21 +359,68 @@ export function AuthFormScreen({
             <Text style={styles.fieldLabel}>密码</Text>
             {mode === 'login' ? <Text style={styles.forgotText}>忘记密码？</Text> : null}
           </View>
-          <TextInput
-            value={password}
-            onChangeText={setPassword}
-            placeholder={mode === 'signup' ? '至少 12 位字符' : '请输入密码'}
-            placeholderTextColor={colors.subtle}
-            secureTextEntry
-            autoCapitalize="none"
-            autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
-            style={[styles.input, submitted && !passwordValid && styles.inputError]}
-            onSubmitEditing={() => void submit()}
-          />
+          <View style={styles.passwordField}>
+            <TextInput
+              value={password}
+              onChangeText={setPassword}
+              placeholder={mode === 'signup' ? '至少 12 位字符' : '请输入密码'}
+              placeholderTextColor={colors.subtle}
+              secureTextEntry={!passwordVisible}
+              autoCapitalize="none"
+              autoComplete={mode === 'login' ? 'current-password' : 'new-password'}
+              style={[styles.input, mode === 'signup' && styles.passwordInput, submitted && !passwordValid && styles.inputError]}
+              onSubmitEditing={() => void submit()}
+            />
+            {mode === 'signup' ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={passwordVisible ? '隐藏密码' : '显示密码'}
+                onPress={() => setPasswordVisible((visible) => !visible)}
+                style={styles.passwordVisibilityButton}
+              >
+                <MaterialIcons
+                  name={passwordVisible ? 'visibility-off' : 'visibility'}
+                  size={20}
+                  color={colors.muted}
+                />
+              </Pressable>
+            ) : null}
+          </View>
           {submitted && !passwordValid ? (
             <Text style={styles.errorText}>{mode === 'signup' ? '密码至少需要 12 位字符' : '请输入正确的密码'}</Text>
           ) : null}
         </View>
+
+        {mode === 'signup' ? (
+          <View style={styles.formGroup}>
+            <Text style={styles.fieldLabel}>确认密码</Text>
+            <View style={styles.passwordField}>
+              <TextInput
+                value={confirmPassword}
+                onChangeText={setConfirmPassword}
+                placeholder="再次输入密码"
+                placeholderTextColor={colors.subtle}
+                secureTextEntry={!confirmPasswordVisible}
+                autoCapitalize="none"
+                autoComplete="new-password"
+                style={[styles.input, styles.passwordInput, submitted && !confirmPasswordValid && styles.inputError]}
+              />
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={confirmPasswordVisible ? '隐藏确认密码' : '显示确认密码'}
+                onPress={() => setConfirmPasswordVisible((visible) => !visible)}
+                style={styles.passwordVisibilityButton}
+              >
+                <MaterialIcons
+                  name={confirmPasswordVisible ? 'visibility-off' : 'visibility'}
+                  size={20}
+                  color={colors.muted}
+                />
+              </Pressable>
+            </View>
+            {submitted && !confirmPasswordValid ? <Text style={styles.errorText}>两次输入的密码不一致</Text> : null}
+          </View>
+        ) : null}
       </View>
 
       {localError || authError ? <Text accessibilityRole="alert" style={styles.errorText}>{localError ?? authError}</Text> : null}
@@ -495,6 +547,17 @@ const styles = StyleSheet.create({
     borderColor: colors.line,
     borderRadius: 12,
     backgroundColor: colors.white,
+  },
+  passwordField: { position: 'relative' },
+  passwordInput: { paddingRight: 50 },
+  passwordVisibilityButton: {
+    position: 'absolute',
+    right: 10,
+    bottom: 7,
+    width: 40,
+    height: 40,
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   inputError: { borderColor: colors.red },
   codeInput: { textAlign: 'center', fontSize: 24, fontVariant: ['tabular-nums'], letterSpacing: 8 },

--- a/frontend/mobile/src/screens/__tests__/AuthScreens.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AuthScreens.test.tsx
@@ -87,6 +87,7 @@ describe('AuthFormScreen backend binding', () => {
     await fireEvent.changeText(screen.getByPlaceholderText('怎么称呼你'), 'Sunny');
     await fireEvent.changeText(screen.getByPlaceholderText('name@example.com'), 'learner@example.com');
     await fireEvent.changeText(screen.getByPlaceholderText('至少 12 位字符'), 'password123456');
+    await fireEvent.changeText(screen.getByPlaceholderText('再次输入密码'), 'password123456');
     await fireEvent.press(screen.getByRole('button', { name: '发送邮箱验证码' }));
 
     await waitFor(() => expect(screen.getByText('查看你的邮箱')).toBeTruthy());
@@ -103,6 +104,49 @@ describe('AuthFormScreen backend binding', () => {
       challengeId: 'challenge-1',
       code: '123456',
     }));
+  });
+
+  it('does not send an email code when the passwords do not match', async () => {
+    const controller = createController({
+      status: 'anonymous', user: null, preference: null, error: null,
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <AuthFormScreen mode="signup" onBack={jest.fn()} onSwitch={jest.fn()} />
+      </AppModelProvider>,
+    );
+
+    await fireEvent.changeText(screen.getByPlaceholderText('怎么称呼你'), 'Sunny');
+    await fireEvent.changeText(screen.getByPlaceholderText('name@example.com'), 'learner@example.com');
+    await fireEvent.changeText(screen.getByPlaceholderText('至少 12 位字符'), 'password123456');
+    await fireEvent.changeText(screen.getByPlaceholderText('再次输入密码'), 'different123456');
+    await fireEvent.press(screen.getByRole('button', { name: '发送邮箱验证码' }));
+
+    expect(screen.getByText('两次输入的密码不一致')).toBeTruthy();
+    expect(controller.issueEmailChallenge).not.toHaveBeenCalled();
+  });
+
+  it('toggles visibility independently for both signup password fields', async () => {
+    const controller = createController({
+      status: 'anonymous', user: null, preference: null, error: null,
+    });
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <AuthFormScreen mode="signup" onBack={jest.fn()} onSwitch={jest.fn()} />
+      </AppModelProvider>,
+    );
+
+    const passwordInput = screen.getByPlaceholderText('至少 12 位字符');
+    const confirmPasswordInput = screen.getByPlaceholderText('再次输入密码');
+    expect(passwordInput.props.secureTextEntry).toBe(true);
+    expect(confirmPasswordInput.props.secureTextEntry).toBe(true);
+
+    await fireEvent.press(screen.getByRole('button', { name: '显示密码' }));
+    expect(passwordInput.props.secureTextEntry).toBe(false);
+    expect(confirmPasswordInput.props.secureTextEntry).toBe(true);
+
+    await fireEvent.press(screen.getByRole('button', { name: '显示确认密码' }));
+    expect(confirmPasswordInput.props.secureTextEntry).toBe(false);
   });
 
   it('shows the backend authentication error without changing the layout flow', async () => {

--- a/frontend/web/scripts/check-auth-contract.mjs
+++ b/frontend/web/scripts/check-auth-contract.mjs
@@ -14,6 +14,9 @@ import {
 test("rejects registration credentials before issuing an email challenge", () => {
   assert.equal(validateRegistrationCredentials("person@example.com", "short"), "WEAK_PASSWORD");
   assert.equal(validateRegistrationCredentials("not-an-email", "correct-password"), "INVALID_EMAIL");
+  assert.equal(validateRegistrationCredentials("person@example.com", "correct-password", ""), "INVALID_NICKNAME");
+  assert.equal(validateRegistrationCredentials("person@example.com", "correct-password", "  "), "INVALID_NICKNAME");
+  assert.equal(validateRegistrationCredentials("person@example.com", "correct-password", "Sunny"), null);
   assert.equal(validateRegistrationCredentials("person@example.com", "correct-password"), null);
 });
 
@@ -48,11 +51,47 @@ test("does not turn an invalid registration challenge into a password login", as
     await assert.rejects(() => registerWithEmail({
       email: "person@example.com",
       password: "correct-password",
+      nickname: "Sunny",
       challengeId: "00000000-0000-0000-0000-000000000001",
       code: "123456",
     }));
     assert.deepEqual(requests, ["/api/auth/email/register/token"]);
   } finally {
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("registration submits nickname without confirmPassword", async () => {
+  const previousFetch = globalThis.fetch;
+  let request;
+  globalThis.fetch = async (path, options) => {
+    request = { path, options };
+    return new Response(JSON.stringify({ data: { accessToken: "token" } }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+  try {
+    globalThis.window = { localStorage: { setItem() {} } };
+    await registerWithEmail({
+      email: "person@example.com",
+      password: "correct-password",
+      nickname: "Sunny",
+      confirmPassword: "different-password",
+      challengeId: "00000000-0000-0000-0000-000000000001",
+      code: "123456",
+    });
+    assert.equal(request.path, "/api/auth/email/register/token");
+    assert.deepEqual(JSON.parse(request.options.body), {
+      email: "person@example.com",
+      password: "correct-password",
+      nickname: "Sunny",
+      challengeId: "00000000-0000-0000-0000-000000000001",
+      code: "123456",
+    });
+    assert.equal(Object.hasOwn(JSON.parse(request.options.body), "confirmPassword"), false);
+  } finally {
+    delete globalThis.window;
     globalThis.fetch = previousFetch;
   }
 });
@@ -202,4 +241,17 @@ test("login UI routes password login through human verification", async () => {
   const source = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
   assert.match(source, /<HumanVerification buttonId=\{captchaButtonId\} onVerify=\{verifyAndIssueChallenge\} \/>/);
   assert.match(source, /loginWithPassword\(normalizedEmail, password, captchaVerifyParam\)/);
+});
+
+test("signup UI includes nickname, confirmed password, and separate visibility toggle", async () => {
+  const source = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
+  for (const expected of [
+    'mode === "signup" && <label>昵称',
+    'mode === "signup" && <label>确认密码',
+    'showConfirmPassword ? "text" : "password"',
+    'setError("两次输入的密码不一致。")',
+    'nickname: draft.nickname',
+  ]) {
+    assert.match(source, new RegExp(expected.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
+  }
 });

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -564,8 +564,10 @@ function Button({ children, variant = "primary", icon, className, ...props }) {
 function Auth({ mode: initialMode, onBack, onSuccess }) {
   const [mode, setMode] = useState(initialMode || "signup");
   const [showPassword, setShowPassword] = useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = useState(false);
   const [step, setStep] = useState("credentials");
   const [email, setEmail] = useState("");
+  const [nickname, setNickname] = useState("");
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
   const [code, setCode] = useState("");
@@ -573,7 +575,7 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const registrationDraftRef = useRef({ email: "", password: "" });
+  const registrationDraftRef = useRef({ email: "", password: "", nickname: "" });
   const captchaButtonId = mode === "login"
     ? "login-email-auth"
     : mode === "reset"
@@ -586,6 +588,7 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
     setCode("");
     setChallengeId("");
     setConfirmPassword("");
+    setShowConfirmPassword(false);
     setError("");
   };
 
@@ -593,23 +596,29 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
     setMode(mode === "signup" ? "login" : "signup");
     clearChallenge();
     setPassword("");
+    setNickname("");
+    setShowPassword(false);
     setNotice("");
-    registrationDraftRef.current = { email: "", password: "" };
+    registrationDraftRef.current = { email: "", password: "", nickname: "" };
   };
 
   const beginPasswordReset = () => {
     setMode("reset");
     clearChallenge();
     setPassword("");
+    setNickname("");
+    setShowPassword(false);
     setNotice("");
-    registrationDraftRef.current = { email: email.trim(), password: "" };
+    registrationDraftRef.current = { email: email.trim(), password: "", nickname: "" };
   };
 
   const returnToLogin = () => {
     setMode("login");
     clearChallenge();
     setPassword("");
-    registrationDraftRef.current = { email: "", password: "" };
+    setNickname("");
+    setShowPassword(false);
+    registrationDraftRef.current = { email: "", password: "", nickname: "" };
   };
 
   const submitCredentials = async (event) => {
@@ -645,13 +654,21 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
       }
     }
     const validationCode = mode === "signup"
-      ? validateRegistrationCredentials(normalizedEmail, password)
+      ? validateRegistrationCredentials(normalizedEmail, password, nickname)
       : null;
+    if (validationCode === "INVALID_NICKNAME") {
+      setError("请输入昵称。");
+      return { captchaResult: true, bizResult: false };
+    }
     if (validationCode === "WEAK_PASSWORD") {
       setError("密码至少需要 12 位字符。");
       return { captchaResult: true, bizResult: false };
     }
-    registrationDraftRef.current = { email: normalizedEmail, password };
+    if (mode === "signup" && password !== confirmPassword) {
+      setError("两次输入的密码不一致。");
+      return { captchaResult: true, bizResult: false };
+    }
+    registrationDraftRef.current = { email: normalizedEmail, password, nickname: nickname.trim() };
     setSubmitting(true);
     try {
       const challenge = mode === "reset"
@@ -702,9 +719,9 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
         setNotice("密码已重置，请使用新密码登录。");
         return;
       }
-      const validationCode = validateRegistrationCredentials(draft.email, draft.password);
+      const validationCode = validateRegistrationCredentials(draft.email, draft.password, draft.nickname);
       if (validationCode) {
-        setError(validationCode === "INVALID_EMAIL" ? "请输入有效邮箱地址。" : "密码至少需要 12 位字符。");
+        setError(validationCode === "INVALID_EMAIL" ? "请输入有效邮箱地址。" : validationCode === "INVALID_NICKNAME" ? "请输入昵称。" : "密码至少需要 12 位字符。");
         setStep("credentials");
         setChallengeId("");
         setCode("");
@@ -713,6 +730,7 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
       const auth = await registerWithEmail({
         email: draft.email,
         password: draft.password,
+        nickname: draft.nickname,
         challengeId,
         code,
       });
@@ -765,7 +783,9 @@ function Auth({ mode: initialMode, onBack, onSuccess }) {
         <div className="auth-panel__heading"><h1>{mode === "signup" ? "创建账号" : mode === "reset" ? "重置密码" : "欢迎回来"}</h1><p>{mode === "signup" ? "用邮箱注册，开始你的口语练习。" : mode === "reset" ? "输入注册邮箱，验证后设置新密码。" : "继续上一次的学习进度。"}</p></div>
         <form onSubmit={submitCredentials}>
           <label>邮箱<input type="email" value={email} onChange={(event) => { const nextEmail = event.target.value; setEmail(nextEmail); registrationDraftRef.current.email = nextEmail.trim(); }} placeholder="name@example.com" autoComplete="email" maxLength="254" required disabled={submitting} /></label>
+          {mode === "signup" && <label>昵称<input type="text" value={nickname} onChange={(event) => { const nextNickname = event.target.value; setNickname(nextNickname); registrationDraftRef.current.nickname = nextNickname.trim(); }} placeholder="请输入昵称" autoComplete="nickname" required disabled={submitting} /></label>}
           {mode !== "reset" && <label>密码<span className="password-field"><input type={showPassword ? "text" : "password"} value={password} onChange={(event) => { const nextPassword = event.target.value; setPassword(nextPassword); registrationDraftRef.current.password = nextPassword; }} placeholder="至少 12 位字符" autoComplete={mode === "signup" ? "new-password" : "current-password"} minLength="12" maxLength="200" required disabled={submitting} /><button type="button" aria-label={showPassword ? "隐藏密码" : "显示密码"} onClick={() => setShowPassword(!showPassword)}>{showPassword ? <EyeSlash /> : <Eye />}</button></span></label>}
+          {mode === "signup" && <label>确认密码<span className="password-field"><input type={showConfirmPassword ? "text" : "password"} value={confirmPassword} onChange={(event) => setConfirmPassword(event.target.value)} placeholder="再次输入密码" autoComplete="new-password" minLength="12" maxLength="200" required disabled={submitting} /><button type="button" aria-label={showConfirmPassword ? "隐藏确认密码" : "显示确认密码"} onClick={() => setShowConfirmPassword(!showConfirmPassword)}>{showConfirmPassword ? <EyeSlash /> : <Eye />}</button></span></label>}
           <HumanVerification buttonId={captchaButtonId} onVerify={verifyAndIssueChallenge} />
           {mode === "login" && <button type="button" className="forgot-link" onClick={beginPasswordReset}>忘记密码？</button>}
           {notice && <p className="auth-notice" role="status">{notice}</p>}

--- a/frontend/web/src/userAuthApi.js
+++ b/frontend/web/src/userAuthApi.js
@@ -24,13 +24,16 @@ const messages = {
   AUTH_SESSION_SYNC_FAILED: "邮箱认证已通过，但学习服务账号同步失败，请稍后重试。",
 };
 
-export function validateRegistrationCredentials(email, password) {
+export function validateRegistrationCredentials(email, password, nickname = null) {
   const normalizedEmail = String(email || "").trim();
   if (!normalizedEmail || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalizedEmail)) {
     return "INVALID_EMAIL";
   }
   if (typeof password !== "string" || password.length < 12 || password.length > 200) {
     return "WEAK_PASSWORD";
+  }
+  if (nickname !== null && !String(nickname || "").trim()) {
+    return "INVALID_NICKNAME";
   }
   return null;
 }
@@ -77,10 +80,10 @@ export function resetPasswordWithEmail({ email, password, challengeId, code }) {
   });
 }
 
-export async function registerWithEmail({ email, password, challengeId, code }) {
+export async function registerWithEmail({ email, password, nickname, challengeId, code }) {
   const auth = await request("/api/auth/email/register/token", {
     method: "POST",
-    body: JSON.stringify({ email, password, challengeId, code }),
+    body: JSON.stringify({ email, password, nickname, challengeId, code }),
   });
   saveAuthSession(auth);
   return auth;


### PR DESCRIPTION
## Summary

- Add nickname and confirm-password fields to the Web signup flow.
- Add password visibility toggles for Web and mobile signup forms.
- Prevent mobile signup from continuing when passwords do not match.
- Remove the default `Yufan` nickname from the mobile app.
- Submit Web signup nicknames through the existing registration API.
- Add Web and mobile regression coverage for the updated signup flow.

## Scope

- Web signup UI and registration request handling.
- Mobile signup UI and initial nickname state.
- Existing Web and mobile authentication tests.

## Out of scope

- No backend API, database schema, route, login, or password-reset changes.
- Existing duplicate-email behavior remains unchanged: the backend reports that the email is already registered after verification.

## Validation

- Web authentication tests: 19 passed.
- Mobile signup/model tests: 11 passed.
- Mobile TypeScript check passed.
- `git diff --check` passed.

Close #96 