### PR TITLE
feat: 支持 Web 与移动端跨端 Umami 用户旅程

### DIFF
--- a/docs/deployment-production.md
+++ b/docs/deployment-production.md
@@ -1,6 +1,6 @@
 # UniSpeaking production deployment
 
-This runbook targets the single-server Docker deployment for `unispeaking.cn`.
+This runbook targets the single-server Docker deployment for `unispeaking.qnsdk.com`.
 It assumes Ubuntu 24.04, Docker Compose, PostgreSQL 17, and public TCP ports
 80 and 443 mapped to the server.
 
@@ -19,7 +19,7 @@ sudo chmod 600 /etc/unispeaking/certs/privkey.pem
 ```
 
 The certificate files must not be committed to Git. The certificate must cover
-both `unispeaking.cn` and `www.unispeaking.cn`.
+`unispeaking.qnsdk.com`.
 
 Create the runtime environment file:
 
@@ -78,10 +78,23 @@ docker compose --env-file deploy/env/.env \
 ```
 
 After release, open the migrated site and confirm the visit in Umami Realtime.
-Then verify Pages and Events for the four anonymous training modes: `SCENE`,
-`FREE_CHAT`, `INTERVIEW`, and `IELTS`. Learning assets are reported separately;
-no real user ID, transcript, audio, resume, job description, or credential is
-sent to Umami.
+Then verify Pages and Events for the four training modes: `SCENE`, `FREE_CHAT`,
+`INTERVIEW`, and `IELTS`. Learning assets are reported separately. Authenticated
+Web and mobile events use the same backend user UUID as the Umami Distinct ID;
+no email, nickname, transcript, audio, resume, job description, JWT, password,
+or other credential is sent to Umami.
+
+Build the mobile app with the same public Website ID:
+
+```dotenv
+EXPO_PUBLIC_UMAMI_ENABLED=true
+EXPO_PUBLIC_UMAMI_ENDPOINT=https://cloud.umami.is/api/send
+EXPO_PUBLIC_UMAMI_WEBSITE_ID=3ae2dee9-d585-43a9-93f3-fcafcd14b258
+```
+
+Do not create a second Umami Website for mobile. The native client sends a
+valid app User-Agent and the production hostname `unispeaking.qnsdk.com` to
+`/api/send`; no Umami login or API token is embedded in the app.
 
 The environment template selects mirrors reachable from mainland China for
 Docker images, Debian packages, Maven, PyPI, and npm. The committed defaults
@@ -169,7 +182,7 @@ docker compose --env-file deploy/env/.env \
   "SELECT version, description, success FROM flyway_schema_history ORDER BY installed_rank;"
 ```
 
-Visit `https://unispeaking.cn` and verify registration, login, microphone
+Visit `https://unispeaking.qnsdk.com` and verify registration, login, microphone
 permission, WebSocket sessions, IELTS topics, and audio features.
 
 Then verify the LLM migration with one request from each business path:

--- a/frontend/mobile/README.md
+++ b/frontend/mobile/README.md
@@ -23,11 +23,27 @@ npx tsc --noEmit
 npx expo-doctor
 ```
 
+## Umami 行为统计
+
+移动端 Umami 默认关闭。生产构建使用与 Web 端相同的 Website ID，并通过 Umami Cloud
+发送同名页面、模式选择、学习资产和训练生命周期事件：
+
+```dotenv
+EXPO_PUBLIC_UMAMI_ENABLED=true
+EXPO_PUBLIC_UMAMI_ENDPOINT=https://cloud.umami.is/api/send
+EXPO_PUBLIC_UMAMI_WEBSITE_ID=3ae2dee9-d585-43a9-93f3-fcafcd14b258
+```
+
+已登录用户使用后端返回的用户 UUID 作为 Distinct ID，以关联 Web 和移动端会话。事件数据
+不包含邮箱、昵称、口令、JWT、对话文本、音频、简历或岗位描述。生产统计主机名固定为
+`unispeaking.qnsdk.com`，不要为移动端创建第二个 Website ID。
+
 ## 主要目录
 
 - `src/components`：移动端通用 UI 组件与对话设置
 - `src/screens`：对话、场景、专项训练、资产和个人中心页面
 - `src/model`：跨页面状态与交互逻辑
+- `src/infrastructure/analytics`：Umami 传输、页面归一化与有效时长计时
 - `src/data`：演示内容和训练数据
 - `src/theme`：移动端设计令牌
 - `assets/images/unispeaking`：移动端使用的品牌与角色图片副本

--- a/frontend/mobile/src/app/(app)/(tabs)/(learning)/learning/index.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/(learning)/learning/index.tsx
@@ -1,15 +1,26 @@
 import { useRouter } from 'expo-router';
 
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { routes } from '@/navigation/routes';
 import { AssetsScreen } from '@/screens/AssetsScreen';
 
 export default function LearningHomeRoute() {
   const router = useRouter();
+  const analytics = useAnalytics();
   return (
     <AssetsScreen
-      onOpenRecord={(record) => router.push(routes.learning.sceneDetail(record.id))}
-      onOpenIelts={() => router.push(routes.learning.ielts.overview)}
-      onOpenInterview={() => router.push(routes.learning.interview.overview)}
+      onOpenRecord={(record) => {
+        analytics.trackLearningAsset({ mode: 'SCENE', pageCode: 'scene-assets' }, 'REPORT');
+        router.push(routes.learning.sceneDetail(record.id));
+      }}
+      onOpenIelts={() => {
+        analytics.trackLearningAsset({ mode: 'IELTS', pageCode: 'ielts-assets' }, 'REPORT');
+        router.push(routes.learning.ielts.overview);
+      }}
+      onOpenInterview={() => {
+        analytics.trackLearningAsset({ mode: 'INTERVIEW', pageCode: 'interview-assets' }, 'REPORT');
+        router.push(routes.learning.interview.overview);
+      }}
     />
   );
 }

--- a/frontend/mobile/src/app/(app)/(tabs)/(scenes)/ielts.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/(scenes)/ielts.tsx
@@ -1,13 +1,16 @@
 import { useRouter } from 'expo-router';
 
 import { forgetSpecialty } from '@/navigation/specialtyMemory';
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { routes } from '@/navigation/routes';
 import { IeltsFlow } from '@/screens/SpecialtyFlows';
 
 export default function IeltsRoute() {
   const router = useRouter();
+  const analytics = useAnalytics();
   return (
     <IeltsFlow
+      analytics={analytics}
       onExit={() => void forgetSpecialty().then(() => router.replace('/(app)/(tabs)/(scenes)/scenes'))}
       onViewDetails={(recordId) => router.replace(routes.learning.ielts.record(recordId))}
     />

--- a/frontend/mobile/src/app/(app)/(tabs)/(scenes)/interview.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/(scenes)/interview.tsx
@@ -1,14 +1,17 @@
 import { useLocalSearchParams, useRouter } from 'expo-router';
 
 import { forgetSpecialty } from '@/navigation/specialtyMemory';
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { routes } from '@/navigation/routes';
 import { InterviewFlow } from '@/screens/SpecialtyFlows';
 
 export default function InterviewRoute() {
   const router = useRouter();
+  const analytics = useAnalytics();
   const { sceneId, jobTitle, practice } = useLocalSearchParams<{ sceneId?: string; jobTitle?: string; practice?: string }>();
   return (
     <InterviewFlow
+      analytics={analytics}
       onExit={() => void forgetSpecialty().then(() => router.replace('/(app)/(tabs)/(scenes)/scenes'))}
       onViewDetails={() => router.replace(routes.learning.interview.history)}
       key={practice === '1' && sceneId ? `practice-${sceneId}` : 'new-interview'}

--- a/frontend/mobile/src/app/(app)/(tabs)/(scenes)/scenes/index.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/(scenes)/scenes/index.tsx
@@ -1,16 +1,35 @@
 import { useRouter } from 'expo-router';
 
+import type { TrainingMode } from '@/infrastructure/analytics/pageCatalog';
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { routes } from '@/navigation/routes';
 import { ScenesScreen } from '@/screens/ScenesScreen';
 
 export default function ScenesHomeRoute() {
   const router = useRouter();
+  const analytics = useAnalytics();
+  const trackMode = (mode: TrainingMode, pageCode: string) => {
+    analytics.trackModeSelection({ mode, pageCode }, 'scene-plaza');
+  };
   return (
     <ScenesScreen
-      onIeltsViewDetails={(recordId) => router.replace(routes.learning.ielts.record(recordId))}
-      onSceneViewDetails={(sceneId) => router.replace(routes.learning.sceneDetail(sceneId))}
-      onOpenIelts={() => router.navigate(routes.specialty.ielts)}
-      onOpenInterview={() => router.navigate(routes.specialty.interview)}
+      onIeltsViewDetails={(recordId) => {
+        analytics.trackLearningAsset({ mode: 'IELTS', pageCode: 'ielts-assets' }, 'REPORT');
+        router.replace(routes.learning.ielts.record(recordId));
+      }}
+      onSceneViewDetails={(sceneId) => {
+        analytics.trackLearningAsset({ mode: 'SCENE', pageCode: 'scene-assets' }, 'REPORT');
+        router.replace(routes.learning.sceneDetail(sceneId));
+      }}
+      onOpenIelts={() => {
+        trackMode('IELTS', 'ielts-training');
+        router.navigate(routes.specialty.ielts);
+      }}
+      onOpenInterview={() => {
+        trackMode('INTERVIEW', 'interview-training');
+        router.navigate(routes.specialty.interview);
+      }}
+      onStartScene={() => trackMode('SCENE', 'scene-training')}
     />
   );
 }

--- a/frontend/mobile/src/app/(app)/(tabs)/(scenes)/scenes/index.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/(scenes)/scenes/index.tsx
@@ -13,6 +13,7 @@ export default function ScenesHomeRoute() {
   };
   return (
     <ScenesScreen
+      analytics={analytics}
       onIeltsViewDetails={(recordId) => {
         analytics.trackLearningAsset({ mode: 'IELTS', pageCode: 'ielts-assets' }, 'REPORT');
         router.replace(routes.learning.ielts.record(recordId));

--- a/frontend/mobile/src/app/(app)/(tabs)/_layout.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/_layout.tsx
@@ -6,6 +6,7 @@ import { WaveformIcon } from 'phosphor-react-native/src/icons/Waveform';
 import { useState } from 'react';
 
 import { LiquidGlassTabBar } from '@/components/LiquidGlassTabBar';
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { colors } from '@/theme/tokens';
 import { LearningStageProvider } from '@/navigation/learningStage';
 import { routes } from '@/navigation/routes';
@@ -14,6 +15,7 @@ import { forgetSpecialty, readRememberedSpecialty, rememberSpecialty } from '@/n
 export default function TabsLayout() {
   const pathname = usePathname();
   const router = useRouter();
+  const analytics = useAnalytics();
   const [immersiveLearning, setImmersiveLearning] = useState(false);
   const hideTabBar = immersiveLearning;
 
@@ -45,6 +47,7 @@ export default function TabsLayout() {
           tabPress: (event) => {
             if (pathname === '/conversation') return;
             event.preventDefault();
+            analytics.trackModeSelection({ mode: 'FREE_CHAT', pageCode: 'conversation' }, 'tab-navigation');
             void (async () => {
               if (pathname === '/ielts' || pathname === '/interview') await rememberSpecialty(pathname === '/ielts' ? 'ielts' : 'interview');
               router.replace('/(app)/(tabs)/conversation');
@@ -65,10 +68,19 @@ export default function TabsLayout() {
           tabPress: (event) => {
             if (pathname === '/ielts' || pathname === '/interview') {
               event.preventDefault();
+              analytics.trackModeSelection({ mode: 'SCENE', pageCode: 'scene-training' }, 'tab-navigation');
               void forgetSpecialty().then(() => router.replace('/(app)/(tabs)/(scenes)/scenes'));
             } else if (pathname !== '/scenes') {
               event.preventDefault();
               void readRememberedSpecialty().then((saved) => {
+                analytics.trackModeSelection(
+                  saved === 'ielts'
+                    ? { mode: 'IELTS', pageCode: 'ielts-training' }
+                    : saved === 'interview'
+                      ? { mode: 'INTERVIEW', pageCode: 'interview-training' }
+                      : { mode: 'SCENE', pageCode: 'scene-training' },
+                  'tab-navigation',
+                );
                 router.replace(
                   saved === 'ielts'
                     ? '/(app)/(tabs)/(scenes)/ielts'
@@ -103,6 +115,12 @@ export default function TabsLayout() {
             event.preventDefault();
             void (async () => {
               if (currentSpecialty) {
+                analytics.trackLearningAsset(
+                  currentSpecialty === 'ielts'
+                    ? { mode: 'IELTS', pageCode: 'ielts-assets' }
+                    : { mode: 'INTERVIEW', pageCode: 'interview-assets' },
+                  'REPORT',
+                );
                 await rememberSpecialty(currentSpecialty);
                 router.replace(
                   currentSpecialty === 'ielts'
@@ -114,6 +132,12 @@ export default function TabsLayout() {
               const remembered = await readRememberedSpecialty();
               if (remembered) {
                 const specialty = remembered;
+                analytics.trackLearningAsset(
+                  specialty === 'ielts'
+                    ? { mode: 'IELTS', pageCode: 'ielts-assets' }
+                    : { mode: 'INTERVIEW', pageCode: 'interview-assets' },
+                  'REPORT',
+                );
                 await rememberSpecialty(specialty);
                 router.replace(
                   specialty === 'ielts'
@@ -122,6 +146,7 @@ export default function TabsLayout() {
                 );
                 return;
               }
+              analytics.trackLearningAsset({ mode: 'SCENE', pageCode: 'scene-assets' }, 'REPORT');
               router.replace('/(app)/(tabs)/(learning)/learning');
             })();
           },

--- a/frontend/mobile/src/app/(app)/(tabs)/conversation/index.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/conversation/index.tsx
@@ -1,9 +1,18 @@
 import { useRouter } from 'expo-router';
 
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { routes } from '@/navigation/routes';
 import { ConversationScreen } from '@/screens/ConversationScreen';
 
 export default function ConversationHomeRoute() {
   const router = useRouter();
-  return <ConversationScreen onStartCall={() => router.push(routes.conversation.call)} />;
+  const analytics = useAnalytics();
+  return (
+    <ConversationScreen
+      onStartCall={() => {
+        analytics.trackModeSelection({ mode: 'FREE_CHAT', pageCode: 'conversation' }, 'conversation-home');
+        router.push(routes.conversation.call);
+      }}
+    />
+  );
 }

--- a/frontend/mobile/src/app/(app)/conversation/call.tsx
+++ b/frontend/mobile/src/app/(app)/conversation/call.tsx
@@ -1,8 +1,10 @@
 import { useRouter } from 'expo-router';
 
+import { useAnalytics } from '@/model/AnalyticsProvider';
 import { CallScreen } from '@/screens/ConversationScreen';
 
 export default function ConversationCallRoute() {
   const router = useRouter();
-  return <CallScreen onEnd={() => router.back()} />;
+  const analytics = useAnalytics();
+  return <CallScreen analytics={analytics} onEnd={() => router.back()} />;
 }

--- a/frontend/mobile/src/app/_layout.tsx
+++ b/frontend/mobile/src/app/_layout.tsx
@@ -5,6 +5,7 @@ import { StatusBar } from 'expo-status-bar';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 import { DevicePreviewFrame } from '@/components/DevicePreviewFrame';
+import { AnalyticsProvider } from '@/model/AnalyticsProvider';
 import { AppModelProvider, useAppModel } from '@/model/AppModel';
 
 function RootNavigator() {
@@ -35,12 +36,14 @@ export default function RootLayout() {
 
   return (
     <AppModelProvider>
-      <StatusBar style="dark" />
-      <GestureHandlerRootView style={{ flex: 1 }}>
-        <DevicePreviewFrame>
-          <RootNavigator />
-        </DevicePreviewFrame>
-      </GestureHandlerRootView>
+      <AnalyticsProvider>
+        <StatusBar style="dark" />
+        <GestureHandlerRootView style={{ flex: 1 }}>
+          <DevicePreviewFrame>
+            <RootNavigator />
+          </DevicePreviewFrame>
+        </GestureHandlerRootView>
+      </AnalyticsProvider>
     </AppModelProvider>
   );
 }

--- a/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
+++ b/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
@@ -3,6 +3,7 @@ import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { Pressable, Text, View } from 'react-native';
 
 import type { RealtimeSessionSnapshot } from '@/features/realtime/RealtimeSessionController';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
 
 import {
   type FreeChatControllerPort,
@@ -50,8 +51,10 @@ function createController(): FreeChatControllerPort & {
 
 function SessionProbe({
   createController,
+  analytics,
 }: {
   createController: () => FreeChatControllerPort;
+  analytics?: TrainingTracker;
 }) {
   const session = useFreeChatSession(
     {
@@ -60,6 +63,7 @@ function SessionProbe({
       speechSpeed: 'NATURAL',
     },
     createController,
+    analytics,
   );
   return (
     <View>
@@ -83,10 +87,25 @@ function SessionProbe({
 describe('useFreeChatSession', () => {
   it('starts once and exposes live state, transcripts, mute and interrupt actions', async () => {
     const controller = createController();
+    const analytics = {
+      attempt: jest.fn(),
+      started: jest.fn(),
+      fail: jest.fn(),
+      pause: jest.fn(),
+      resume: jest.fn(),
+      setVisible: jest.fn(),
+      settle: jest.fn(),
+      complete: jest.fn(),
+      abandon: jest.fn(),
+      isStarted: jest.fn(() => true),
+      start: jest.fn(),
+      stop: jest.fn(),
+    } as unknown as TrainingTracker;
     const factory = jest.fn(() => controller);
-    const screen = await render(<SessionProbe createController={factory} />);
+    const screen = await render(<SessionProbe analytics={analytics} createController={factory} />);
 
     await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1));
+    expect(analytics.attempt).toHaveBeenCalledTimes(1);
     expect(factory).toHaveBeenCalledWith({
       voice: 'Harvey',
       model: 'qwen3.5-omni-flash-realtime',
@@ -107,11 +126,15 @@ describe('useFreeChatSession', () => {
         'AI 正在回答',
       ),
     );
+    expect(analytics.started).toHaveBeenCalledTimes(1);
+    expect(analytics.resume).toHaveBeenCalledTimes(1);
     await fireEvent.press(screen.getByLabelText('mute'));
     await fireEvent.press(screen.getByLabelText('interrupt'));
 
     expect(controller.setMuted).toHaveBeenCalledWith(true);
     expect(controller.interrupt).toHaveBeenCalledTimes(1);
+    await fireEvent.press(screen.getByLabelText('end'));
+    await waitFor(() => expect(analytics.complete).toHaveBeenCalledTimes(1));
   });
 
   it('does not end and restart the same controller during StrictMode effect replay', async () => {

--- a/frontend/mobile/src/features/conversation/useFreeChatSession.ts
+++ b/frontend/mobile/src/features/conversation/useFreeChatSession.ts
@@ -12,6 +12,7 @@ import type { RealtimeState } from '@/features/realtime/types';
 import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
 import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
 import { ApiClient } from '@/infrastructure/http/ApiClient';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
 
 export type FreeChatConfig = Pick<
   RealtimeSessionOptions,
@@ -78,6 +79,7 @@ const initialSnapshot: RealtimeSessionSnapshot = {
 export function useFreeChatSession(
   config: FreeChatConfig,
   createController: FreeChatControllerFactory = createFreeChatController,
+  analytics?: TrainingTracker,
 ) {
   const [controller] = useState(() => createController(config));
   const [snapshot, setSnapshot] = useState<RealtimeSessionSnapshot>(() =>
@@ -91,10 +93,17 @@ export function useFreeChatSession(
 
   const end = useCallback(() => {
     if (!endPromise.current) {
-      endPromise.current = Promise.resolve(controller.end());
+      endPromise.current = Promise.resolve(controller.end()).then((result) => {
+        analytics?.complete();
+        return result;
+      }).catch((error: unknown) => {
+        if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+        else analytics?.fail('REALTIME_ERROR');
+        throw error;
+      });
     }
     return endPromise.current;
-  }, [controller]);
+  }, [analytics, controller]);
 
   useEffect(() => controller.subscribe(setSnapshot), [controller]);
 
@@ -102,10 +111,12 @@ export function useFreeChatSession(
     lifecycleVersion.current += 1;
     let active = true;
     if (!startPromise.current) {
+      analytics?.attempt();
       startPromise.current = Promise.resolve().then(() => controller.start());
     }
     void startPromise.current.catch((error: unknown) => {
       if (active) {
+        analytics?.fail('REALTIME_ERROR');
         setStartupError(
           error instanceof Error ? error.message : '实时对话启动失败',
         );
@@ -117,11 +128,24 @@ export function useFreeChatSession(
       const cleanupVersion = lifecycleVersion.current;
       queueMicrotask(() => {
         if (lifecycleVersion.current === cleanupVersion) {
+          analytics?.abandon('USER_EXIT');
           void end().catch(() => undefined);
         }
       });
     };
-  }, [controller, end]);
+  }, [analytics, controller, end]);
+
+  useEffect(() => {
+    if (['ready', 'user_speaking', 'assistant_speaking'].includes(snapshot.state)) {
+      analytics?.started();
+      analytics?.resume();
+    } else if (snapshot.state === 'paused') {
+      analytics?.pause();
+    } else if (snapshot.state === 'error') {
+      if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+      else analytics?.fail('REALTIME_ERROR');
+    }
+  }, [analytics, snapshot.state]);
 
   useEffect(() => {
     const active = !['idle', 'ending', 'ended', 'error'].includes(snapshot.state);

--- a/frontend/mobile/src/features/ielts/useIeltsSession.ts
+++ b/frontend/mobile/src/features/ielts/useIeltsSession.ts
@@ -17,6 +17,7 @@ import type { RealtimeState } from '@/features/realtime/types';
 import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
 import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
 import { ApiClient } from '@/infrastructure/http/ApiClient';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
 import { useAppModel } from '@/model/AppModel';
 
 import { IELTS_REALTIME_MODEL } from './ieltsMappings';
@@ -92,7 +93,7 @@ export function createIeltsSessionController(
   return controller;
 }
 
-export function useIeltsSession(config: IeltsSessionConfig | null) {
+export function useIeltsSession(config: IeltsSessionConfig | null, analytics?: TrainingTracker) {
   const { speed } = useAppModel();
   const [controller] = useState<IeltsSessionControllerPort | null>(() =>
     config ? createIeltsSessionController(config, speed) : null,
@@ -100,14 +101,22 @@ export function useIeltsSession(config: IeltsSessionConfig | null) {
   const [snapshot, setSnapshot] = useState<RealtimeSessionSnapshot>(initialSnapshot);
   const [startupError, setStartupError] = useState<string | null>(null);
   const endPromise = useRef<Promise<unknown> | null>(null);
+  const lifecycleVersion = useRef(0);
 
   const end = useCallback(() => {
     if (!controller) return Promise.resolve(null);
     if (!endPromise.current) {
-      endPromise.current = Promise.resolve(controller.end());
+      endPromise.current = Promise.resolve(controller.end()).then((result) => {
+        analytics?.complete();
+        return result;
+      }).catch((error: unknown) => {
+        if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+        else analytics?.fail('REALTIME_ERROR');
+        throw error;
+      });
     }
     return endPromise.current;
-  }, [controller]);
+  }, [analytics, controller]);
 
   useEffect(() => {
     if (!controller) return;
@@ -116,20 +125,42 @@ export function useIeltsSession(config: IeltsSessionConfig | null) {
 
   useEffect(() => {
     if (!controller) return;
+    lifecycleVersion.current += 1;
     let active = true;
     if (config?.part === 'PART_2') {
       controller.setMuted(true);
     }
+    analytics?.attempt();
     void controller.start().catch((error: unknown) => {
       if (active) {
+        analytics?.fail('REALTIME_ERROR');
         setStartupError(error instanceof Error ? error.message : 'IELTS 会话启动失败');
       }
     });
     return () => {
       active = false;
-      void end().catch(() => undefined);
+      lifecycleVersion.current += 1;
+      const cleanupVersion = lifecycleVersion.current;
+      queueMicrotask(() => {
+        if (lifecycleVersion.current === cleanupVersion) {
+          analytics?.abandon('USER_EXIT');
+          void end().catch(() => undefined);
+        }
+      });
     };
-  }, [controller, config?.part, end]);
+  }, [analytics, controller, config?.part, end]);
+
+  useEffect(() => {
+    if (['ready', 'user_speaking', 'assistant_speaking'].includes(snapshot.state)) {
+      analytics?.started();
+      analytics?.resume();
+    } else if (snapshot.state === 'paused') {
+      analytics?.pause();
+    } else if (snapshot.state === 'error') {
+      if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+      else analytics?.fail('REALTIME_ERROR');
+    }
+  }, [analytics, snapshot.state]);
 
   const toggleMuted = useCallback(
     (muted: boolean) => {

--- a/frontend/mobile/src/features/interview/useInterviewSession.ts
+++ b/frontend/mobile/src/features/interview/useInterviewSession.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { ContinuousTurnRecorder } from '@/features/audio/ContinuousTurnRecorder';
 import { ReactNativeWebRTCTransport } from '@/features/realtime/ReactNativeWebRTCTransport';
@@ -6,6 +6,7 @@ import { SessionMessageSocket } from '@/features/realtime/SessionMessageSocket';
 import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
 import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
 import { ApiClient } from '@/infrastructure/http/ApiClient';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
 
 import {
   InterviewSessionController,
@@ -43,7 +44,7 @@ export function useInterviewSession({
   sceneId: string;
   voice: string;
   model?: string;
-}) {
+}, analytics?: TrainingTracker) {
   // Keep native Audio Studio loading out of Jest's module graph while Metro
   // still includes the production hook in Android development builds.
   // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -69,16 +70,49 @@ export function useInterviewSession({
   });
   const [snapshot, setSnapshot] = useState<InterviewSessionSnapshot>(initialSnapshot);
   const [elapsed, setElapsed] = useState(0);
-  const end = useCallback(() => controller.end(), [controller]);
+  const endPromise = useRef<Promise<unknown> | null>(null);
+  const lifecycleVersion = useRef(0);
+  const end = useCallback(() => {
+    if (!endPromise.current) {
+      endPromise.current = Promise.resolve(controller.end()).then((result) => {
+        analytics?.complete();
+        return result;
+      }).catch((error: unknown) => {
+        if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+        else analytics?.fail('REALTIME_ERROR');
+        throw error;
+      });
+    }
+    return endPromise.current;
+  }, [analytics, controller]);
 
   useEffect(() => {
+    lifecycleVersion.current += 1;
     const unsubscribe = controller.subscribe(setSnapshot);
-    void controller.start().catch(() => undefined);
+    analytics?.attempt();
+    void controller.start().catch(() => analytics?.fail('REALTIME_ERROR'));
     return () => {
       unsubscribe();
-      void end().catch(() => undefined);
+      lifecycleVersion.current += 1;
+      const cleanupVersion = lifecycleVersion.current;
+      queueMicrotask(() => {
+        if (lifecycleVersion.current === cleanupVersion) {
+          analytics?.abandon('USER_EXIT');
+          void end().catch(() => undefined);
+        }
+      });
     };
-  }, [controller, end]);
+  }, [analytics, controller, end]);
+
+  useEffect(() => {
+    if (snapshot.state === 'active') {
+      analytics?.started();
+      analytics?.resume();
+    } else if (snapshot.state === 'error') {
+      if (analytics?.isStarted()) analytics.abandon('REALTIME_ERROR');
+      else analytics?.fail('REALTIME_ERROR');
+    }
+  }, [analytics, snapshot.state]);
 
   useEffect(() => {
     if (snapshot.state !== 'active') return;

--- a/frontend/mobile/src/infrastructure/analytics/ActivityTimer.ts
+++ b/frontend/mobile/src/infrastructure/analytics/ActivityTimer.ts
@@ -1,0 +1,53 @@
+export type Clock = () => number;
+
+export function createActivityTimer(now: Clock = () => Date.now()) {
+  let elapsedMs = 0;
+  let activeSince: number | null = null;
+  let started = false;
+  let paused = false;
+  let visible = true;
+
+  const settle = () => {
+    if (activeSince !== null) {
+      elapsedMs += Math.max(0, now() - activeSince);
+      activeSince = null;
+    }
+    if (started && !paused && visible) activeSince = now();
+    return Math.round(elapsedMs / 1000);
+  };
+
+  return {
+    start() {
+      if (started) return;
+      started = true;
+      if (visible) activeSince = now();
+    },
+    pause() {
+      if (!started || paused) return Math.round(elapsedMs / 1000);
+      settle();
+      paused = true;
+      activeSince = null;
+      return Math.round(elapsedMs / 1000);
+    },
+    resume() {
+      if (!started || !paused) return;
+      paused = false;
+      if (visible) activeSince = now();
+    },
+    setVisible(nextVisible: boolean) {
+      const next = Boolean(nextVisible);
+      if (next === visible) return;
+      settle();
+      visible = next;
+      activeSince = started && !paused && visible ? now() : null;
+    },
+    settle,
+    stop() {
+      settle();
+      started = false;
+      activeSince = null;
+      return Math.round(elapsedMs / 1000);
+    },
+    isStarted: () => started,
+  };
+}

--- a/frontend/mobile/src/infrastructure/analytics/AnalyticsClient.ts
+++ b/frontend/mobile/src/infrastructure/analytics/AnalyticsClient.ts
@@ -1,0 +1,147 @@
+import { createActivityTimer, type Clock } from './ActivityTimer';
+import { normalizeTrackedPath, type TrainingMode } from './pageCatalog';
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+
+type UmamiConfig = Readonly<{
+  enabled: boolean;
+  endpoint: string;
+  websiteId: string;
+  hostname: string;
+}>;
+
+export type AnalyticsContext = Readonly<{
+  mode?: TrainingMode;
+  pageCode?: string;
+}>;
+
+export type TrainingTracker = ReturnType<typeof createActivityTimer> & {
+  attempt(): void;
+  started(): void;
+  fail(reason?: string): void;
+  complete(): void;
+  abandon(reason?: string): void;
+};
+
+const trainingModes = new Set<TrainingMode>(['SCENE', 'FREE_CHAT', 'INTERVIEW', 'IELTS']);
+const safeValues = new Set(['mode', 'page_code', 'source', 'reason', 'asset_type', 'effective_duration_seconds']);
+
+function safeData(input: Record<string, unknown> = {}) {
+  return Object.fromEntries(Object.entries(input).filter(([key, value]) => {
+    if (!safeValues.has(key)) return false;
+    if (typeof value === 'string') return value.length > 0 && value.length <= 80;
+    return (typeof value === 'number' && Number.isFinite(value)) || typeof value === 'boolean';
+  }));
+}
+
+function contextData(context: AnalyticsContext = {}) {
+  return safeData({ mode: context.mode, page_code: context.pageCode });
+}
+
+function validTrainingContext(context: AnalyticsContext = {}) {
+  return typeof context.mode === 'string' && trainingModes.has(context.mode);
+}
+
+export class AnalyticsClient {
+  private distinctId: string | null = null;
+  private currentUrl = '/';
+  private readonly activeTrackers = new Set<TrainingTracker>();
+  private appVisible = true;
+
+  constructor(
+    private readonly config: UmamiConfig,
+    private readonly dependencies: Readonly<{
+      fetch: FetchLike;
+      now?: Clock;
+      language?: () => string;
+      screen?: () => string;
+      userAgent?: () => string;
+    }>,
+  ) {}
+
+  setDistinctId(value: string | null | undefined) {
+    this.distinctId = typeof value === 'string' && value.length > 0 && value.length <= 50 ? value : null;
+  }
+
+  setAppVisible(visible: boolean) {
+    this.appVisible = visible;
+    this.activeTrackers.forEach((tracker) => tracker.setVisible(visible));
+  }
+
+  trackPageView(pathname = '/') {
+    this.currentUrl = normalizeTrackedPath(pathname);
+    this.send();
+  }
+
+  trackModeSelection(context: AnalyticsContext = {}, source = 'navigation') {
+    if (validTrainingContext(context)) {
+      this.send('mode_selected', { ...contextData(context), source });
+    }
+  }
+
+  trackLearningAsset(context: AnalyticsContext = {}, assetType = 'REPORT') {
+    this.send('learning_asset_view', { ...contextData(context), asset_type: assetType });
+  }
+
+  training(context: AnalyticsContext = {}) {
+    const timer = createActivityTimer(this.dependencies.now);
+    const base = contextData(context);
+    let ended = false;
+    const tracker: TrainingTracker = {
+      ...timer,
+      attempt: () => {
+        if (!ended && validTrainingContext(context)) this.send('training_start_attempt', base);
+      },
+      started: () => {
+        if (ended || timer.isStarted() || !validTrainingContext(context)) return;
+        timer.start();
+        timer.setVisible(this.appVisible);
+        this.activeTrackers.add(tracker);
+        this.send('training_started', base);
+      },
+      fail: (reason = 'REALTIME_ERROR') => {
+        if (ended || timer.isStarted() || !validTrainingContext(context)) return;
+        this.send('training_start_failed', { ...base, reason });
+        ended = true;
+      },
+      complete: () => {
+        if (ended || !timer.isStarted()) return;
+        this.send('training_completed', { ...base, effective_duration_seconds: timer.stop() });
+        this.activeTrackers.delete(tracker);
+        ended = true;
+      },
+      abandon: (reason = 'USER_EXIT') => {
+        if (ended || !timer.isStarted()) return;
+        this.send('training_abandoned', { ...base, reason, effective_duration_seconds: timer.stop() });
+        this.activeTrackers.delete(tracker);
+        ended = true;
+      },
+    };
+    return tracker;
+  }
+
+  private send(name?: string, data: Record<string, unknown> = {}) {
+    if (!this.config.enabled) return;
+
+    const payload = {
+      website: this.config.websiteId,
+      hostname: this.config.hostname,
+      language: this.dependencies.language?.() ?? 'zh-CN',
+      screen: this.dependencies.screen?.() ?? 'mobile',
+      title: 'UniSpeaking',
+      url: this.currentUrl,
+      id: this.distinctId || undefined,
+      name,
+      data: name ? safeData(data) : undefined,
+    };
+
+    void this.dependencies.fetch(this.config.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'User-Agent': this.dependencies.userAgent?.() ?? 'UniSpeaking-Mobile/1.0',
+      },
+      body: JSON.stringify({ type: 'event', payload }),
+    }).catch(() => undefined);
+  }
+}

--- a/frontend/mobile/src/infrastructure/analytics/AnalyticsClient.ts
+++ b/frontend/mobile/src/infrastructure/analytics/AnalyticsClient.ts
@@ -86,11 +86,14 @@ export class AnalyticsClient {
   training(context: AnalyticsContext = {}) {
     const timer = createActivityTimer(this.dependencies.now);
     const base = contextData(context);
+    let attempted = false;
     let ended = false;
     const tracker: TrainingTracker = {
       ...timer,
       attempt: () => {
-        if (!ended && validTrainingContext(context)) this.send('training_start_attempt', base);
+        if (ended || attempted || !validTrainingContext(context)) return;
+        attempted = true;
+        this.send('training_start_attempt', base);
       },
       started: () => {
         if (ended || timer.isStarted() || !validTrainingContext(context)) return;
@@ -145,3 +148,5 @@ export class AnalyticsClient {
     }).catch(() => undefined);
   }
 }
+
+export type AnalyticsTrackerFactory = Pick<AnalyticsClient, 'training'>;

--- a/frontend/mobile/src/infrastructure/analytics/__tests__/ActivityTimer.test.ts
+++ b/frontend/mobile/src/infrastructure/analytics/__tests__/ActivityTimer.test.ts
@@ -1,0 +1,21 @@
+import { createActivityTimer } from '../ActivityTimer';
+
+describe('createActivityTimer', () => {
+  it('excludes paused and hidden time from effective duration', () => {
+    let current = 0;
+    const timer = createActivityTimer(() => current);
+
+    timer.start();
+    current = 4_000;
+    timer.pause();
+    current = 14_000;
+    timer.resume();
+    current = 19_000;
+    timer.setVisible(false);
+    current = 29_000;
+    timer.setVisible(true);
+    current = 32_000;
+
+    expect(timer.stop()).toBe(12);
+  });
+});

--- a/frontend/mobile/src/infrastructure/analytics/__tests__/AnalyticsClient.test.ts
+++ b/frontend/mobile/src/infrastructure/analytics/__tests__/AnalyticsClient.test.ts
@@ -73,6 +73,7 @@ describe('AnalyticsClient', () => {
 
     const training = client.training({ mode: 'FREE_CHAT', pageCode: 'conversation' });
     training.attempt();
+    training.attempt();
     training.started();
     current = 7_400;
     training.complete();

--- a/frontend/mobile/src/infrastructure/analytics/__tests__/AnalyticsClient.test.ts
+++ b/frontend/mobile/src/infrastructure/analytics/__tests__/AnalyticsClient.test.ts
@@ -1,0 +1,99 @@
+import { AnalyticsClient } from '../AnalyticsClient';
+
+function createClient() {
+  const calls: { input: RequestInfo | URL; init?: RequestInit }[] = [];
+  const client = new AnalyticsClient(
+    {
+      enabled: true,
+      endpoint: 'https://cloud.umami.is/api/send',
+      websiteId: '3ae2dee9-d585-43a9-93f3-fcafcd14b258',
+      hostname: 'unispeaking.qnsdk.com',
+    },
+    {
+      fetch: jest.fn(async (input, init) => {
+        calls.push({ input, init });
+        return new Response(null, { status: 200 });
+      }),
+      language: () => 'zh-CN',
+      screen: () => '390x844',
+      userAgent: () => 'UniSpeaking-Mobile/1.0 (ios)',
+    },
+  );
+  return { client, calls };
+}
+
+function payload(call: { init?: RequestInit }) {
+  return JSON.parse(String(call.init?.body)).payload;
+}
+
+describe('AnalyticsClient', () => {
+  it('sends Umami events with the shared Website ID and Distinct ID', () => {
+    const { client, calls } = createClient();
+
+    client.setDistinctId('c8ca76c6-ea4b-46e8-aaf1-848d074d54ec');
+    client.trackPageView('/scenes/private-scene/training?stage=speak');
+    client.trackModeSelection({ mode: 'SCENE', pageCode: 'scene-training' });
+
+    expect(calls).toHaveLength(2);
+    expect(payload(calls[0])).toMatchObject({
+      website: '3ae2dee9-d585-43a9-93f3-fcafcd14b258',
+      hostname: 'unispeaking.qnsdk.com',
+      id: 'c8ca76c6-ea4b-46e8-aaf1-848d074d54ec',
+      url: '/scenes/session',
+    });
+    expect(payload(calls[1])).toMatchObject({
+      name: 'mode_selected',
+      data: { mode: 'SCENE', page_code: 'scene-training', source: 'navigation' },
+      url: '/scenes/session',
+    });
+    expect(calls[1].init?.headers).toMatchObject({
+      'Content-Type': 'application/json',
+      'User-Agent': 'UniSpeaking-Mobile/1.0 (ios)',
+    });
+  });
+
+  it('records training lifecycle duration without private identifiers in event data', () => {
+    let current = 0;
+    const calls: { init?: RequestInit }[] = [];
+    const client = new AnalyticsClient(
+      {
+        enabled: true,
+        endpoint: 'https://cloud.umami.is/api/send',
+        websiteId: 'website-id',
+        hostname: 'unispeaking.qnsdk.com',
+      },
+      {
+        fetch: jest.fn(async (_input, init) => {
+          calls.push({ init });
+          return new Response(null, { status: 200 });
+        }),
+        now: () => current,
+      },
+    );
+
+    const training = client.training({ mode: 'FREE_CHAT', pageCode: 'conversation' });
+    training.attempt();
+    training.started();
+    current = 7_400;
+    training.complete();
+
+    expect(calls.map(payload).map(({ name, data }) => ({ name, data }))).toEqual([
+      { name: 'training_start_attempt', data: { mode: 'FREE_CHAT', page_code: 'conversation' } },
+      { name: 'training_started', data: { mode: 'FREE_CHAT', page_code: 'conversation' } },
+      { name: 'training_completed', data: { mode: 'FREE_CHAT', page_code: 'conversation', effective_duration_seconds: 7 } },
+    ]);
+  });
+
+  it('silently ignores analytics when disabled', () => {
+    const fetch = jest.fn();
+    const client = new AnalyticsClient(
+      { enabled: false, endpoint: 'https://cloud.umami.is/api/send', websiteId: '', hostname: 'unispeaking.qnsdk.com' },
+      { fetch },
+    );
+
+    client.trackPageView('/conversation');
+    client.trackModeSelection({ mode: 'FREE_CHAT', pageCode: 'conversation' });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/mobile/src/infrastructure/analytics/__tests__/pageCatalog.test.ts
+++ b/frontend/mobile/src/infrastructure/analytics/__tests__/pageCatalog.test.ts
@@ -1,0 +1,17 @@
+import { normalizeTrackedPath, pageForPath } from '../pageCatalog';
+
+describe('analytics page catalog', () => {
+  it('normalizes mobile routes without dynamic identifiers', () => {
+    expect(normalizeTrackedPath('/conversation/call')).toBe('/conversation/session');
+    expect(normalizeTrackedPath('/scenes/scene-1/training?stage=speak')).toBe('/scenes/session');
+    expect(normalizeTrackedPath('/learning/scenes/private-scene')).toBe('/learning/scenes/detail');
+    expect(normalizeTrackedPath('/profile/help/article/article-1')).toBe('/profile/help/article');
+  });
+
+  it('maps tracked routes to the same stable mode codes as Web analytics', () => {
+    expect(pageForPath('/conversation')).toEqual({ pageCode: 'conversation', mode: 'FREE_CHAT' });
+    expect(pageForPath('/scenes/scene-1/intro')).toEqual({ pageCode: 'scene-training', mode: 'SCENE' });
+    expect(pageForPath('/ielts/assets/record-1')).toEqual({ pageCode: 'ielts-assets', mode: 'IELTS', assetType: 'REPORT' });
+    expect(pageForPath('/interview')).toEqual({ pageCode: 'interview-training', mode: 'INTERVIEW' });
+  });
+});

--- a/frontend/mobile/src/infrastructure/analytics/pageCatalog.ts
+++ b/frontend/mobile/src/infrastructure/analytics/pageCatalog.ts
@@ -1,0 +1,39 @@
+export type TrainingMode = 'SCENE' | 'FREE_CHAT' | 'INTERVIEW' | 'IELTS';
+
+export type AnalyticsPage = Readonly<{
+  pageCode: string;
+  mode?: TrainingMode;
+  assetType?: 'REPORT';
+}>;
+
+const routes: readonly { prefix: string; value: AnalyticsPage }[] = [
+  { prefix: '/conversation', value: { pageCode: 'conversation', mode: 'FREE_CHAT' } },
+  { prefix: '/scenes', value: { pageCode: 'scene-training', mode: 'SCENE' } },
+  { prefix: '/learning/scenes', value: { pageCode: 'scene-assets', mode: 'SCENE', assetType: 'REPORT' } },
+  { prefix: '/learning', value: { pageCode: 'scene-assets', mode: 'SCENE', assetType: 'REPORT' } },
+  { prefix: '/ielts/assets', value: { pageCode: 'ielts-assets', mode: 'IELTS', assetType: 'REPORT' } },
+  { prefix: '/ielts', value: { pageCode: 'ielts-training', mode: 'IELTS' } },
+  { prefix: '/interview/assets', value: { pageCode: 'interview-assets', mode: 'INTERVIEW', assetType: 'REPORT' } },
+  { prefix: '/interview', value: { pageCode: 'interview-training', mode: 'INTERVIEW' } },
+];
+
+export function pageForPath(pathname = '/'): AnalyticsPage {
+  const path = normalizeTrackedPath(pathname);
+  return routes.find(({ prefix }) => path === prefix || path.startsWith(`${prefix}/`))?.value
+    ?? { pageCode: 'other' };
+}
+
+export function normalizeTrackedPath(pathname = '/') {
+  const path = `/${String(pathname).split(/[?#]/, 1)[0].split('/').filter(Boolean).join('/')}`;
+
+  if (/^\/conversation\/call$/.test(path)) return '/conversation/session';
+  if (/^\/scenes\/[^/]+\/intro$/.test(path)) return '/scenes/intro';
+  if (/^\/scenes\/[^/]+\/training$/.test(path)) return '/scenes/session';
+  if (/^\/learning\/scenes\/[^/]+$/.test(path)) return '/learning/scenes/detail';
+  if (/^\/ielts\/assets\/[^/]+$/.test(path)) return '/ielts/assets/detail';
+  if (/^\/interview\/assets\/[^/]+$/.test(path)) return '/interview/assets/detail';
+  if (/^\/profile\/help\/article\/[^/]+$/.test(path)) return '/profile/help/article';
+  if (/^\/profile\/help\/[^/]+$/.test(path)) return '/profile/help/category';
+
+  return path || '/';
+}

--- a/frontend/mobile/src/infrastructure/config/__tests__/runtimeConfig.test.ts
+++ b/frontend/mobile/src/infrastructure/config/__tests__/runtimeConfig.test.ts
@@ -8,12 +8,24 @@ describe('getRuntimeConfig', () => {
       }),
     ).toEqual({
       backendUrl: 'http://127.0.0.1:8080',
+      umami: {
+        enabled: false,
+        endpoint: 'https://cloud.umami.is/api/send',
+        websiteId: '',
+        hostname: 'unispeaking.qnsdk.com',
+      },
     });
   });
 
   it('uses the USB-forwarded Android development URL when no URL is configured', () => {
     expect(getRuntimeConfig({})).toEqual({
       backendUrl: 'http://127.0.0.1:8080',
+      umami: {
+        enabled: false,
+        endpoint: 'https://cloud.umami.is/api/send',
+        websiteId: '',
+        hostname: 'unispeaking.qnsdk.com',
+      },
     });
   });
 
@@ -23,5 +35,23 @@ describe('getRuntimeConfig', () => {
         EXPO_PUBLIC_BACKEND_URL: '/backend',
       }),
     ).toThrow('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
+  });
+
+  it('enables the shared Umami website only with an explicit valid configuration', () => {
+    expect(getRuntimeConfig({
+      EXPO_PUBLIC_UMAMI_ENABLED: 'true',
+      EXPO_PUBLIC_UMAMI_ENDPOINT: 'https://cloud.umami.is/api/send/',
+      EXPO_PUBLIC_UMAMI_WEBSITE_ID: '3ae2dee9-d585-43a9-93f3-fcafcd14b258',
+    }).umami).toEqual({
+      enabled: true,
+      endpoint: 'https://cloud.umami.is/api/send',
+      websiteId: '3ae2dee9-d585-43a9-93f3-fcafcd14b258',
+      hostname: 'unispeaking.qnsdk.com',
+    });
+  });
+
+  it('rejects an enabled Umami configuration without a valid Website ID', () => {
+    expect(() => getRuntimeConfig({ EXPO_PUBLIC_UMAMI_ENABLED: 'true' }))
+      .toThrow('EXPO_PUBLIC_UMAMI_WEBSITE_ID must be a valid Umami Website ID');
   });
 });

--- a/frontend/mobile/src/infrastructure/config/runtimeConfig.ts
+++ b/frontend/mobile/src/infrastructure/config/runtimeConfig.ts
@@ -1,33 +1,72 @@
 export type RuntimeEnvironment = Readonly<{
   EXPO_PUBLIC_BACKEND_URL?: string;
+  EXPO_PUBLIC_UMAMI_ENABLED?: string;
+  EXPO_PUBLIC_UMAMI_ENDPOINT?: string;
+  EXPO_PUBLIC_UMAMI_WEBSITE_ID?: string;
 }>;
 
 export type RuntimeConfig = Readonly<{
   backendUrl: string;
+  umami: Readonly<{
+    enabled: boolean;
+    endpoint: string;
+    websiteId: string;
+    hostname: string;
+  }>;
 }>;
 
 const androidUsbDevelopmentUrl = 'http://127.0.0.1:8080';
+const umamiCloudEndpoint = 'https://cloud.umami.is/api/send';
+const productionHostname = 'unispeaking.qnsdk.com';
+
+function normalizeHttpUrl(value: string, variableName: string) {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(value);
+  } catch {
+    throw new Error(`${variableName} must be an absolute HTTP(S) URL`);
+  }
+
+  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+    throw new Error(`${variableName} must be an absolute HTTP(S) URL`);
+  }
+
+  return value.replace(/\/+$/, '');
+}
+
+function normalizeHttpsUrl(value: string, variableName: string) {
+  const normalized = normalizeHttpUrl(value, variableName);
+  if (!normalized.toLowerCase().startsWith('https://')) {
+    throw new Error(`${variableName} must be an HTTPS URL`);
+  }
+  return normalized;
+}
 
 export function getRuntimeConfig(
   environment: RuntimeEnvironment = {
     EXPO_PUBLIC_BACKEND_URL: process.env.EXPO_PUBLIC_BACKEND_URL,
+    EXPO_PUBLIC_UMAMI_ENABLED: process.env.EXPO_PUBLIC_UMAMI_ENABLED,
+    EXPO_PUBLIC_UMAMI_ENDPOINT: process.env.EXPO_PUBLIC_UMAMI_ENDPOINT,
+    EXPO_PUBLIC_UMAMI_WEBSITE_ID: process.env.EXPO_PUBLIC_UMAMI_WEBSITE_ID,
   },
 ): RuntimeConfig {
   const configuredUrl = environment.EXPO_PUBLIC_BACKEND_URL?.trim();
   const backendUrl = configuredUrl || androidUsbDevelopmentUrl;
+  const umamiEnabled = environment.EXPO_PUBLIC_UMAMI_ENABLED === 'true';
+  const umamiEndpoint = environment.EXPO_PUBLIC_UMAMI_ENDPOINT?.trim() || umamiCloudEndpoint;
+  const umamiWebsiteId = environment.EXPO_PUBLIC_UMAMI_WEBSITE_ID?.trim() || '';
 
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(backendUrl);
-  } catch {
-    throw new Error('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
-  }
-
-  if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
-    throw new Error('EXPO_PUBLIC_BACKEND_URL must be an absolute HTTP(S) URL');
+  if (umamiEnabled && !/^[a-zA-Z0-9-]{8,80}$/.test(umamiWebsiteId)) {
+    throw new Error('EXPO_PUBLIC_UMAMI_WEBSITE_ID must be a valid Umami Website ID');
   }
 
   return {
-    backendUrl: backendUrl.replace(/\/+$/, ''),
+    backendUrl: normalizeHttpUrl(backendUrl, 'EXPO_PUBLIC_BACKEND_URL'),
+    umami: {
+      enabled: umamiEnabled,
+      endpoint: normalizeHttpsUrl(umamiEndpoint, 'EXPO_PUBLIC_UMAMI_ENDPOINT'),
+      websiteId: umamiEnabled ? umamiWebsiteId : '',
+      hostname: productionHostname,
+    },
   };
 }

--- a/frontend/mobile/src/model/AnalyticsProvider.tsx
+++ b/frontend/mobile/src/model/AnalyticsProvider.tsx
@@ -1,0 +1,61 @@
+import { usePathname } from 'expo-router';
+import { createContext, type PropsWithChildren, useContext, useEffect, useMemo } from 'react';
+import { AppState, Dimensions, Platform } from 'react-native';
+
+import { AnalyticsClient } from '@/infrastructure/analytics/AnalyticsClient';
+import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
+
+import { useAppModel } from './AppModel';
+
+export type AnalyticsPort = Pick<
+  AnalyticsClient,
+  'setDistinctId' | 'setAppVisible' | 'trackPageView' | 'trackModeSelection' | 'trackLearningAsset' | 'training'
+>;
+
+const AnalyticsContext = createContext<AnalyticsPort | null>(null);
+
+function createDefaultAnalyticsClient() {
+  const config = getRuntimeConfig().umami;
+  return new AnalyticsClient(config, {
+    fetch: globalThis.fetch.bind(globalThis),
+    language: () => Intl.DateTimeFormat().resolvedOptions().locale || 'zh-CN',
+    screen: () => {
+      const { width, height } = Dimensions.get('screen');
+      return `${Math.round(width)}x${Math.round(height)}`;
+    },
+    userAgent: () => `UniSpeaking-Mobile/1.0 (${Platform.OS})`,
+  });
+}
+
+export function AnalyticsProvider({
+  children,
+  analyticsClient,
+}: PropsWithChildren<{ analyticsClient?: AnalyticsPort }>) {
+  const client = useMemo(() => analyticsClient ?? createDefaultAnalyticsClient(), [analyticsClient]);
+  const pathname = usePathname();
+  const { userId } = useAppModel();
+
+  useEffect(() => {
+    client.setDistinctId(userId);
+  }, [client, userId]);
+
+  useEffect(() => {
+    client.trackPageView(pathname);
+  }, [client, pathname]);
+
+  useEffect(() => {
+    client.setAppVisible(AppState.currentState === 'active');
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      client.setAppVisible(nextState === 'active');
+    });
+    return () => subscription.remove();
+  }, [client]);
+
+  return <AnalyticsContext.Provider value={client}>{children}</AnalyticsContext.Provider>;
+}
+
+export function useAnalytics() {
+  const context = useContext(AnalyticsContext);
+  if (!context) throw new Error('useAnalytics must be used inside AnalyticsProvider');
+  return context;
+}

--- a/frontend/mobile/src/model/AppModel.tsx
+++ b/frontend/mobile/src/model/AppModel.tsx
@@ -43,6 +43,7 @@ export type AppModelAuthController = {
 type AppModelValue = {
   isModelReady: boolean;
   isAuthenticated: boolean;
+  userId: string | null;
   hasCompletedOnboarding: boolean;
   authStatus: AuthSessionState['status'];
   authError: string | null;
@@ -215,6 +216,7 @@ export function AppModelProvider({
     () => ({
       isModelReady,
       isAuthenticated,
+      userId: authState.user?.id ?? null,
       hasCompletedOnboarding,
       authStatus: authState.status,
       authError: authState.error,

--- a/frontend/mobile/src/screens/ConversationScreen.tsx
+++ b/frontend/mobile/src/screens/ConversationScreen.tsx
@@ -27,6 +27,7 @@ import { createTranscriptTranslationApi } from '@/features/conversation/Transcri
 import type { RealtimeTranscriptEntry } from '@/features/realtime/RealtimeSessionController';
 import type { RealtimeState } from '@/features/realtime/types';
 import { useAppModel } from '@/model/AppModel';
+import type { AnalyticsTrackerFactory } from '@/infrastructure/analytics/AnalyticsClient';
 import { colors } from '@/theme/tokens';
 
 function formatDuration(total: number) {
@@ -408,13 +409,17 @@ export function CallExperience({
   );
 }
 
-export function CallScreen({ onEnd }: { onEnd: () => void }) {
+export function CallScreen({ onEnd, analytics }: { onEnd: () => void; analytics?: AnalyticsTrackerFactory }) {
   const { teacher, speed } = useAppModel();
+  const [trainingAnalytics] = useState(() => analytics?.training({
+    mode: 'FREE_CHAT',
+    pageCode: 'conversation',
+  }));
   const session = useFreeChatSession({
     voice: teacher.voiceId,
     model: 'qwen3.5-omni-flash-realtime',
     speechSpeed: speedCodeForLabel(speed),
-  });
+  }, undefined, trainingAnalytics);
   const caption = selectCallCaption(session, teacher.name, session.statusLabel);
   const [translationApi] = useState(createTranscriptTranslationApi);
   const translate = useCallback((text: string) => {

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -827,10 +827,12 @@ function ScenePromptInput({
 
 export function ScenesHome({
   onOpen,
+  onStartScene,
   promptExample = getDailyScenePromptExample(),
   sceneService: injectedSceneService,
 }: {
   onOpen: (route: SceneRoute) => void;
+  onStartScene?: () => void;
   promptExample?: ScenePromptExample;
   sceneService?: Pick<SceneService, 'generate'>;
 }) {
@@ -1040,7 +1042,10 @@ export function ScenesHome({
               </Pressable>
               <Pressable
                 accessibilityRole="button"
-                onPress={() => onOpen({ name: 'training', scene: preview })}
+                onPress={() => {
+                  onStartScene?.();
+                  onOpen({ name: 'training', scene: preview });
+                }}
                 style={[styles.previewButton, styles.previewButtonPrimary]}
               >
                 <Text style={styles.previewButtonPrimaryText}>开始练习</Text>
@@ -1059,11 +1064,13 @@ export function ScenesScreen({
   onSceneViewDetails,
   onOpenIelts,
   onOpenInterview,
+  onStartScene,
 }: {
   onIeltsViewDetails?: (recordId: string) => void;
   onSceneViewDetails?: (sceneId: string) => void;
   onOpenIelts?: () => void;
   onOpenInterview?: () => void;
+  onStartScene?: () => void;
 } = {}) {
   const [route, setRoute] = useState<SceneRoute>({ name: 'home' });
   const openRoute = (nextRoute: SceneRoute) => {
@@ -1085,7 +1092,7 @@ export function ScenesScreen({
   }
   if (route.name === 'ielts') return <IeltsFlow onExit={() => setRoute({ name: 'home' })} onViewDetails={onIeltsViewDetails} />;
   if (route.name === 'interview') return <InterviewFlow onExit={() => setRoute({ name: 'home' })} />;
-  return <ScenesHome onOpen={openRoute} />;
+  return <ScenesHome onOpen={openRoute} onStartScene={onStartScene} />;
 }
 
 const styles = StyleSheet.create({

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -49,6 +49,7 @@ import { getRuntimeConfig } from '@/infrastructure/config/runtimeConfig';
 import { ApiClient } from '@/infrastructure/http/ApiClient';
 import { sceneCategoryForLabel } from '@/data/sceneCategories';
 import { useAppModel } from '@/model/AppModel';
+import type { AnalyticsTrackerFactory } from '@/infrastructure/analytics/AnalyticsClient';
 import { useLearningStage } from '@/navigation/learningStage';
 import { forgetSpecialty } from '@/navigation/specialtyMemory';
 import { createTranscriptTranslationApi } from '@/features/conversation/TranscriptTranslationApi';
@@ -252,14 +253,20 @@ export function SceneCallStage({
   scene,
   progressCollapsed,
   onComplete,
+  analytics,
   createController = createDefaultSceneController,
 }: {
   scene: GeneratedScene;
   progressCollapsed: boolean;
   onComplete: (completion: DialogueCompletion) => void;
+  analytics?: AnalyticsTrackerFactory;
   createController?: SceneControllerFactory;
 }) {
   const { teacher, speed } = useAppModel();
+  const [trainingAnalytics] = useState(() => analytics?.training({
+    mode: 'SCENE',
+    pageCode: 'scene-training',
+  }));
   const deliveredCompletion = useRef<DialogueCompletion | null>(null);
   const autoEnding = useRef(false);
   const [evaluationPending, setEvaluationPending] = useState(false);
@@ -271,6 +278,7 @@ export function SceneCallStage({
       speechSpeed: speedCodeForLabel(speed),
     },
     (config) => createController(scene.sceneId, config),
+    trainingAnalytics,
   );
 
   useEffect(() => {
@@ -321,7 +329,7 @@ export function SceneCallStage({
   );
 }
 
-export function Training({ id, scene, trainingController: injectedTrainingController, wavRecorder: injectedWavRecorder, ttsPlayer: injectedTtsPlayer, initialStage = 'learn', onBack, onFinish, onViewDetails }: { id?: string; scene?: GeneratedScene; trainingController?: SceneTrainingController; wavRecorder?: Pick<WavRecorder, 'start' | 'stop' | 'cancel'>; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'>; initialStage?: TrainingStage; onBack: () => void; onFinish: () => void; onViewDetails?: (id: string) => void }) {
+export function Training({ id, scene, analytics, trainingController: injectedTrainingController, wavRecorder: injectedWavRecorder, ttsPlayer: injectedTtsPlayer, initialStage = 'learn', onBack, onFinish, onViewDetails }: { id?: string; scene?: GeneratedScene; analytics?: AnalyticsTrackerFactory; trainingController?: SceneTrainingController; wavRecorder?: Pick<WavRecorder, 'start' | 'stop' | 'cancel'>; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'>; initialStage?: TrainingStage; onBack: () => void; onFinish: () => void; onViewDetails?: (id: string) => void }) {
   const { setImmersiveLearning } = useLearningStage();
   const sceneId = scene?.sceneId ?? id ?? recommendations[0].id;
   const scenario = scene
@@ -656,6 +664,7 @@ export function Training({ id, scene, trainingController: injectedTrainingContro
         <View style={styles.sceneCallStage}>
           {scene ? (
             <SceneCallStage
+              analytics={analytics}
               scene={scene}
               progressCollapsed={progressCollapsed}
               onComplete={(completion) => {
@@ -1065,12 +1074,14 @@ export function ScenesScreen({
   onOpenIelts,
   onOpenInterview,
   onStartScene,
+  analytics,
 }: {
   onIeltsViewDetails?: (recordId: string) => void;
   onSceneViewDetails?: (sceneId: string) => void;
   onOpenIelts?: () => void;
   onOpenInterview?: () => void;
   onStartScene?: () => void;
+  analytics?: AnalyticsTrackerFactory;
 } = {}) {
   const [route, setRoute] = useState<SceneRoute>({ name: 'home' });
   const openRoute = (nextRoute: SceneRoute) => {
@@ -1088,7 +1099,7 @@ export function ScenesScreen({
     if (route.name === 'home') void forgetSpecialty();
   }, [route.name]);
   if (route.name === 'training') {
-    return <Training scene={route.scene} onBack={() => setRoute({ name: 'home' })} onFinish={() => setRoute({ name: 'home' })} onViewDetails={onSceneViewDetails} />;
+    return <Training analytics={analytics} scene={route.scene} onBack={() => setRoute({ name: 'home' })} onFinish={() => setRoute({ name: 'home' })} onViewDetails={onSceneViewDetails} />;
   }
   if (route.name === 'ielts') return <IeltsFlow onExit={() => setRoute({ name: 'home' })} onViewDetails={onIeltsViewDetails} />;
   if (route.name === 'interview') return <InterviewFlow onExit={() => setRoute({ name: 'home' })} />;

--- a/frontend/mobile/src/screens/SpecialtyFlows.tsx
+++ b/frontend/mobile/src/screens/SpecialtyFlows.tsx
@@ -29,6 +29,7 @@ import { type InterviewSessionApi } from '@/features/interview/InterviewSessionA
 import { createInterviewApi, useInterviewSession } from '@/features/interview/useInterviewSession';
 import { useInterviewPreparation, type InterviewDifficultyOption, type InterviewPreparationResult } from '@/features/interview/useInterviewPreparation';
 import { useAppModel } from '@/model/AppModel';
+import type { AnalyticsTrackerFactory } from '@/infrastructure/analytics/AnalyticsClient';
 import { useLearningStage } from '@/navigation/learningStage';
 import { rememberSpecialty } from '@/navigation/specialtyMemory';
 import { colors, examinerAssets, ieltsAssets, interviewAssets, levels } from '@/theme/tokens';
@@ -106,19 +107,25 @@ function IeltsSession({
   voiceId,
   autoAdvance,
   onFinish,
+  analytics,
 }: {
   examiner: (typeof examiners)[number];
   part: 'p1' | 'p3';
   ieltsId: string;
   voiceId: string;
   autoAdvance: boolean;
+  analytics?: AnalyticsTrackerFactory;
   onFinish: (
     sessionId: string | null,
     ending: Promise<unknown>,
     turnEvaluations: Promise<void>,
   ) => void;
 }) {
-  const session = useIeltsSession({ ieltsId, voiceId, part: toApiPart(part) });
+  const [trainingAnalytics] = useState(() => analytics?.training({
+    mode: 'IELTS',
+    pageCode: 'ielts-training',
+  }));
+  const session = useIeltsSession({ ieltsId, voiceId, part: toApiPart(part) }, trainingAnalytics);
   const partThreeTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const lastInputReadyTick = useRef(0);
   const finishingRef = useRef(false);
@@ -233,18 +240,24 @@ function IeltsPart2Session({
   ieltsId,
   voiceId,
   onFinish,
+  analytics,
 }: {
   examiner: (typeof examiners)[number];
   cueCard: { title: string; points: string[] };
   ieltsId: string;
   voiceId: string;
+  analytics?: AnalyticsTrackerFactory;
   onFinish: (
     sessionId: string | null,
     ending: Promise<unknown>,
     turnEvaluations: Promise<void>,
   ) => void;
 }) {
-  const session = useIeltsSession({ ieltsId, voiceId, part: 'PART_2' });
+  const [trainingAnalytics] = useState(() => analytics?.training({
+    mode: 'IELTS',
+    pageCode: 'ielts-training',
+  }));
+  const session = useIeltsSession({ ieltsId, voiceId, part: 'PART_2' }, trainingAnalytics);
   const [phase, setPhase] = useState<Part2Phase>('INTRODUCTION');
   const [prepRemaining, setPrepRemaining] = useState(60);
   const [longTurnRemaining, setLongTurnRemaining] = useState(120);
@@ -549,7 +562,7 @@ function ReportMetric({ label, value }: { label: string; value: string }) {
   );
 }
 
-export function IeltsFlow({ onExit, onViewDetails }: { onExit: () => void; onViewDetails?: (recordId: string) => void }) {
+export function IeltsFlow({ onExit, onViewDetails, analytics }: { onExit: () => void; onViewDetails?: (recordId: string) => void; analytics?: AnalyticsTrackerFactory }) {
   const { addIeltsRecord, hasCompletedOnboarding, level, saveLevel } = useAppModel();
   const { setImmersiveLearning } = useLearningStage();
   const ielts = useIeltsFlowController();
@@ -1162,6 +1175,7 @@ export function IeltsFlow({ onExit, onViewDetails }: { onExit: () => void; onVie
       const cueCard = resolvePart2CueCard(generatedScene, ielts.training);
       return (
         <IeltsPart2Session
+          analytics={analytics}
           cueCard={cueCard}
           examiner={examiner}
           ieltsId={ieltsId}
@@ -1172,6 +1186,7 @@ export function IeltsFlow({ onExit, onViewDetails }: { onExit: () => void; onVie
     }
     return (
       <IeltsSession
+        analytics={analytics}
         examiner={examiner}
         part={part}
         ieltsId={ieltsId}
@@ -1310,9 +1325,16 @@ const interviewDifficulties: readonly { id: InterviewDifficulty; title: string; 
   { id: 'hard', title: '困难', note: '深入追问' },
 ];
 
-function InterviewSession({ preparation, onFinished }: { preparation: InterviewPreparationResult & { scene: NonNullable<InterviewPreparationResult['scene']> }; onFinished: (sessionId: string, api: InterviewSessionApi) => void }) {
+function InterviewSession({ preparation, onFinished, analytics }: { preparation: InterviewPreparationResult & { scene: NonNullable<InterviewPreparationResult['scene']> }; onFinished: (sessionId: string, api: InterviewSessionApi) => void; analytics?: AnalyticsTrackerFactory }) {
   const { teacher } = useAppModel();
-  const session = useInterviewSession({ sceneId: preparation.scene.sceneId, voice: teacher.voiceId });
+  const [trainingAnalytics] = useState(() => analytics?.training({
+    mode: 'INTERVIEW',
+    pageCode: 'interview-training',
+  }));
+  const session = useInterviewSession(
+    { sceneId: preparation.scene.sceneId, voice: teacher.voiceId },
+    trainingAnalytics,
+  );
   const deliveredSession = useRef<string | null>(null);
 
   useEffect(() => {
@@ -1354,7 +1376,7 @@ function InterviewSession({ preparation, onFinished }: { preparation: InterviewP
   );
 }
 
-export function InterviewFlow({ onExit, onViewDetails, practiceScene }: { onExit: () => void; onViewDetails?: () => void; practiceScene?: { sceneId: string; jobTitle?: string } }) {
+export function InterviewFlow({ onExit, onViewDetails, practiceScene, analytics }: { onExit: () => void; onViewDetails?: () => void; practiceScene?: { sceneId: string; jobTitle?: string }; analytics?: AnalyticsTrackerFactory }) {
   const { setImmersiveLearning } = useLearningStage();
   const [route, setRoute] = useState<InterviewRoute>(practiceScene ? 'live' : 'input');
   const [jobDescription, setJobDescription] = useState('');
@@ -1565,6 +1587,7 @@ export function InterviewFlow({ onExit, onViewDetails, practiceScene }: { onExit
     const livePreparation = preparation as InterviewPreparationResult & { scene: NonNullable<InterviewPreparationResult['scene']> };
     return (
       <InterviewSession
+        analytics={analytics}
         preparation={livePreparation}
         onFinished={(sessionId, api) => {
           setCompletedSession({ sessionId, api });

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -137,12 +137,14 @@ describe('ScenesHome backend generation binding', () => {
 
   it('shows the generated backend preview and opens that exact scene', async () => {
     const onOpen = jest.fn();
+    const onStartScene = jest.fn();
     const sceneService = {
       generate: jest.fn(async () => scene),
     };
     const screen = await render(
       <ScenesHome
         onOpen={onOpen}
+        onStartScene={onStartScene}
         promptExample={{ id: 'airport', prompt: '机场托运行李' }}
         sceneService={sceneService}
       />,
@@ -161,6 +163,7 @@ describe('ScenesHome backend generation binding', () => {
     expect(screen.getByText('你将扮演')).toBeTruthy();
     expect(screen.getByText('乘客')).toBeTruthy();
     await fireEvent.press(screen.getByText('开始练习'));
+    expect(onStartScene).toHaveBeenCalledTimes(1);
     expect(onOpen).toHaveBeenCalledWith({ name: 'training', scene });
   });
 

--- a/frontend/web/scripts/check-analytics-client.mjs
+++ b/frontend/web/scripts/check-analytics-client.mjs
@@ -7,7 +7,19 @@ import { pageForPath } from '../src/analytics/pageCatalog.js'
 
 function recorder() {
   const events = []
-  return { events, tracker: { track: (name, data) => events.push({ name, data }) } }
+  const identities = []
+  return {
+    events,
+    identities,
+    tracker: {
+      identify: (id) => identities.push(id),
+      track: (payload) => events.push(payload({
+        hostname: 'unispeaking.qnsdk.com',
+        title: 'Initial title',
+        url: '/initial/private-path',
+      })),
+    },
+  }
 }
 
 function eventTargetRecorder() {
@@ -31,6 +43,7 @@ test('queues the initial page view until the Umami tracker is ready', () => {
     enabled: true,
     tracker: () => tracker,
     eventTarget,
+    schedule: () => undefined,
   })
 
   client.trackPageView('/conversation/private-session')
@@ -38,15 +51,18 @@ test('queues the initial page view until the Umami tracker is ready', () => {
   assert.deepEqual(calls, [])
 
   tracker = { track: (...args) => calls.push(args) }
-  eventTarget.dispatch('umami:loaded')
+  eventTarget.dispatch('load')
 
   assert.equal(calls.length, 2)
   assert.equal(typeof calls[0][0], 'function')
-  assert.deepEqual(calls[1], ['mode_selected', {
-    mode: 'FREE_CHAT',
-    page_code: 'conversation',
-    source: 'sidebar',
-  }])
+  assert.equal(typeof calls[1][0], 'function')
+  assert.deepEqual(calls[1][0]({ url: '/private' }), {
+    url: '/conversation/session',
+    id: undefined,
+    name: 'mode_selected',
+    data: { mode: 'FREE_CHAT', page_code: 'conversation', source: 'sidebar' },
+    title: 'UniSpeaking',
+  })
 })
 
 test('tracks only approved primitive mode-selection properties', () => {
@@ -61,8 +77,12 @@ test('tracks only approved primitive mode-selection properties', () => {
   }, 'main_navigation')
 
   assert.deepEqual(events, [{
+    hostname: 'unispeaking.qnsdk.com',
+    id: undefined,
     name: 'mode_selected',
     data: { mode: 'INTERVIEW', page_code: 'interview-training', source: 'main_navigation' },
+    title: 'UniSpeaking',
+    url: '/',
   }])
 })
 
@@ -101,7 +121,7 @@ test('emits terminal training duration without heartbeat or identifiers', () => 
   training.heartbeat()
   training.complete({ transcript: 'private-transcript' })
 
-  assert.deepEqual(events, [
+  assert.deepEqual(events.map(({ name, data }) => ({ name, data })), [
     { name: 'training_start_attempt', data: { mode: 'FREE_CHAT', page_code: 'conversation' } },
     { name: 'training_started', data: { mode: 'FREE_CHAT', page_code: 'conversation' } },
     { name: 'training_completed', data: { mode: 'FREE_CHAT', page_code: 'conversation', effective_duration_seconds: 7 } },
@@ -135,10 +155,35 @@ test('tracks learning assets separately from training modes', () => {
   const { events, tracker } = recorder()
   const client = createAnalyticsClient({ enabled: true, tracker: () => tracker })
   client.trackLearningAsset({ pageCode: 'interview-assets', mode: 'INTERVIEW' }, 'REPORT')
-  assert.deepEqual(events, [{
+  assert.deepEqual(events.map(({ name, data }) => ({ name, data })), [{
     name: 'learning_asset_view',
     data: { mode: 'INTERVIEW', page_code: 'interview-assets', asset_type: 'REPORT' },
   }])
+})
+
+test('uses and clears the authenticated user UUID as the Umami Distinct ID', () => {
+  const { events, identities, tracker } = recorder()
+  const client = createAnalyticsClient({ enabled: true, tracker: () => tracker })
+
+  client.setDistinctId('c8ca76c6-ea4b-46e8-aaf1-848d074d54ec')
+  client.trackModeSelection({ mode: 'SCENE', pageCode: 'scene-training' })
+  client.setDistinctId(null)
+  client.trackModeSelection({ mode: 'FREE_CHAT', pageCode: 'conversation' })
+
+  assert.deepEqual(identities, ['c8ca76c6-ea4b-46e8-aaf1-848d074d54ec', ''])
+  assert.equal(events[0].id, 'c8ca76c6-ea4b-46e8-aaf1-848d074d54ec')
+  assert.equal(events[1].id, undefined)
+})
+
+test('attributes custom events to the latest normalized page URL', () => {
+  const { events, tracker } = recorder()
+  const client = createAnalyticsClient({ enabled: true, tracker: () => tracker })
+
+  client.trackPageView('/scenes/private-scene/session/private-session')
+  client.trackModeSelection({ mode: 'SCENE', pageCode: 'scene-training' })
+
+  assert.equal(events[1].url, '/scenes/session')
+  assert.equal(events[1].name, 'mode_selected')
 })
 
 test('reports page views with normalized paths and without route identifiers or query strings', () => {
@@ -161,7 +206,7 @@ test('reports page views with normalized paths and without route identifiers or 
     title: 'Private title',
     url: '/private/path?token=private',
     website: 'public-website-id',
-  })), [
+  })).map(({ id: _id, ...payload }) => payload), [
     {
       hostname: 'unispeaking.qnsdk.com',
       language: 'zh-CN',

--- a/frontend/web/scripts/check-analytics-wiring.mjs
+++ b/frontend/web/scripts/check-analytics-wiring.mjs
@@ -52,6 +52,10 @@ test("explicit mode choices and learning asset opens are instrumented without cu
   assert.doesNotMatch(interviewSource, /track\(["']page_view["']/);
 });
 
+test("authenticated web sessions set and clear the shared Umami Distinct ID", () => {
+  assert.match(appSource, /analytics\.setDistinctId\(user\?\.id \|\| null\)/);
+});
+
 test("IELTS ignores a late realtime start after the session effect was cleaned up", () => {
   assert.match(ieltsSource, /\.then\(\(started\) => \{\s+if \(cancelled\) return;/);
 });

--- a/frontend/web/src/analytics/analyticsClient.js
+++ b/frontend/web/src/analytics/analyticsClient.js
@@ -20,18 +20,35 @@ export function createAnalyticsClient(options = {}) {
   const enabled = options.enabled ?? false
   const tracker = options.tracker || (() => globalThis.window?.umami)
   const eventTarget = options.eventTarget || globalThis.window
+  const schedule = options.schedule || ((callback) => globalThis.setTimeout(callback, 100))
   const now = options.now || (() => Date.now())
   const pending = []
+  let flushScheduled = false
+  let remainingFlushAttempts = 50
+  let distinctId = null
+  let currentUrl = normalizeTrackedPath(options.initialPath || globalThis.window?.location?.pathname || '/')
+
+  function scheduleFlush() {
+    if (flushScheduled || remainingFlushAttempts <= 0) return
+    flushScheduled = true
+    const timer = schedule(() => {
+      flushScheduled = false
+      remainingFlushAttempts -= 1
+      flushPending()
+      if (pending.length > 0) scheduleFlush()
+    })
+    timer?.unref?.()
+  }
 
   function dispatch(send) {
     if (!enabled) return
     try {
       const instance = tracker()
-      if (typeof instance?.track === 'function') {
-        send(instance)
+      if (send(instance)) {
         return
       }
       if (pending.length < 50) pending.push(send)
+      scheduleFlush()
     } catch {
       // Analytics must never block product behavior.
     }
@@ -44,18 +61,32 @@ export function createAnalyticsClient(options = {}) {
     } catch {
       return
     }
-    if (typeof instance?.track !== 'function') return
     pending.splice(0).forEach((send) => {
-      try { send(instance) } catch { /* One event must not block the remaining queue. */ }
+      try {
+        if (!send(instance)) pending.push(send)
+      } catch { /* One event must not block the remaining queue. */ }
     })
   }
 
   if (enabled && typeof eventTarget?.addEventListener === 'function') {
-    eventTarget.addEventListener('umami:loaded', flushPending, { once: true })
+    eventTarget.addEventListener('load', flushPending, { once: true })
   }
 
   function emit(name, data = {}) {
-    dispatch((instance) => instance.track(name, safeData(data)))
+    const eventDistinctId = distinctId
+    const eventUrl = currentUrl
+    dispatch((instance) => {
+      if (typeof instance?.track !== 'function') return false
+      instance.track((properties) => ({
+        ...properties,
+        id: eventDistinctId || undefined,
+        name,
+        data: safeData(data),
+        title: 'UniSpeaking',
+        url: eventUrl,
+      }))
+      return true
+    })
   }
 
   function validTrainingContext(context = {}) {
@@ -101,9 +132,33 @@ export function createAnalyticsClient(options = {}) {
 
   return {
     training,
+    setDistinctId(value) {
+      const nextDistinctId = typeof value === 'string' && value.length > 0 && value.length <= 50
+        ? value
+        : null
+      if (nextDistinctId === distinctId) return
+      distinctId = nextDistinctId
+      const identity = distinctId
+      dispatch((instance) => {
+        if (typeof instance?.identify !== 'function') return false
+        instance.identify(identity || '')
+        return true
+      })
+    },
     trackPageView(pathname = '/') {
-      const url = normalizeTrackedPath(pathname)
-      dispatch((instance) => instance.track((properties) => ({ ...properties, url, title: 'UniSpeaking' })))
+      currentUrl = normalizeTrackedPath(pathname)
+      const pageDistinctId = distinctId
+      const pageUrl = currentUrl
+      dispatch((instance) => {
+        if (typeof instance?.track !== 'function') return false
+        instance.track((properties) => ({
+          ...properties,
+          id: pageDistinctId || undefined,
+          url: pageUrl,
+          title: 'UniSpeaking',
+        }))
+        return true
+      })
     },
     trackModeSelection(context = {}, source = 'navigation') {
       if (validTrainingContext(context)) emit('mode_selected', { ...contextData(context), source })

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2901,6 +2901,10 @@ export function App() {
   }, []);
 
   useEffect(() => {
+    analytics.setDistinctId(user?.id || null);
+  }, [user?.id]);
+
+  useEffect(() => {
     let cancelled = false;
     const bootstrapAuth = async () => {
       const bootstrapToken = getAccessToken();


### PR DESCRIPTION
## 变更说明

支持 Web 与移动端使用统一的 Umami Website ID 和登录用户 UUID，形成跨端用户旅程。

### Web

- 使用登录用户 UUID 设置 Umami Distinct ID
- 修复 SPA 页面切换后自定义事件的页面归因
- 增加 tracker 延迟加载期间的事件队列
- 补充 analytics 客户端和接线检查

### 移动端

- 新增 Umami `/api/send` 统计客户端
- 新增全局 AnalyticsProvider
- 支持页面路径归一化和 Page View 上报
- 支持模式选择和学习资产查看事件
- 支持 SCENE、FREE_CHAT、INTERVIEW、IELTS 四类训练生命周期监控
- 支持训练开始尝试、开始成功、开始失败、完成和中途退出事件
- 统计有效训练时长，排除暂停及 App 后台时间

### 隐私与用户标识

- Web 与移动端均使用登录用户 UUID 关联跨端行为
- 不上报邮箱、昵称、JWT、对话文本、音频、简历或岗位描述

### 移动端配置

移动端统计默认关闭，构建环境需要配置：

EXPO_PUBLIC_UMAMI_ENABLED=true
EXPO_PUBLIC_UMAMI_ENDPOINT=https://cloud.umami.is/api/send
EXPO_PUBLIC_UMAMI_WEBSITE_ID=3ae2dee9-d585-43a9-93f3-fcafcd14b258

### 验证结果

- 移动端 Jest：44 个测试套件、207 项测试通过
- 移动端 TypeScript 检查通过
- Expo Android export 成功
- Web analytics 检查：24/24 通过
- Web 生产构建通过
- ESLint 无新增错误