### PR TITLE
fix (mobile): Android back navigation

### DIFF
--- a/frontend/mobile/src/app/(app)/(tabs)/_layout.tsx
+++ b/frontend/mobile/src/app/(app)/(tabs)/_layout.tsx
@@ -3,7 +3,8 @@ import { BookOpenTextIcon } from 'phosphor-react-native/src/icons/BookOpenText';
 import { SquaresFourIcon } from 'phosphor-react-native/src/icons/SquaresFour';
 import { UserIcon } from 'phosphor-react-native/src/icons/User';
 import { WaveformIcon } from 'phosphor-react-native/src/icons/Waveform';
-import { useState } from 'react';
+import { BackHandler, Platform } from 'react-native';
+import { useEffect, useState } from 'react';
 
 import { LiquidGlassTabBar } from '@/components/LiquidGlassTabBar';
 import { useAnalytics } from '@/model/AnalyticsProvider';
@@ -18,6 +19,22 @@ export default function TabsLayout() {
   const analytics = useAnalytics();
   const [immersiveLearning, setImmersiveLearning] = useState(false);
   const hideTabBar = immersiveLearning;
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const rootTab = pathname === '/conversation'
+      || pathname === '/learning'
+      || pathname === '/profile';
+    if (!rootTab) return;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      // A root tab has no parent screen to pop. Consuming the event prevents
+      // Android from closing the Activity; nested screens handle their own back.
+      return true;
+    });
+    return () => subscription.remove();
+  }, [pathname]);
 
   return (
     <LearningStageProvider immersiveLearning={immersiveLearning} setImmersiveLearning={setImmersiveLearning}>

--- a/frontend/mobile/src/app/(app)/_layout.tsx
+++ b/frontend/mobile/src/app/(app)/_layout.tsx
@@ -3,7 +3,7 @@ import { Stack } from 'expo-router';
 export default function AppLayout() {
   return (
     <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
-      <Stack.Screen name="(tabs)" options={{ animation: 'fade' }} />
+      <Stack.Screen name="(tabs)" options={{ animation: 'fade', gestureEnabled: false }} />
     </Stack>
   );
 }

--- a/frontend/mobile/src/app/_layout.tsx
+++ b/frontend/mobile/src/app/_layout.tsx
@@ -14,7 +14,11 @@ function RootNavigator() {
   if (!isModelReady) return null;
 
   return (
-    <Stack screenOptions={{ headerShown: false, animation: 'slide_from_right' }}>
+    <Stack
+      // The protected app is a single root screen. Let nested stacks own back
+      // gestures so an edge swipe cannot pop the whole app and exit.
+      screenOptions={{ headerShown: false, animation: 'slide_from_right', gestureEnabled: false }}
+    >
       <Stack.Screen name="index" />
       <Stack.Protected guard={!isAuthenticated}>
         <Stack.Screen name="(public)" />

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Animated, Image, PanResponder, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Animated, BackHandler, Image, PanResponder, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Reanimated, {
   cancelAnimation,
@@ -855,6 +855,16 @@ export function ScenesHome({
   const [generatingSource, setGeneratingSource] = useState<'custom' | string | null>(null);
   const [generationError, setGenerationError] = useState<string | null>(null);
   const generating = generatingSource !== null;
+  useEffect(() => {
+    if (Platform.OS !== 'android' || !preview) return;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      setPreview(null);
+      return true;
+    });
+    return () => subscription.remove();
+  }, [preview]);
+
   const generatePreview = async (sceneInput: string, source: 'custom' | string) => {
     if (!sceneInput.trim() || generating) return;
     setGeneratingSource(source);
@@ -1095,6 +1105,15 @@ export function ScenesScreen({
     }
     setRoute(nextRoute);
   };
+  useEffect(() => {
+    if (Platform.OS !== 'android' || route.name === 'home') return;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      setRoute({ name: 'home' });
+      return true;
+    });
+    return () => subscription.remove();
+  }, [route.name]);
   useEffect(() => {
     if (route.name === 'home') void forgetSpecialty();
   }, [route.name]);

--- a/frontend/mobile/src/screens/SpecialtyFlows.tsx
+++ b/frontend/mobile/src/screens/SpecialtyFlows.tsx
@@ -1,6 +1,6 @@
 import { Image } from 'expo-image';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { BackHandler, KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
@@ -596,6 +596,30 @@ export function IeltsFlow({ onExit, onViewDetails, analytics }: { onExit: () => 
     !ielts.settingsLoading &&
     ielts.settings?.targetScore != null &&
     hasCompletedOnboarding;
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (route === 'intake') {
+        if (intakeStep > 0) setIntakeStep(0);
+        else onExit();
+        return true;
+      }
+      if (route === 'home') {
+        onExit();
+      } else if (route === 'topics') {
+        setRoute('home');
+      } else if (route === 'examiner') {
+        setRoute('topics');
+      } else if (route === 'report') {
+        setRoute('home');
+      }
+      // Do not leave the Activity while a live session or evaluation is active.
+      return true;
+    });
+    return () => subscription.remove();
+  }, [intakeStep, onExit, route]);
 
   useEffect(() => {
     void rememberSpecialty('ielts');
@@ -1394,11 +1418,24 @@ export function InterviewFlow({ onExit, onViewDetails, practiceScene, analytics 
 
   useEffect(() => () => setImmersiveLearning(false), [setImmersiveLearning]);
 
-  const closeReport = () => {
+  const closeReport = useCallback(() => {
     setPreparation(null);
     setCompletedSession(null);
     setRoute('input');
-  };
+  }, []);
+
+  useEffect(() => {
+    if (Platform.OS !== 'android') return;
+
+    const subscription = BackHandler.addEventListener('hardwareBackPress', () => {
+      if (route === 'input') onExit();
+      else if (route === 'review') setRoute('input');
+      else if (route === 'finalizing') closeReport();
+      // A live interview must be ended from its call control.
+      return true;
+    });
+    return () => subscription.remove();
+  }, [closeReport, onExit, route]);
 
   if (route === 'input') {
     return (


### PR DESCRIPTION
## Summary

- align Android system back gestures with the visible navigation controls in scene, IELTS, and interview flows
- prevent root app and tab containers from being popped when there is no valid parent screen
- close the generated-scene preview before leaving the scene marketplace
- keep active speaking sessions and evaluations from accidentally closing the Android activity

## Root cause

Several mobile flows keep their current step in component state while the Expo Router pathname remains on a root tab. Android therefore had no native stack entry to pop when the user performed the system edge-back gesture, so React Native fell through to closing the activity instead of running the same transition as the on-screen back or close button.

## Impact

Android edge-back navigation now follows the same step transitions as the corresponding UI controls. Root tabs no longer close the app unexpectedly, while genuine nested stack screens retain their normal back behavior.

## Validation

- `npx tsc --noEmit`
- `npm test -- --runInBand` (45 suites, 216 tests)
- targeted ESLint check completed with no errors
- OnePlus 8T physical device on Android 11: edge-back returned from login to welcome and the activity remained in the foreground, with no crash in ADB logs
