### PR TITLE
feat(assets): implement learning asset deletion

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/controller/CustomSceneController.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/controller/CustomSceneController.java
@@ -37,6 +37,7 @@ import java.util.List;
 import org.springframework.http.CacheControl;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -181,6 +182,12 @@ public class CustomSceneController {
 	public ApiResponse<LearningAssetDetail> getLearningAsset(
 			@PathVariable String sceneId) {
 		return ApiResponse.success(learningAssetService.getAsset(sceneId));
+	}
+
+	@DeleteMapping("/{sceneId}/assets")
+	public ApiResponse<Void> deleteLearningAsset(@PathVariable String sceneId) {
+		learningAssetService.deleteAsset(sceneId);
+		return ApiResponse.success(null);
 	}
 
 	@GetMapping("/{sceneId}/sessions/{sessionId}/state")

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisSceneRepository.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisSceneRepository.java
@@ -1,6 +1,7 @@
 package com.unispeaking.infrastructure.persistence.repository.scene;
 
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.unispeaking.domain.dto.scene.LearningContentItem;
 import com.unispeaking.domain.dto.scene.SceneGenerationResponse;
 import com.unispeaking.domain.po.scene.CustomSceneDefinition;
@@ -17,6 +18,7 @@ import com.unispeaking.infrastructure.persistence.mapper.scene.ScenePhraseMapper
 import com.unispeaking.infrastructure.persistence.mapper.scene.SceneSentenceMapper;
 import com.unispeaking.infrastructure.persistence.mapper.scene.SceneWordMapper;
 import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -119,6 +121,24 @@ public class MybatisSceneRepository implements SceneRepository {
 						scene.getCreatedAt(),
 						scene.getUpdatedAt()))
 				.toList();
+	}
+
+	@Override
+	public boolean softDelete(String sceneId, String userId) {
+		UUID ownerId;
+		try {
+			ownerId = UUID.fromString(userId);
+		}
+		catch (IllegalArgumentException exception) {
+			return false;
+		}
+		return sceneMapper.update(
+				null,
+				new LambdaUpdateWrapper<SceneEntity>()
+						.eq(SceneEntity::getId, sceneId)
+						.eq(SceneEntity::getUserId, ownerId)
+						.isNull(SceneEntity::getDeletedAt)
+						.set(SceneEntity::getDeletedAt, OffsetDateTime.now())) == 1;
 	}
 
 	@Override

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/scene/SceneRepository.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/scene/SceneRepository.java
@@ -16,6 +16,7 @@ public interface SceneRepository {
 	Optional<SceneGenerationResponse> findGeneratedById(String sceneId);
 	Optional<CustomSceneDefinition> findCustomDefinitionById(String sceneId);
 	List<SceneAssetSnapshot> findAssetsByUserId(String userId);
+	boolean softDelete(String sceneId, String userId);
 	long countActiveByUserId(String userId);
 	long countAllByUserId(String userId);
 	List<String> findAllIdsByUserId(String userId);

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/asset/LearningAssetService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/asset/LearningAssetService.java
@@ -13,6 +13,9 @@ public interface LearningAssetService {
 	/** Returns the complete learning asset for a scene. */
 	LearningAssetDetail getAsset(String sceneId);
 
+	/** Removes a learning asset owned by the current user. */
+	void deleteAsset(String sceneId);
+
 	/** Returns the evaluation report for a scene session. */
 	DialogueReportResult getReport(String sceneId, String sessionId);
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/asset/impl/LearningAssetServiceImpl.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/asset/impl/LearningAssetServiceImpl.java
@@ -71,6 +71,16 @@ public class LearningAssetServiceImpl implements LearningAssetService {
 	}
 
 	@Override
+	public void deleteAsset(String sceneId) {
+		CustomSceneDefinition scene = requireOwnedScene(sceneId);
+		if (!sceneRepository.softDelete(sceneId, scene.userId())) {
+			throw new BusinessException(
+					"LEARNING_ASSET_NOT_FOUND",
+					"学习资产不存在");
+		}
+	}
+
+	@Override
 	public DialogueReportResult getReport(
 			String sceneId,
 			String sessionId) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneCompletionEndpointTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneCompletionEndpointTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -24,6 +25,24 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 class CustomSceneCompletionEndpointTest {
+
+	@Test
+	void deletesLearningAssetThroughItsAssetEndpoint() throws Exception {
+		LearningAssetService assets = mock(LearningAssetService.class);
+		CustomSceneController controller = new CustomSceneController(
+				mock(CustomSceneService.class),
+				mock(CustomSceneFlowService.class),
+				mock(CustomEvaluationService.class),
+				mock(CustomSessionService.class),
+				assets);
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller).build();
+
+		mvc.perform(delete("/api/custom-scenes/custom_2001/assets"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+
+		verify(assets).deleteAsset("custom_2001");
+	}
 
 	@Test
 	void activeHangupReturnsPersistedFiveDimensionReport() throws Exception {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisSceneRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisSceneRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.infrastructure.persistence.repository.scene;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -122,6 +123,20 @@ class MybatisSceneRepositoryTest {
 
 		assertEquals(3, count);
 		verify(sceneMapper).selectCount(any());
+	}
+
+	@Test
+	void softDeletesOnlyAnActiveOwnedScene() {
+		SceneMapper sceneMapper = mock(SceneMapper.class);
+		when(sceneMapper.update(any(), any())).thenReturn(1);
+		MybatisSceneRepository repository = repository(sceneMapper);
+
+		assertTrue(repository.softDelete(
+				"custom_1",
+				"11111111-1111-4111-8111-111111111111"));
+		assertFalse(repository.softDelete("custom_1", "invalid-user-id"));
+
+		verify(sceneMapper).update(any(), any());
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/asset/LearningAssetServiceImplTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/asset/LearningAssetServiceImplTest.java
@@ -1,9 +1,13 @@
 package com.unispeaking.service.asset;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.dto.asset.SessionEvaluationRecord;
 import com.unispeaking.domain.dto.evaluation.DialogueEvaluationResult;
 import com.unispeaking.domain.dto.evaluation.DialogueReportResult;
@@ -23,6 +27,45 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class LearningAssetServiceImplTest {
+
+	@Test
+	void deletesOnlyAnAssetOwnedByTheCurrentUser() {
+		String userId = "f3cc4bdf-8db1-48b4-b504-d31375e1eb68";
+		String sceneId = "custom_2001";
+		AuthService authService = mock(AuthService.class);
+		SceneRepository sceneRepository = mock(SceneRepository.class);
+		CustomSceneDefinition scene = scene(sceneId, userId);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(sceneRepository.findCustomDefinitionById(sceneId))
+				.thenReturn(Optional.of(scene));
+		when(sceneRepository.softDelete(sceneId, userId)).thenReturn(true);
+		LearningAssetService service = service(authService, sceneRepository);
+
+		service.deleteAsset(sceneId);
+
+		verify(sceneRepository).softDelete(sceneId, userId);
+	}
+
+	@Test
+	void rejectsDeletingAnotherUsersAsset() {
+		String userId = "f3cc4bdf-8db1-48b4-b504-d31375e1eb68";
+		String sceneId = "custom_2001";
+		AuthService authService = mock(AuthService.class);
+		SceneRepository sceneRepository = mock(SceneRepository.class);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(sceneRepository.findCustomDefinitionById(sceneId))
+				.thenReturn(Optional.of(scene(
+						sceneId,
+						"11111111-1111-4111-8111-111111111111")));
+		LearningAssetService service = service(authService, sceneRepository);
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> service.deleteAsset(sceneId));
+
+		assertEquals("LEARNING_ASSET_ACCESS_DENIED", exception.code());
+		verify(sceneRepository, never()).softDelete(sceneId, userId);
+	}
 
 	@Test
 	void loadsSceneContentLatestDialogueAndReportHistory() {
@@ -99,5 +142,32 @@ class LearningAssetServiceImplTest {
 		assertEquals(
 				report,
 				service.getAsset(sceneId).latestReport());
+	}
+
+	private LearningAssetService service(
+			AuthService authService,
+			SceneRepository sceneRepository) {
+		return new LearningAssetServiceImpl(
+				authService,
+				sceneRepository,
+				mock(SessionEvaluationRepository.class),
+				mock(CustomEvaluationService.class));
+	}
+
+	private CustomSceneDefinition scene(String sceneId, String userId) {
+		return new CustomSceneDefinition(
+				sceneId,
+				userId,
+				"咖啡店点单",
+				"餐饮",
+				"在咖啡店完成点单",
+				"咖啡店店员",
+				"顾客",
+				"完成一杯咖啡的点单",
+				"简短自然",
+				"{\"stop_when\":\"order confirmed\"}",
+				List.of(),
+				List.of(),
+				List.of());
 	}
 }

--- a/frontend/mobile/src/features/scenes/LearningAssetService.ts
+++ b/frontend/mobile/src/features/scenes/LearningAssetService.ts
@@ -164,6 +164,13 @@ export class LearningAssetService {
     };
   }
 
+  async deleteRecord(sceneId: string): Promise<void> {
+    await this.client.request(
+      `/api/custom-scenes/${encodeURIComponent(sceneId)}/assets`,
+      { method: 'DELETE' },
+    );
+  }
+
   async getScene(sceneId: string): Promise<GeneratedScene> {
     const value = await this.getDetail(sceneId);
     return {

--- a/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
@@ -164,6 +164,18 @@ describe('LearningAssetService', () => {
     );
   });
 
+  it('deletes an encoded learning asset through the authenticated endpoint', async () => {
+    const client = createClient([null]);
+    const service = new LearningAssetService(client);
+
+    await expect(service.deleteRecord('scene/airport')).resolves.toBeUndefined();
+
+    expect(client.request).toHaveBeenCalledWith(
+      '/api/custom-scenes/scene%2Fairport/assets',
+      { method: 'DELETE' },
+    );
+  });
+
   it('restores the complete generated scene needed by backend repractice', async () => {
     const client = createClient([detail]);
     const service = new LearningAssetService(client);

--- a/frontend/mobile/src/screens/AssetsScreen.tsx
+++ b/frontend/mobile/src/screens/AssetsScreen.tsx
@@ -21,7 +21,7 @@ import { colors } from '@/theme/tokens';
 
 type LearningAssetServicePort = Pick<
   LearningAssetService,
-  'listRecords' | 'getRecord'
+  'listRecords' | 'getRecord' | 'deleteRecord'
 >;
 
 function createLearningAssetService(): LearningAssetService {
@@ -208,9 +208,11 @@ function ConversationThread({ record }: { record: SceneLearningRecord }) {
   );
 }
 
-export function SceneAssetDetail({ record, onBack, onPractice, onDelete, ttsPlayer: injectedTtsPlayer }: { record: SceneLearningRecord; onBack: () => void; onPractice: () => void; onDelete: () => void; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'> }) {
+export function SceneAssetDetail({ record, onBack, onPractice, onDelete, ttsPlayer: injectedTtsPlayer }: { record: SceneLearningRecord; onBack: () => void; onPractice: () => void; onDelete: () => void | Promise<void>; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'> }) {
   const [view, setView] = useState<'expressions' | 'conversation'>('expressions');
   const [confirmDelete, setConfirmDelete] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [playingExpressionId, setPlayingExpressionId] = useState<string | null>(null);
   const [audioError, setAudioError] = useState<string | null>(null);
   const [ttsPlayer] = useState<Pick<TtsPlayer, 'play' | 'stop'>>(
@@ -235,6 +237,31 @@ export function SceneAssetDetail({ record, onBack, onPractice, onDelete, ttsPlay
       setAudioError(error instanceof Error ? error.message : '发音播放失败');
     }
   };
+
+  const openDeleteConfirmation = () => {
+    setDeleteError(null);
+    setConfirmDelete(true);
+  };
+
+  const closeDeleteConfirmation = () => {
+    if (deleting) return;
+    setConfirmDelete(false);
+  };
+
+  const deleteRecord = async () => {
+    if (deleting) return;
+    setDeleting(true);
+    setDeleteError(null);
+    try {
+      await onDelete();
+      setConfirmDelete(false);
+    } catch (cause) {
+      setDeleteError(cause instanceof Error ? cause.message : '学习资产删除失败，请稍后重试');
+    } finally {
+      setDeleting(false);
+    }
+  };
+
   return (
     <>
       <AppScreen
@@ -243,7 +270,7 @@ export function SceneAssetDetail({ record, onBack, onPractice, onDelete, ttsPlay
             fixed
             onBack={onBack}
             title="详情"
-            action={<HeaderIconButton icon="delete" accessibilityLabel="删除当前学习资产" onPress={() => setConfirmDelete(true)} color={colors.muted} />}
+            action={<HeaderIconButton icon="delete" accessibilityLabel="删除当前学习资产" onPress={openDeleteConfirmation} color={colors.muted} />}
           />
         }
       >
@@ -264,15 +291,16 @@ export function SceneAssetDetail({ record, onBack, onPractice, onDelete, ttsPlay
           </Card>
         ) : <ConversationThread record={record} />}
       </AppScreen>
-      <Modal transparent visible={confirmDelete} animationType="fade" onRequestClose={() => setConfirmDelete(false)}>
+      <Modal transparent visible={confirmDelete} animationType="fade" onRequestClose={closeDeleteConfirmation}>
         <View style={styles.confirmRoot}>
-          <Pressable style={styles.confirmBackdrop} onPress={() => setConfirmDelete(false)} />
+          <Pressable disabled={deleting} style={styles.confirmBackdrop} onPress={closeDeleteConfirmation} />
           <View style={styles.confirmCard}>
             <Text style={styles.confirmTitle}>删除当前学习资产？</Text>
             <Text style={styles.confirmCopy}>这条场景记录、最近对话和评分将一起删除，且无法恢复。</Text>
+            {deleteError ? <Text accessibilityRole="alert" style={styles.deleteError}>{deleteError}</Text> : null}
             <View style={styles.confirmActions}>
-              <AppButton title="取消" variant="secondary" onPress={() => setConfirmDelete(false)} style={styles.flex} />
-              <AppButton title="确认删除" variant="danger" onPress={onDelete} style={styles.flex} />
+              <AppButton title="取消" variant="secondary" disabled={deleting} onPress={closeDeleteConfirmation} style={styles.flex} />
+              <AppButton title={deleting ? '正在删除…' : '确认删除'} variant="danger" disabled={deleting} onPress={() => void deleteRecord()} style={styles.flex} />
             </View>
           </View>
         </View>
@@ -332,7 +360,10 @@ export function SceneAssetDetailLoader({
         record={record}
         onBack={onBack}
         onPractice={onPractice}
-        onDelete={onDelete}
+        onDelete={async () => {
+          await assetService.deleteRecord(sceneId);
+          onDelete();
+        }}
         ttsPlayer={ttsPlayer}
       />
     );
@@ -405,5 +436,6 @@ const styles = StyleSheet.create({
   confirmCard: { padding: 22, gap: 11, borderRadius: 20, backgroundColor: colors.white },
   confirmTitle: { color: colors.ink, fontSize: 22, fontWeight: '600' },
   confirmCopy: { color: colors.muted, fontSize: 13, lineHeight: 20, fontWeight: '300' },
+  deleteError: { color: '#B94D44', fontSize: 12, lineHeight: 18 },
   confirmActions: { marginTop: 10, flexDirection: 'row', gap: 10 },
 });

--- a/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
@@ -38,6 +38,7 @@ describe('AssetsScreen backend binding', () => {
     const service = {
       listRecords: jest.fn(() => recordsPromise),
       getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
     };
     const screen = await render(
       <AssetsScreen
@@ -62,6 +63,7 @@ describe('AssetsScreen backend binding', () => {
         throw new Error('资产服务暂时不可用');
       }),
       getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
     };
     const screen = await render(
       <AssetsScreen
@@ -83,6 +85,7 @@ describe('SceneAssetDetailLoader', () => {
     const service = {
       listRecords: jest.fn(async () => []),
       getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
     };
     const screen = await render(
       <SceneAssetDetailLoader
@@ -115,5 +118,77 @@ describe('SceneAssetDetailLoader', () => {
     expect(ttsPlayer.play).toHaveBeenCalledWith(detailRecord.id, 'baggage');
     await fireEvent.press(screen.getByLabelText('停止播放 baggage'));
     expect(ttsPlayer.stop).toHaveBeenCalled();
+  });
+
+  it('waits for backend deletion before dismissing the confirmation', async () => {
+    let resolveDelete: () => void = () => undefined;
+    const deletePromise = new Promise<void>((resolve) => {
+      resolveDelete = resolve;
+    });
+    const onDelete = jest.fn(() => deletePromise);
+    const screen = await render(
+      <SceneAssetDetail
+        record={detailRecord}
+        onBack={jest.fn()}
+        onPractice={jest.fn()}
+        onDelete={onDelete}
+        ttsPlayer={{ play: jest.fn(), stop: jest.fn() }}
+      />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('删除当前学习资产'));
+    await fireEvent.press(screen.getByText('确认删除'));
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(screen.getByText('正在删除…')).toBeTruthy();
+    resolveDelete();
+    await waitFor(() => expect(screen.queryByText('删除当前学习资产？')).toBeNull());
+  });
+
+  it('keeps the confirmation open and shows backend deletion failures', async () => {
+    const screen = await render(
+      <SceneAssetDetail
+        record={detailRecord}
+        onBack={jest.fn()}
+        onPractice={jest.fn()}
+        onDelete={jest.fn(async () => {
+          throw new Error('删除服务暂时不可用');
+        })}
+        ttsPlayer={{ play: jest.fn(), stop: jest.fn() }}
+      />,
+    );
+
+    await fireEvent.press(screen.getByLabelText('删除当前学习资产'));
+    await fireEvent.press(screen.getByText('确认删除'));
+
+    await waitFor(() => expect(screen.getByText('删除服务暂时不可用')).toBeTruthy());
+    expect(screen.getByText('删除当前学习资产？')).toBeTruthy();
+    expect(screen.getByText('确认删除')).toBeTruthy();
+  });
+
+  it('deletes through the loader service before navigating back', async () => {
+    const service = {
+      listRecords: jest.fn(async () => []),
+      getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
+    };
+    const onDelete = jest.fn();
+    const screen = await render(
+      <SceneAssetDetailLoader
+        assetService={service}
+        sceneId="scene/airport"
+        onBack={jest.fn()}
+        onPractice={jest.fn()}
+        onDelete={onDelete}
+        ttsPlayer={{ play: jest.fn(), stop: jest.fn() }}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByText('baggage')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('删除当前学习资产'));
+    await fireEvent.press(screen.getByText('确认删除'));
+
+    await waitFor(() => expect(onDelete).toHaveBeenCalledTimes(1));
+    expect(service.deleteRecord).toHaveBeenCalledWith('scene/airport');
   });
 });

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -8,6 +8,7 @@
     "build": "vite build",
     "test:auth": "node --test scripts/check-auth-contract.mjs scripts/check-captcha-config.mjs scripts/check-api-client-auth.mjs",
     "test:analytics": "node --test scripts/check-umami-config.mjs scripts/check-analytics-client.mjs scripts/check-analytics-wiring.mjs",
+    "test:assets": "node --test scripts/check-learning-asset-deletion.mjs",
     "check:feedback-invitation": "node scripts/check-feedback-invitation.mjs",
     "check:realtime-events": "node scripts/check-realtime-events.mjs",
     "check:routes": "node scripts/check-routes.mjs",

--- a/frontend/web/scripts/check-learning-asset-deletion.mjs
+++ b/frontend/web/scripts/check-learning-asset-deletion.mjs
@@ -1,0 +1,41 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { deleteLearningAsset } from "../src/infrastructure/http/apiClient.js";
+
+test("learning asset deletion uses the authenticated DELETE endpoint", async () => {
+  const previousWindow = globalThis.window;
+  const previousFetch = globalThis.fetch;
+  const requests = [];
+  globalThis.window = {
+    localStorage: {
+      getItem: () => "asset-token",
+      removeItem: () => {},
+    },
+  };
+  globalThis.fetch = async (url, options) => {
+    requests.push({ url, options });
+    return new Response(JSON.stringify({ success: true, data: null }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  };
+
+  try {
+    await deleteLearningAsset("custom/a b");
+    assert.equal(requests[0].url, "/api/custom-scenes/custom%2Fa%20b/assets");
+    assert.equal(requests[0].options.method, "DELETE");
+    assert.equal(requests[0].options.headers.Authorization, "Bearer asset-token");
+  } finally {
+    globalThis.window = previousWindow;
+    globalThis.fetch = previousFetch;
+  }
+});
+
+test("asset screen waits for deletion and handles success and failure", async () => {
+  const appSource = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
+  assert.match(appSource, /await deleteLearningAsset\(deletedSceneId\)/);
+  assert.match(appSource, /setRecords\(\(current\) => current\.filter/);
+  assert.match(appSource, /setDeleteError\(error instanceof Error/);
+  assert.match(appSource, /deleting \? "正在删除" : "确认删除"/);
+});

--- a/frontend/web/scripts/check-learning-asset-deletion.mjs
+++ b/frontend/web/scripts/check-learning-asset-deletion.mjs
@@ -39,3 +39,13 @@ test("asset screen waits for deletion and handles success and failure", async ()
   assert.match(appSource, /setDeleteError\(error instanceof Error/);
   assert.match(appSource, /deleting \? "正在删除" : "确认删除"/);
 });
+
+test("unfinished learning assets open their detail and restart the full flow", async () => {
+  const appSource = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
+  assert.doesNotMatch(appSource, /disabled=\{!selected\.latestSessionId\}/);
+  assert.match(appSource, /您还没有完成模拟对话/);
+  assert.match(appSource, /function AssetPracticeButton\(\{ scene, onPractice \}\)/);
+  assert.doesNotMatch(appSource, /asset-practice-menu__popover/);
+  assert.match(appSource, /startTraining\(scene, "speak", \{ standaloneSpeak: false, returnPage: "assets" \}\)/);
+  assert.match(appSource, /<nav className="stepper" aria-label="练习进度">/);
+});

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -854,29 +854,23 @@ svg { display: block; }
 .asset-conversation-page .page-header { margin-bottom: 28px; }
 .asset-conversation-actions { display: flex; align-items: flex-start; gap: 10px; }
 .asset-conversation-exit { width: 56px; height: 56px; }
-.asset-practice-menu { position: relative; z-index: 7; }
-.asset-practice-menu__primary { min-width: 192px; min-height: 56px; position: relative; display: flex; align-items: center; justify-content: center; gap: 10px; padding: 0 16px 0 9px; overflow: hidden; border: 0; border-radius: 999px; background: transparent; color: #fff; font: inherit; cursor: pointer; transition: transform .2s, filter .25s; }
-.asset-practice-menu__primary::before { content: ""; position: absolute; inset: 0; border-radius: inherit; background-image: linear-gradient(135deg, #111110 0%, #686863 54%, #292927 100%); background-size: 210% 210%; background-position: 0 50%; box-shadow: 0 9px 24px rgba(20,20,19,.13); transition: background-position .38s ease, filter .25s ease; }
-.asset-practice-menu__primary:hover::before { background-position: 100% 50%; filter: brightness(1.06); }
-.asset-practice-menu__primary:active { transform: scale(.97); }
-.asset-practice-menu__primary > * { position: relative; z-index: 1; }
-.asset-practice-menu__primary strong { font-size: 16px; letter-spacing: .01em; }
-.asset-practice-menu__icon { width: 36px; height: 36px; flex: 0 0 36px; display: grid; place-items: center; border: 1px solid rgba(255,255,255,.45); border-radius: 50%; background: rgba(255,255,255,.08); }
-.asset-practice-menu__icon svg { width: 16px; height: 16px; transform: translateX(1px); }
-.asset-practice-menu__primary > svg:last-child { width: 17px; height: 17px; margin-left: 3px; transition: transform .2s; }
-.asset-practice-menu__popover { width: 245px; position: absolute; top: calc(100% + 8px); right: 0; padding: 7px; border: 1px solid var(--line); border-radius: 14px; background: #fff; box-shadow: 0 16px 38px rgba(0,0,0,.13); opacity: 0; visibility: hidden; transform: translateY(-6px); transition: opacity .2s, visibility .2s, transform .2s; }
-.asset-practice-menu:hover .asset-practice-menu__popover, .asset-practice-menu:focus-within .asset-practice-menu__popover { opacity: 1; visibility: visible; transform: translateY(0); }
-.asset-practice-menu:hover .asset-practice-menu__primary > svg:last-child, .asset-practice-menu:focus-within .asset-practice-menu__primary > svg:last-child { transform: rotate(180deg); }
-.asset-practice-menu__popover button { width: 100%; min-height: 64px; display: grid; grid-template-columns: 34px 1fr; align-items: center; gap: 9px; padding: 9px 11px; border: 0; border-radius: 10px; background: transparent; color: var(--ink); text-align: left; cursor: pointer; transition: background .2s; }
-.asset-practice-menu__popover button:hover { background: #f3f3ef; }
-.asset-practice-menu__popover svg { width: 17px; height: 17px; }
-.asset-practice-menu__popover strong, .asset-practice-menu__popover small { display: block; }
-.asset-practice-menu__popover strong { font-size: 14px; }
-.asset-practice-menu__popover small { margin-top: 4px; color: var(--muted); font-size: 10px; }
+.asset-practice-button { min-width: 192px; min-height: 56px; position: relative; display: flex; align-items: center; justify-content: center; gap: 10px; padding: 0 18px 0 9px; overflow: hidden; border: 0; border-radius: 999px; background: transparent; color: #fff; font: inherit; cursor: pointer; transition: transform .2s, filter .25s; }
+.asset-practice-button::before { content: ""; position: absolute; inset: 0; border-radius: inherit; background-image: linear-gradient(135deg, #111110 0%, #686863 54%, #292927 100%); background-size: 210% 210%; background-position: 0 50%; box-shadow: 0 9px 24px rgba(20,20,19,.13); transition: background-position .38s ease, filter .25s ease; }
+.asset-practice-button:hover::before { background-position: 100% 50%; filter: brightness(1.06); }
+.asset-practice-button:active { transform: scale(.97); }
+.asset-practice-button > * { position: relative; z-index: 1; }
+.asset-practice-button strong { font-size: 16px; letter-spacing: .01em; }
+.asset-practice-button__icon { width: 36px; height: 36px; flex: 0 0 36px; display: grid; place-items: center; border: 1px solid rgba(255,255,255,.45); border-radius: 50%; background: rgba(255,255,255,.08); }
+.asset-practice-button__icon svg { width: 16px; height: 16px; transform: translateX(1px); }
 .asset-conversation-card { min-height: 660px; border: 1px solid #d9d9d4; border-radius: 22px; background: #fff; box-shadow: 0 2px 0 rgba(22,22,21,.03); overflow: hidden; }
 .asset-conversation-card__label { height: 72px; display: flex; align-items: center; gap: 9px; padding: 0 26px; border-bottom: 1px solid var(--line); font-size: 13px; font-weight: 750; }
 .asset-conversation-card__label svg { width: 18px; height: 18px; }
 .asset-conversation-thread { padding: 28px 30px 48px; display: grid; gap: 22px; }
+.asset-conversation-empty { min-height: 470px; display: flex; flex-direction: column; align-items: center; justify-content: center; padding: 48px 24px; text-align: center; }
+.asset-conversation-empty > svg { width: 42px; height: 42px; margin-bottom: 18px; color: #777773; stroke-width: 1.5; }
+.asset-conversation-empty .eyebrow { margin: 0 0 9px; color: #8a8a85; }
+.asset-conversation-empty h2 { margin: 0; font-size: 28px; }
+.asset-conversation-empty > p:last-child { max-width: 520px; margin: 14px 0 0; color: var(--muted); font-size: 14px; line-height: 1.75; }
 .asset-message { width: 100%; display: flex; flex-direction: column; align-items: flex-start; }
 .asset-message > small { margin-bottom: 7px; color: #989894; font-size: 10px; font-weight: 800; letter-spacing: .06em; }
 .asset-message > p { max-width: 62%; margin: 0; padding: 14px 18px; border: 1px solid var(--line); border-radius: 15px; background: #fdfdfb; font-size: 15px; line-height: 1.6; }
@@ -1371,6 +1365,8 @@ svg { display: block; }
   .achievement-overall { width: 100%; }
   .achievement-filters { overflow-x: auto; padding-bottom: 4px; }
   .achievement-series-grid, .achievement-loading > div { grid-template-columns: 1fr; }
+  .asset-conversation-empty { min-height: 360px; padding-inline: 12px; }
+  .asset-conversation-empty h2 { font-size: 24px; }
   .achievement-level-panel > header { align-items: flex-start; }
   .achievement-level-track { padding-inline: 18px; }
   .achievement-level-track li { width: 174px; flex-basis: 174px; }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -63,6 +63,7 @@ import {
   clearAuthSession,
   advanceCustomSceneFlow,
   createCustomSceneFlow,
+  deleteLearningAsset,
   evaluateSentenceReading,
   generateCustomScene,
   getAchievementOverview,
@@ -2283,10 +2284,11 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
   const [detail, setDetail] = useState(null);
   const [loading, setLoading] = useState(true);
   const [assetError, setAssetError] = useState("");
-  const [deleted, setDeleted] = useState([]);
   const [deleteOpen, setDeleteOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
   const [reservedModule, setReservedModule] = useState(null);
-  const visibleRecords = records.filter((record) => !deleted.includes(record.sceneId));
+  const visibleRecords = records;
   const selected = visibleRecords.find((record) => record.sceneId === selectedId)
     || visibleRecords.find((record) => record.title === initialRecordTitle)
     || visibleRecords[0]
@@ -2342,12 +2344,24 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
     return <main className="page assets-page"><PageHeader title="学习资产" subtitle="正在读取最近一次对话与评分。" />{assetError ? <p className="call-error" role="alert">{assetError}</p> : <NewtonsCradle label="正在加载学习资产" />}</main>;
   }
 
-  const deleteSelected = () => {
-    if (!selected) return;
-    const remaining = visibleRecords.filter((record) => record.sceneId !== selected.sceneId);
-    setDeleted((current) => [...current, selected.sceneId]);
-    setDeleteOpen(false);
-    setSelectedId(remaining[0]?.sceneId || "");
+  const deleteSelected = async () => {
+    if (!selected || deleting) return;
+    const deletedSceneId = selected.sceneId;
+    const remaining = visibleRecords.filter((record) => record.sceneId !== deletedSceneId);
+    setDeleting(true);
+    setDeleteError("");
+    try {
+      await deleteLearningAsset(deletedSceneId);
+      setRecords((current) => current.filter((record) => record.sceneId !== deletedSceneId));
+      setDetail(null);
+      setSelectedId(remaining[0]?.sceneId || "");
+      setAssetError("");
+      setDeleteOpen(false);
+    } catch (error) {
+      setDeleteError(error instanceof Error ? error.message : "学习资产删除失败，请稍后重试");
+    } finally {
+      setDeleting(false);
+    }
   };
 
   const items = detail ? [
@@ -2369,7 +2383,7 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
         <article className="asset-detail">
           {selected && <header>
             <div><p className="eyebrow">{selected.label || "其他"}</p><h2>{selected.title}</h2><p>{selected.latestPracticedAt ? `${new Date(selected.latestPracticedAt).toLocaleDateString("zh-CN")} · 已完成 ${selected.practiceCount} 次模拟` : "尚未完成模拟对话"}</p></div>
-            <div className="asset-detail__actions"><AnimatedDeleteButton onClick={() => setDeleteOpen(true)} /><ExpandingCta className="teacher-cta asset-open-button" disabled={!selected.latestSessionId} onClick={() => onOpenRecord(selected.sceneId)}>打开当前学习资产</ExpandingCta></div>
+            <div className="asset-detail__actions"><AnimatedDeleteButton onClick={() => { setDeleteError(""); setDeleteOpen(true); }} /><ExpandingCta className="teacher-cta asset-open-button" disabled={!selected.latestSessionId} onClick={() => onOpenRecord(selected.sceneId)}>打开当前学习资产</ExpandingCta></div>
           </header>}
           <div className="asset-items" aria-label="已保存的单词、短语和句子">
             {items.map((item) => <div key={`${item.type}-${item.contentId}`}><span className="tag">{item.type}</span><p><strong>{item.englishText}</strong><small>{item.chineseText}</small></p><ScenePlaybackToggle sceneId={selected.sceneId} text={item.englishText} label={`播放 ${item.englishText} 的发音`} /></div>)}
@@ -2377,7 +2391,7 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
           </div>
         </article>
       </section>
-      {deleteOpen && <Modal onClose={() => setDeleteOpen(false)}><p className="eyebrow">DELETE ASSET</p><h2>删除当前学习资产？</h2><p className="modal-lead">这条场景记录、对话和评分将一起删除，且无法恢复。</p><div className="modal-actions"><Button variant="secondary" onClick={() => setDeleteOpen(false)}>取消</Button><Button onClick={deleteSelected}>确认删除</Button></div></Modal>}
+      {deleteOpen && <Modal dismissible={!deleting} onClose={() => setDeleteOpen(false)}><p className="eyebrow">DELETE ASSET</p><h2>删除当前学习资产？</h2><p className="modal-lead">这条场景记录、对话和评分将一起删除，且无法恢复。</p>{deleteError && <p className="call-error" role="alert">{deleteError}</p>}<div className="modal-actions"><Button variant="secondary" disabled={deleting} onClick={() => setDeleteOpen(false)}>取消</Button><Button disabled={deleting} onClick={() => void deleteSelected()}>{deleting ? "正在删除" : "确认删除"}</Button></div></Modal>}
     </main>
   );
 }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2217,18 +2217,13 @@ function AssetFeedback({ feedback }) {
   );
 }
 
-function AssetPracticeMenu({ scene, onPractice, onRestart }) {
+function AssetPracticeButton({ scene, onPractice }) {
   return (
-    <div className="asset-practice-menu">
-      <button className="asset-practice-menu__primary" type="button" onClick={() => onPractice(scene)}><span className="asset-practice-menu__icon"><Play weight="fill" /></span><strong>复练场景</strong><CaretDown weight="bold" /></button>
-      <div className="asset-practice-menu__popover">
-        <button type="button" onClick={() => onRestart(scene)}><ArrowLeft weight="bold" /><span><strong>重新学习</strong><small>从学、读、说第一步开始</small></span></button>
-      </div>
-    </div>
+    <button className="asset-practice-button" type="button" onClick={() => onPractice(scene)}><span className="asset-practice-button__icon"><Play weight="fill" /></span><strong>复练场景</strong></button>
   );
 }
 
-function AssetConversationDetail({ record, onBack, onPractice, onRestart }) {
+function AssetConversationDetail({ record, onBack, onPractice }) {
   const evaluationByTurn = new Map(
     (record.dialogueEvaluation?.turnEvaluation || [])
       .map((evaluation) => [evaluation.turnNo, evaluation]),
@@ -2245,15 +2240,16 @@ function AssetConversationDetail({ record, onBack, onPractice, onRestart }) {
       feedback: isUser ? evaluationByTurn.get(userTurn) : null,
     };
   });
+  const hasCompletedConversation = conversation.length > 0;
   return (
     <main className="page assets-page asset-conversation-page">
       <PageHeader
         title={`${record.title} · 语境复现`}
-        subtitle="最近一次模拟对话已完整保留，每句表达都附有 AI 评价与更自然的说法。"
-        action={<div className="asset-conversation-actions"><AssetPracticeMenu scene={record} onPractice={onPractice} onRestart={onRestart} /><button className="training-exit asset-conversation-exit" type="button" aria-label="退出当前学习资产" onClick={onBack}><span><X weight="bold" /></span></button></div>}
+        subtitle={hasCompletedConversation ? "最近一次模拟对话已完整保留，每句表达都附有 AI 评价与更自然的说法。" : "学与读阶段的语言资产已保存，可随时回到完整流程继续练习。"}
+        action={<div className="asset-conversation-actions"><AssetPracticeButton scene={record} onPractice={onPractice} /><button className="training-exit asset-conversation-exit" type="button" aria-label="退出当前学习资产" onClick={onBack}><span><X weight="bold" /></span></button></div>}
       />
       <section className="asset-conversation-card">
-        <div className="asset-conversation-card__label"><Translate weight="bold" />对话语境下的纠错与地道表达</div>
+        <div className="asset-conversation-card__label">{hasCompletedConversation ? <Translate weight="bold" /> : <BookOpenText weight="bold" />}{hasCompletedConversation ? "对话语境下的纠错与地道表达" : "学习进度"}</div>
         <div className="asset-conversation-thread">
           {conversation.map((message) => (
             <article key={message.id} className={cx("asset-message", message.role === "user" && "is-user")}>
@@ -2262,7 +2258,7 @@ function AssetConversationDetail({ record, onBack, onPractice, onRestart }) {
               {message.feedback && <AssetFeedback feedback={message.feedback} />}
             </article>
           ))}
-          {!conversation.length && <div className="asset-list__empty">该场景还没有已完成的模拟对话</div>}
+          {!hasCompletedConversation && <section className="asset-conversation-empty" role="status"><MessagesSquare /><p className="eyebrow">SIMULATION PENDING</p><h2>您还没有完成模拟对话</h2><p>学与读阶段的内容已经保存。点击右上角“复练场景”将继续进入说阶段，也可以通过进度条返回学或读阶段复练。</p></section>}
         </div>
       </section>
     </main>
@@ -2278,7 +2274,7 @@ function AssetModulePlaceholder({ module, onBack }) {
   );
 }
 
-function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRecord, onCloseRecord, initialView = "home", initialRecordTitle }) {
+function Assets({ sceneId, onPractice, onIelts, onInterview, onOpenRecord, onCloseRecord, initialView = "home", initialRecordTitle }) {
   const [records, setRecords] = useState([]);
   const [selectedId, setSelectedId] = useState(sceneId || "");
   const [detail, setDetail] = useState(null);
@@ -2339,7 +2335,7 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
   }, [sceneId, selected?.sceneId]);
 
   if (reservedModule) return <AssetModulePlaceholder module={reservedModule} onBack={() => setReservedModule(null)} />;
-  if (initialView === "detail" && detail) return <AssetConversationDetail record={detail} onBack={onCloseRecord} onPractice={onPractice} onRestart={onRestart} />;
+  if (initialView === "detail" && detail) return <AssetConversationDetail record={detail} onBack={onCloseRecord} onPractice={onPractice} />;
   if (initialView === "detail" && (loading || !detail)) {
     return <main className="page assets-page"><PageHeader title="学习资产" subtitle="正在读取最近一次对话与评分。" />{assetError ? <p className="call-error" role="alert">{assetError}</p> : <NewtonsCradle label="正在加载学习资产" />}</main>;
   }
@@ -2383,7 +2379,7 @@ function Assets({ sceneId, onPractice, onRestart, onIelts, onInterview, onOpenRe
         <article className="asset-detail">
           {selected && <header>
             <div><p className="eyebrow">{selected.label || "其他"}</p><h2>{selected.title}</h2><p>{selected.latestPracticedAt ? `${new Date(selected.latestPracticedAt).toLocaleDateString("zh-CN")} · 已完成 ${selected.practiceCount} 次模拟` : "尚未完成模拟对话"}</p></div>
-            <div className="asset-detail__actions"><AnimatedDeleteButton onClick={() => { setDeleteError(""); setDeleteOpen(true); }} /><ExpandingCta className="teacher-cta asset-open-button" disabled={!selected.latestSessionId} onClick={() => onOpenRecord(selected.sceneId)}>打开当前学习资产</ExpandingCta></div>
+            <div className="asset-detail__actions"><AnimatedDeleteButton onClick={() => { setDeleteError(""); setDeleteOpen(true); }} /><ExpandingCta className="teacher-cta asset-open-button" onClick={() => onOpenRecord(selected.sceneId)}>打开当前学习资产</ExpandingCta></div>
           </header>}
           <div className="asset-items" aria-label="已保存的单词、短语和句子">
             {items.map((item) => <div key={`${item.type}-${item.contentId}`}><span className="tag">{item.type}</span><p><strong>{item.englishText}</strong><small>{item.chineseText}</small></p><ScenePlaybackToggle sceneId={selected.sceneId} text={item.englishText} label={`播放 ${item.englishText} 的发音`} /></div>)}
@@ -3323,7 +3319,7 @@ export function App() {
   if (training) content = <Training sceneId={training.sceneId} sessionId={training.sessionId} sceneTitle={sceneTitle} sceneContent={generatedScene} teacher={teacher} speed={conversationSpeed} initialStep={training.initialStep} initialStage={training.stage} standaloneSpeak={training.standaloneSpeak} result={result} onExit={() => setMainPage(training.returnPage || "scenes")} onComplete={completeScenePractice} onBack={() => setMainPage(training.returnPage || "scenes")} onAssets={openCompletedAssetDetail} onStageChange={navigateSceneStage} />;
   else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={(sessionId) => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); recordCompletedPractice("free", sessionId); void synchronizeAchievements({ revealNotifications: true }); }} />;
   else if (page === "scenes") content = <Scenes onStartTraining={startTraining} onLocked={setPaywall} onIelts={selectIelts} onInterview={selectInterview} />;
-  else if (page === "assets") content = <Assets sceneId={assetSceneId} initialView={assetView} initialRecordTitle={sceneTitle} onOpenRecord={openCompletedAssetDetail} onCloseRecord={() => navigate(paths.assets.root, { assetView: "home", assetSceneId: null, authMode })} onIelts={() => selectMainPage("ielts-assets")} onInterview={() => selectMainPage("interview-assets")} onPractice={(scene) => startTraining(scene, "speak", { standaloneSpeak: true, returnPage: "assets" })} onRestart={(scene) => startTraining(scene, "learn", { returnPage: "assets" })} />;
+  else if (page === "assets") content = <Assets sceneId={assetSceneId} initialView={assetView} initialRecordTitle={sceneTitle} onOpenRecord={openCompletedAssetDetail} onCloseRecord={() => navigate(paths.assets.root, { assetView: "home", assetSceneId: null, authMode })} onIelts={() => selectMainPage("ielts-assets")} onInterview={() => selectMainPage("interview-assets")} onPractice={(scene) => startTraining(scene, "speak", { standaloneSpeak: false, returnPage: "assets" })} />;
   else if (page === "ielts") content = <IeltsTrainingCenter route={ieltsRoute} onNavigate={navigateIelts} onExit={() => setMainPage("scenes")} onAssets={() => navigateIelts(paths.ielts.assets.root)} />;
   else if (page === "ielts-assets") content = <IeltsAssets route={ieltsRoute} onNavigate={navigateIelts} onBack={() => setMainPage("scenes")} onBackToAssets={() => setMainPage("assets")} onBackToInterview={() => selectMainPage("interview-assets")} onTraining={() => navigateIelts(paths.ielts.root)} />;
   else if (page === "interview") content = <InterviewModule route={interviewRoute} teacher={teacher} speed={conversationSpeed} onNavigate={navigateInterview} onBack={() => setMainPage("scenes")} />;

--- a/frontend/web/src/infrastructure/http/apiClient.js
+++ b/frontend/web/src/infrastructure/http/apiClient.js
@@ -430,6 +430,13 @@ export function getLearningAsset(sceneId) {
   );
 }
 
+export function deleteLearningAsset(sceneId) {
+  return request(
+    `/api/custom-scenes/${encodeURIComponent(sceneId)}/assets`,
+    { method: "DELETE" },
+  );
+}
+
 export async function synthesizeSpeech(sceneId, text, model = null) {
 	const token = getAccessToken();
 	const response = await fetch(


### PR DESCRIPTION
## Summary

- add an authenticated DELETE endpoint that soft-deletes learning assets owned by the current user
- connect the Web confirmation flow with pending, success, and failure states
- add the same deletion flow to the Expo mobile app and navigate back only after deletion succeeds
- cover controller, service, repository, Web client, and mobile interaction contracts

## Verification

- Backend focused tests: LearningAssetServiceImplTest, MybatisSceneRepositoryTest, CustomSceneCompletionEndpointTest
- Web: 44 tests passed and Vite production build succeeded
- Mobile: 203 tests passed, TypeScript check passed, Android production bundle export succeeded
- Manual Web verification: list count decreased after deletion, the asset remained absent after reload, and no console errors were reported