### PR TITLE
fix: prevent selecting future learning calendar dates

### DIFF
--- a/frontend/mobile/src/screens/ProfileScreen.tsx
+++ b/frontend/mobile/src/screens/ProfileScreen.tsx
@@ -306,7 +306,21 @@ function ProfileEditModal({
   );
 }
 
-function CalendarCard({
+export function getShanghaiToday() {
+  const parts = new Intl.DateTimeFormat('en-US', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).formatToParts(new Date());
+  const values = parts.reduce<Record<string, string>>((result, { type, value }) => {
+    result[type] = value;
+    return result;
+  }, {});
+  return `${values.year}-${values.month}-${values.day}`;
+}
+
+export function CalendarCard({
   calendar,
   onMonthChange,
 }: {
@@ -314,8 +328,8 @@ function CalendarCard({
   onMonthChange: (month: string) => void;
 }) {
   const [year, monthNumber] = calendar.month.split('-').map(Number);
-  const today = new Date();
-  const todayDay = today.getFullYear() === year && today.getMonth() + 1 === monthNumber ? today.getDate() : null;
+  const today = getShanghaiToday();
+  const todayDay = today.startsWith(calendar.month) ? Number(today.slice(-2)) : null;
   const [selectedDay, setSelectedDay] = useState(todayDay ?? 1);
   const leadingDays = (new Date(year, monthNumber - 1, 1).getDay() + 6) % 7;
   const daysInMonth = new Date(year, monthNumber, 0).getDate();
@@ -323,7 +337,7 @@ function CalendarCard({
   const checkedDates = new Set(calendar.checkedDates);
   const selectedDate = `${calendar.month}-${String(selectedDay).padStart(2, '0')}`;
   const selectedChecked = checkedDates.has(selectedDate);
-  const currentMonth = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}`;
+  const currentMonth = today.slice(0, 7);
   const shiftMonth = (offset: number) => {
     const shifted = new Date(year, monthNumber - 1 + offset, 1);
     onMonthChange(`${shifted.getFullYear()}-${String(shifted.getMonth() + 1).padStart(2, '0')}`);
@@ -366,19 +380,33 @@ function CalendarCard({
         {days.map((day) => {
           const date = `${calendar.month}-${String(day).padStart(2, '0')}`;
           const checked = checkedDates.has(date);
+          const isFuture = date > today;
           return (
             <Pressable
               key={day}
               accessibilityRole="button"
+              accessibilityState={{ disabled: isFuture }}
               accessibilityLabel={`${monthNumber}月${day}日${checked ? '，已打卡' : '，未打卡'}`}
-              onPress={() => setSelectedDay(day)}
+              disabled={isFuture}
+              onPress={() => {
+                if (!isFuture) setSelectedDay(day);
+              }}
               style={[
                 styles.calendarCell,
                 selectedDay === day && styles.calendarCellSelected,
                 checked && styles.calendarCellChecked,
+                isFuture && styles.calendarCellDisabled,
               ]}
             >
-              <Text style={[styles.calendarDay, selectedDay === day && styles.calendarDaySelected]}>{day}</Text>
+              <Text
+                style={[
+                  styles.calendarDay,
+                  selectedDay === day && styles.calendarDaySelected,
+                  isFuture && styles.calendarDayDisabled,
+                ]}
+              >
+                {day}
+              </Text>
               {day === todayDay ? (
                 <Text style={styles.calendarToday}>今天</Text>
               ) : checked ? (
@@ -507,8 +535,7 @@ function AchievementSummary({
 
 export function Overview({ onBack }: { onBack: () => void }) {
   const api = useProfileApi();
-  const now = new Date();
-  const [month, setMonth] = useState(`${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`);
+  const [month, setMonth] = useState(() => getShanghaiToday().slice(0, 7));
   const [overview, setOverview] = useState<ProfileOverview | null>(null);
   const [achievements, setAchievements] = useState<AchievementOverview | null>(null);
   const [loading, setLoading] = useState(true);
@@ -2001,8 +2028,10 @@ const styles = StyleSheet.create({
   },
   calendarCellChecked: { borderWidth: 1, borderColor: colors.green },
   calendarCellSelected: { backgroundColor: colors.ink },
+  calendarCellDisabled: { opacity: 0.4 },
   calendarDay: { color: colors.muted, fontSize: 12, fontWeight: '300' },
   calendarDaySelected: { color: colors.white, fontWeight: '600' },
+  calendarDayDisabled: { color: colors.subtle },
   calendarToday: { marginTop: 1, color: colors.white, fontSize: 7 },
   calendarCheckDot: {
     width: 4,

--- a/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { CalendarCard } from '../ProfileScreen';
+
+const calendarFor = (month: string) => ({
+  month,
+  checkedDates: [],
+  checkedInToday: false,
+});
+
+describe('CalendarCard', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-08-18T00:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('disables future days and keeps the selected day unchanged when pressed', async () => {
+    const view = await render(<CalendarCard calendar={calendarFor('2026-08')} onMonthChange={jest.fn()} />);
+
+    expect(view.getByLabelText('8月19日，未打卡')).toBeDisabled();
+    expect(view.getByText('8 月 18 日')).toBeTruthy();
+
+    fireEvent.press(view.getByLabelText('8月19日，未打卡'));
+
+    expect(view.getByText('8 月 18 日')).toBeTruthy();
+    expect(view.queryByText('8 月 19 日')).toBeNull();
+  });
+
+  it('keeps historical month days available for review', async () => {
+    const view = await render(<CalendarCard calendar={calendarFor('2026-07')} onMonthChange={jest.fn()} />);
+
+    expect(view.getByLabelText('7月31日，未打卡')).not.toBeDisabled();
+    await fireEvent.press(view.getByLabelText('7月31日，未打卡'));
+
+    expect(view.getByText(/7\s*月\s*31\s*日/)).toBeTruthy();
+  });
+});

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -1145,6 +1145,8 @@ svg { display: block; }
 .calendar-days .calendar-blank { min-height: 46px; }
 .calendar-days button { position: relative; min-width: 0; min-height: 46px; display: grid; place-items: center; padding: 4px; border: 1px solid transparent; border-radius: 10px; background: transparent; color: #9a9a95; font-size: 12px; cursor: pointer; transition: color .18s, background .18s, border-color .18s, transform .18s, box-shadow .18s; }
 .calendar-days button:hover { color: var(--ink); background: #f5f5f2; transform: translateY(-1px); }
+.calendar-days button:disabled { color: #d0d0cb; cursor: not-allowed; }
+.calendar-days button:disabled:hover { background: transparent; transform: none; }
 .calendar-days button.is-practiced { color: #3a3a37; background: #f1f1ee; font-weight: 650; }
 .calendar-days button.is-today { border-color: #b7b7b1; }
 .calendar-days button.is-selected { border-color: #20201f; background: #20201f; color: #fff; box-shadow: 0 7px 18px rgba(20,20,19,.12); }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2636,8 +2636,10 @@ function LearningCalendar({ calendar, onMonthChange }) {
           const day = index + 1;
           const record = checkedDays.has(day);
           const isToday = todayDay === day;
+          const dateKey = `${monthKey}-${String(day).padStart(2, "0")}`;
+          const isFuture = dateKey > today;
           return (
-            <button key={day} type="button" role="gridcell" aria-label={`${label}${day}日${record ? "，已自动打卡" : "，无打卡记录"}`} className={cx(record && "is-practiced", isToday && "is-today", selectedDay === day && "is-selected")} onClick={() => setSelectedDay(day)}>
+            <button key={day} type="button" role="gridcell" disabled={isFuture} aria-label={`${label}${day}日${isFuture ? "，尚未到达" : record ? "，已自动打卡" : "，无打卡记录"}`} className={cx(record && "is-practiced", isToday && "is-today", isFuture && "is-future", selectedDay === day && "is-selected")} onClick={() => { if (!isFuture) setSelectedDay(day); }}>
               <span>{day}</span>{record && <i aria-hidden="true" />}{isToday && <small>今天</small>}
             </button>
           );


### PR DESCRIPTION
## Summary

- Prevent selecting future dates in the Web learning calendar.
- Prevent selecting future dates in the mobile learning calendar.
- Standardize mobile date calculations to `Asia/Shanghai`.
- Add mobile calendar interaction coverage.

## Root Cause

The calendar only prevented navigation to future months. Dates after today within the current month were still rendered as interactive controls, allowing users to select future dates.

The Web client already used `Asia/Shanghai`, while the mobile client used the device's local timezone, which could cause inconsistent behavior near date boundaries.

## Changes

- Disable future dates in the current month on Web and mobile.
- Add event-level guards so future dates cannot change the selected date.
- Add disabled-state styling and accessibility state.
- Keep historical months, today, and past dates fully available.
- Add mobile tests for future-date blocking and historical-month navigation.

## Validation

- `npm run build`
- `npm test -- --runInBand src/screens/__tests__/ProfileScreen.test.tsx`
- `npx tsc --noEmit`
- `git diff --check`

Close #106 