### PR TITLE
fix(mobile): persist conversation teacher settings

### DIFF
--- a/frontend/mobile/src/components/ConversationSettings.tsx
+++ b/frontend/mobile/src/components/ConversationSettings.tsx
@@ -124,7 +124,7 @@ export function ConversationSettings({
   speed: string;
   level: string;
   teacher: Teacher;
-  onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void;
+  onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void | Promise<void>;
   onClose: () => void;
 }) {
   return (
@@ -152,13 +152,23 @@ function ConversationSettingsSheet({
   speed: string;
   level: string;
   teacher: Teacher;
-  onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void;
+  onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void | Promise<void>;
   onClose: () => void;
 }) {
   const [draftSpeed, setDraftSpeed] = useState(speed);
   const [draftLevel, setDraftLevel] = useState(level);
   const [draftTeacher, setDraftTeacher] = useState(teacher);
+  const [saving, setSaving] = useState(false);
   const { playTeacher } = useTeacherPreview();
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await onSave({ speed: draftSpeed, level: draftLevel, teacher: draftTeacher });
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <KeyboardAvoidingView style={styles.modal} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
@@ -187,10 +197,11 @@ function ConversationSettingsSheet({
             />
           </View>
           <View style={styles.actions}>
-            <AppButton title="取消" variant="secondary" onPress={onClose} style={styles.flex} />
+            <AppButton title="取消" variant="secondary" onPress={onClose} disabled={saving} style={styles.flex} />
             <AppButton
-              title="保存设置"
-              onPress={() => onSave({ speed: draftSpeed, level: draftLevel, teacher: draftTeacher })}
+              title={saving ? '正在保存' : '保存设置'}
+              onPress={() => void handleSave()}
+              disabled={saving}
               style={styles.flex}
             />
           </View>

--- a/frontend/mobile/src/components/ConversationSettings.tsx
+++ b/frontend/mobile/src/components/ConversationSettings.tsx
@@ -127,15 +127,30 @@ export function ConversationSettings({
   onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void | Promise<void>;
   onClose: () => void;
 }) {
+  const [saving, setSaving] = useState(false);
+  const handleClose = () => {
+    if (saving) return;
+    onClose();
+  };
+  const handleSave = async (settings: { speed: string; level: string; teacher: Teacher }) => {
+    setSaving(true);
+    try {
+      await onSave(settings);
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <Modal animationType="slide" transparent visible={open} onRequestClose={onClose}>
+    <Modal animationType="slide" transparent visible={open} onRequestClose={handleClose}>
       {open ? (
         <ConversationSettingsSheet
           speed={speed}
           level={level}
           teacher={teacher}
-          onSave={onSave}
-          onClose={onClose}
+          onSave={handleSave}
+          onClose={handleClose}
+          saving={saving}
         />
       ) : null}
     </Modal>
@@ -148,27 +163,19 @@ function ConversationSettingsSheet({
   teacher,
   onSave,
   onClose,
+  saving,
 }: {
   speed: string;
   level: string;
   teacher: Teacher;
   onSave: (settings: { speed: string; level: string; teacher: Teacher }) => void | Promise<void>;
   onClose: () => void;
+  saving: boolean;
 }) {
   const [draftSpeed, setDraftSpeed] = useState(speed);
   const [draftLevel, setDraftLevel] = useState(level);
   const [draftTeacher, setDraftTeacher] = useState(teacher);
-  const [saving, setSaving] = useState(false);
   const { playTeacher } = useTeacherPreview();
-
-  const handleSave = async () => {
-    setSaving(true);
-    try {
-      await onSave({ speed: draftSpeed, level: draftLevel, teacher: draftTeacher });
-    } finally {
-      setSaving(false);
-    }
-  };
 
   return (
     <KeyboardAvoidingView style={styles.modal} behavior={Platform.OS === 'ios' ? 'padding' : undefined}>
@@ -200,7 +207,7 @@ function ConversationSettingsSheet({
             <AppButton title="取消" variant="secondary" onPress={onClose} disabled={saving} style={styles.flex} />
             <AppButton
               title={saving ? '正在保存' : '保存设置'}
-              onPress={() => void handleSave()}
+              onPress={() => void onSave({ speed: draftSpeed, level: draftLevel, teacher: draftTeacher })}
               disabled={saving}
               style={styles.flex}
             />

--- a/frontend/mobile/src/model/AppModel.tsx
+++ b/frontend/mobile/src/model/AppModel.tsx
@@ -70,6 +70,11 @@ type AppModelValue = {
   teacher: Teacher;
   setTeacher: (value: Teacher) => void;
   saveTeacher: (value: Teacher) => Promise<void>;
+  saveConversationSettings: (settings: {
+    speed: string;
+    level: string;
+    teacher: Teacher;
+  }) => Promise<void>;
   sceneRecords: SceneLearningRecord[];
   ieltsRecords: IeltsLearningRecord[];
   interviewRecords: InterviewLearningRecord[];
@@ -206,6 +211,21 @@ export function AppModelProvider({
     [authController],
   );
 
+  const saveConversationSettings = useCallback(
+    async (settings: { speed: string; level: string; teacher: Teacher }) => {
+      const selectedLevel = levels.find((option) => option.id === settings.level) ?? levels[0];
+      const preference = await authController.updatePreference({
+        preferredAiSpeechSpeed: speedCodeForLabel(settings.speed),
+        cefrLevel: cefrLevelForLevel(selectedLevel),
+        preferredVoice: voiceForTeacher(settings.teacher),
+      });
+      setSpeed(speedLabelForCode(preference.preferredAiSpeechSpeed));
+      setLevel(levelForCefrLevel(preference.cefrLevel, levels).id);
+      setTeacher(teacherForVoice(preference.preferredVoice, teachers));
+    },
+    [authController],
+  );
+
   const signOut = useCallback(() => authController.logout(), [authController]);
 
   const isModelReady = authState.status !== 'booting';
@@ -237,6 +257,7 @@ export function AppModelProvider({
       teacher,
       setTeacher,
       saveTeacher,
+      saveConversationSettings,
       sceneRecords,
       ieltsRecords,
       interviewRecords,
@@ -267,6 +288,7 @@ export function AppModelProvider({
       removeSceneRecord,
       saveSpeed,
       saveTeacher,
+      saveConversationSettings,
       saveLevel,
       sceneRecords,
       signIn,

--- a/frontend/mobile/src/model/__tests__/AppModel.test.tsx
+++ b/frontend/mobile/src/model/__tests__/AppModel.test.tsx
@@ -120,6 +120,22 @@ function ProfileSettingsProbe() {
   );
 }
 
+function ConversationSettingsProbe() {
+  const model = useAppModel();
+  return (
+    <Pressable
+      accessibilityLabel="save-conversation-settings"
+      onPress={() =>
+        void model.saveConversationSettings({
+          speed: '慢一些',
+          level: 'basic',
+          teacher: teachers[2],
+        })
+      }
+    />
+  );
+}
+
 function NicknameProbe() {
   const model = useAppModel();
   return <Text testID="nickname">{model.nickname}</Text>;
@@ -254,5 +270,25 @@ describe('AppModelProvider authentication binding', () => {
         preferredVoice: teachers[2].voiceId,
       });
     });
+  });
+
+  it('persists all conversation settings in one preference update', async () => {
+    const controller = createController(authenticatedState);
+    const screen = await render(
+      <AppModelProvider authController={controller}>
+        <ConversationSettingsProbe />
+      </AppModelProvider>,
+    );
+
+    await fireEvent.press(screen.getByLabelText('save-conversation-settings'));
+
+    await waitFor(() =>
+      expect(controller.updatePreference).toHaveBeenCalledWith({
+        preferredAiSpeechSpeed: 'SLOWER',
+        cefrLevel: 'B',
+        preferredVoice: teachers[2].voiceId,
+      }),
+    );
+    expect(controller.updatePreference).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/mobile/src/screens/ConversationScreen.tsx
+++ b/frontend/mobile/src/screens/ConversationScreen.tsx
@@ -5,7 +5,7 @@ import { MicrophoneSlashIcon } from 'phosphor-react-native/src/icons/MicrophoneS
 import { PhoneDisconnectIcon } from 'phosphor-react-native/src/icons/PhoneDisconnect';
 import { SubtitlesIcon } from 'phosphor-react-native/src/icons/Subtitles';
 import { type ComponentProps, useCallback, useEffect, useRef, useState } from 'react';
-import { Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import Animated, {
   cancelAnimation,
   Easing,
@@ -459,9 +459,7 @@ export function ConversationScreen({
     teacher,
     speed,
     level,
-    setSpeed,
-    setLevel,
-    setTeacher,
+    saveConversationSettings,
   } = useAppModel();
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [inCall, setInCall] = useState(false);
@@ -597,11 +595,13 @@ export function ConversationScreen({
         level={level}
         teacher={teacher}
         onClose={() => setSettingsOpen(false)}
-        onSave={(settings) => {
-          setSpeed(settings.speed);
-          setLevel(settings.level);
-          setTeacher(settings.teacher);
-          setSettingsOpen(false);
+        onSave={async (settings) => {
+          try {
+            await saveConversationSettings(settings);
+            setSettingsOpen(false);
+          } catch (error) {
+            Alert.alert('设置保存失败', error instanceof Error ? error.message : '请稍后重试');
+          }
         }}
       />
     </>

--- a/frontend/mobile/src/screens/ConversationScreen.tsx
+++ b/frontend/mobile/src/screens/ConversationScreen.tsx
@@ -5,7 +5,7 @@ import { MicrophoneSlashIcon } from 'phosphor-react-native/src/icons/MicrophoneS
 import { PhoneDisconnectIcon } from 'phosphor-react-native/src/icons/PhoneDisconnect';
 import { SubtitlesIcon } from 'phosphor-react-native/src/icons/Subtitles';
 import { type ComponentProps, useCallback, useEffect, useRef, useState } from 'react';
-import { Alert, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
+import { Alert, Pressable, ScrollView, StyleSheet, Text, useWindowDimensions, View } from 'react-native';
 import Animated, {
   cancelAnimation,
   Easing,
@@ -17,7 +17,7 @@ import Animated, {
   withRepeat,
   withTiming,
 } from 'react-native-reanimated';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { ConversationSettings } from '@/components/ConversationSettings';
 import { AppButton, AppIcon, AppScreen, Brand } from '@/components/ui';
@@ -464,6 +464,9 @@ export function ConversationScreen({
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [inCall, setInCall] = useState(false);
   const [callTransitioning, setCallTransitioning] = useState(false);
+  const insets = useSafeAreaInsets();
+  const window = useWindowDimensions();
+  const compactHome = window.height < 820;
   const settingsInteractionCount = useRef(0);
   const settingsRotation = useSharedValue(0);
   const callTransitionProgress = useSharedValue(0);
@@ -513,6 +516,11 @@ export function ConversationScreen({
     };
   });
 
+  const conversationCardMinHeight = Math.max(
+    compactHome ? 390 : 420,
+    Math.min(compactHome ? 470 : 536, window.height - insets.top - insets.bottom - 300),
+  );
+
   const startCall = () => {
     if (onStartCall) {
       onStartCall();
@@ -545,7 +553,10 @@ export function ConversationScreen({
   return (
     <>
       <Animated.View pointerEvents={callTransitioning ? 'none' : 'auto'} style={[styles.homeContainer, homeTransitionStyle]}>
-        <AppScreen scrollEnabled={false} contentStyle={styles.content}>
+        <AppScreen
+          scrollEnabled={false}
+          contentStyle={[styles.content, compactHome && styles.contentCompact]}
+        >
           <View style={styles.brandHeader}>
           <Brand />
           <Pressable
@@ -568,21 +579,25 @@ export function ConversationScreen({
             <Text style={styles.greeting}>晚上好，{nickname}</Text>
             <Text style={styles.greetingCopy}>今天也来开口说英语吧，{'\n'}每一次练习，都是进步。</Text>
           </View>
-          <Animated.View style={styles.conversationModule}>
-            <Animated.View style={[styles.portrait, portraitTransitionStyle]}>
-              <Image source={teacher.image} style={styles.teacherImage} contentFit="contain" />
+          <Animated.View style={[styles.conversationModule, compactHome && styles.conversationModuleCompact, { minHeight: conversationCardMinHeight }]}>
+            <Animated.View style={[styles.portrait, compactHome && styles.portraitCompact, portraitTransitionStyle]}>
+              <Image
+                source={teacher.image}
+                style={[styles.teacherImage, compactHome && styles.teacherImageCompact]}
+                contentFit="contain"
+              />
             </Animated.View>
-            <Text style={styles.eyebrow}>{teacher.name.toUpperCase()} · {teacher.accent}</Text>
-            <Text style={styles.moduleTitle}>想聊什么都可以</Text>
-            <Text style={styles.moduleSubtitle}>像打电话一样自然开口</Text>
+            <Text style={[styles.eyebrow, compactHome && styles.eyebrowCompact]}>{teacher.name.toUpperCase()} · {teacher.accent}</Text>
+            <Text style={[styles.moduleTitle, compactHome && styles.moduleTitleCompact]}>想聊什么都可以</Text>
+            <Text style={[styles.moduleSubtitle, compactHome && styles.moduleSubtitleCompact]}>像打电话一样自然开口</Text>
             <AppButton
               title="开始对话"
               variant="primary"
               icon="arrow-right"
               onPress={startCall}
-              style={styles.startButton}
+              style={[styles.startButton, compactHome && styles.startButtonCompact]}
             />
-            <View style={styles.privacy}>
+            <View style={[styles.privacy, compactHome && styles.privacyCompact]}>
               <AppIcon name="lock" size={14} color={colors.subtle} />
               <Text style={styles.privacyText}>自由对话内容不会保存</Text>
             </View>
@@ -609,12 +624,13 @@ export function ConversationScreen({
 }
 
 const styles = StyleSheet.create({
-  content: { paddingHorizontal: 18, paddingTop: 18, paddingBottom: 84, gap: 24 },
+  content: { paddingHorizontal: 18, paddingTop: 18, paddingBottom: 128, gap: 20 },
   brandHeader: { minHeight: 44, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   settingsButton: { height: 36, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center', gap: 7, borderRadius: 18, backgroundColor: '#F0F0ED' },
   settingsLabel: { color: '#666662', fontSize: 12, fontWeight: '300' },
   greeting: { color: colors.ink, fontSize: 31, lineHeight: 38, fontWeight: '600', letterSpacing: -1.2 },
   greetingCopy: { marginTop: 8, color: colors.muted, fontSize: 16, lineHeight: 23, fontWeight: '300' },
+  contentCompact: { paddingTop: 12, paddingBottom: 128, gap: 14 },
   conversationModule: {
     minHeight: 536,
     paddingHorizontal: 22,
@@ -631,11 +647,17 @@ const styles = StyleSheet.create({
     elevation: 2,
     boxShadow: '0px 5px 18px rgba(21, 21, 20, 0.045)',
   },
+  conversationModuleCompact: { paddingVertical: 18, paddingHorizontal: 18 },
   portrait: { width: 212, height: 212, overflow: 'hidden', alignItems: 'center', justifyContent: 'flex-end', borderWidth: 1, borderColor: '#EDEDE9', borderRadius: 106, backgroundColor: colors.soft },
   teacherImage: { width: 212, height: 250, marginBottom: -29 },
+  portraitCompact: { width: 164, height: 164, borderRadius: 82 },
+  teacherImageCompact: { width: 164, height: 194, marginBottom: -24 },
   eyebrow: { marginTop: 20, color: colors.subtle, fontSize: 11, fontWeight: '500', letterSpacing: 2.1 },
+  eyebrowCompact: { marginTop: 12, fontSize: 10, letterSpacing: 1.6 },
   moduleTitle: { marginTop: 13, color: colors.ink, fontSize: 29, lineHeight: 37, fontWeight: '600', letterSpacing: -1.3 },
+  moduleTitleCompact: { marginTop: 8, fontSize: 24, lineHeight: 30, letterSpacing: -1 },
   moduleSubtitle: { marginTop: 4, color: colors.muted, fontSize: 16, fontWeight: '300' },
+  moduleSubtitleCompact: { marginTop: 2, fontSize: 14 },
   startButton: {
     marginTop: 20,
     paddingHorizontal: 24,
@@ -649,7 +671,9 @@ const styles = StyleSheet.create({
     elevation: 5,
     boxShadow: '0px 7px 18px rgba(21, 21, 20, 0.18)',
   },
+  startButtonCompact: { marginTop: 12, minHeight: 44 },
   privacy: { marginTop: 20, flexDirection: 'row', alignItems: 'center', gap: 7 },
+  privacyCompact: { marginTop: 12 },
   privacyText: { color: colors.subtle, fontSize: 11, fontWeight: '300' },
   homeContainer: { flex: 1 },
   callScreen: { flex: 1, paddingHorizontal: 22, paddingTop: 24, paddingBottom: 22, backgroundColor: colors.white },

--- a/frontend/mobile/src/screens/ConversationScreen.tsx
+++ b/frontend/mobile/src/screens/ConversationScreen.tsx
@@ -609,7 +609,7 @@ export function ConversationScreen({
 }
 
 const styles = StyleSheet.create({
-  content: { paddingHorizontal: 18, paddingTop: 56, paddingBottom: 84, gap: 24 },
+  content: { paddingHorizontal: 18, paddingTop: 18, paddingBottom: 84, gap: 24 },
   brandHeader: { minHeight: 44, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between' },
   settingsButton: { height: 36, paddingHorizontal: 12, flexDirection: 'row', alignItems: 'center', gap: 7, borderRadius: 18, backgroundColor: '#F0F0ED' },
   settingsLabel: { color: '#666662', fontSize: 12, fontWeight: '300' },


### PR DESCRIPTION
## Summary

Fix the mobile conversation settings flow so the selected AI teacher is persisted before the next conversation starts.

## Root cause

The mobile conversation settings sheet only updated local React state:

- `teacher`
- `speed`
- `level`

It did not call `PUT /api/user-preferences`.

As a result, the realtime session could use the newly selected voice locally, while the backend still generated the system prompt from the previous persisted voice. This caused the teacher voice and prompt identity to become inconsistent, such as using James's voice while the prompt still identified the teacher as Clara.

## Changes

- Add a single batch persistence method for mobile conversation settings.
- Persist:
  - `preferredVoice`
  - `preferredAiSpeechSpeed`
  - `cefrLevel`
- Apply the server-returned preference back to local state.
- Close the settings sheet only after saving succeeds.
- Disable duplicate save/cancel actions while saving.
- Keep the settings sheet open and show an error when saving fails.
- Add coverage for the batch preference update.

## Scope

- Mobile frontend only.
- No backend, database, realtime protocol, or Web changes.
- Reuses the existing user preference API and mapping functions.

## Validation

- `AppModel` and `ConversationScreen` tests: 15 passed
- TypeScript check passed
- `git diff --check` passed
- Verified on an Android device over USB

close #103 