### PR TITLE
fix: add exit confirmation for web and mobile training

### DIFF
--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Animated, BackHandler, Image, PanResponder, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Alert, Animated, BackHandler, Image, PanResponder, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Reanimated, {
   cancelAnimation,
@@ -420,6 +420,17 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
   const readingResult = trainingSnapshot?.readingResult;
   const trainingTransitioning = trainingSnapshot?.status === 'loading';
   const completionMetrics = sceneMetricsForReport(dialogueCompletion?.evaluation);
+  const confirmExit = () => {
+    Alert.alert(
+      '退出当前训练？',
+      '退出后将返回场景广场。',
+      [
+        { text: '继续训练', style: 'cancel' },
+        { text: '确认退出', style: 'destructive', onPress: onBack },
+      ],
+      { cancelable: true },
+    );
+  };
 
   const toggleDemo = async (text: string) => {
     if (!scene || !ttsPlayer) {
@@ -549,7 +560,7 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
           <Text style={styles.trainingTitle}>{scenario.title}</Text>
           <Text style={styles.trainingSubtitle}>从语言到真实表达</Text>
         </View>
-        <Pressable accessibilityRole="button" accessibilityLabel="取消训练" onPress={onBack} style={styles.trainingCancel}>
+        <Pressable accessibilityRole="button" accessibilityLabel="退出训练" onPress={confirmExit} style={styles.trainingCancel}>
           <AppIcon name="close" size={19} color={colors.muted} />
         </Pressable>
       </View>

--- a/frontend/mobile/src/screens/SpecialtyFlows.tsx
+++ b/frontend/mobile/src/screens/SpecialtyFlows.tsx
@@ -1,6 +1,6 @@
 import { Image } from 'expo-image';
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { BackHandler, KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
+import { Alert, BackHandler, KeyboardAvoidingView, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 import {
@@ -105,6 +105,7 @@ function IeltsSession({
   part,
   ieltsId,
   voiceId,
+  onExit,
   autoAdvance,
   onFinish,
   analytics,
@@ -113,6 +114,7 @@ function IeltsSession({
   part: 'p1' | 'p3';
   ieltsId: string;
   voiceId: string;
+  onExit: () => void;
   autoAdvance: boolean;
   analytics?: AnalyticsTrackerFactory;
   onFinish: (
@@ -144,6 +146,17 @@ function IeltsSession({
     if (!session.sessionId) return Promise.reject(new Error('会话尚未连接，暂时无法翻译'));
     return translationApi.translateFreeChat(session.sessionId, text);
   }, [session.sessionId, translationApi]);
+  const confirmExit = () => {
+    Alert.alert(
+      '退出当前训练？',
+      '退出后将返回场景广场。',
+      [
+        { text: '继续训练', style: 'cancel' },
+        { text: '确认退出', style: 'destructive', onPress: onExit },
+      ],
+      { cancelable: true },
+    );
+  };
 
   useEffect(() => {
     if (part !== 'p3') return undefined;
@@ -192,6 +205,9 @@ function IeltsSession({
 
   return (
     <SafeAreaView edges={['top', 'bottom']} style={styles.ieltsCallScreen}>
+      <View style={styles.ieltsSessionHeader}>
+        <HeaderIconButton accessibilityLabel="退出雅思训练" color={ieltsPalette.purpleDark} icon="close" onPress={confirmExit} />
+      </View>
       <CallExperience
         endAccessibilityLabel="结束本题并进入下一题"
         endControlIcon="arrow"
@@ -239,6 +255,7 @@ function IeltsPart2Session({
   cueCard,
   ieltsId,
   voiceId,
+  onExit,
   onFinish,
   analytics,
 }: {
@@ -246,6 +263,7 @@ function IeltsPart2Session({
   cueCard: { title: string; points: string[] };
   ieltsId: string;
   voiceId: string;
+  onExit: () => void;
   analytics?: AnalyticsTrackerFactory;
   onFinish: (
     sessionId: string | null,
@@ -272,6 +290,17 @@ function IeltsPart2Session({
   const silenceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const finishTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastInputReadyTick = useRef(0);
+  const confirmExit = () => {
+    Alert.alert(
+      '退出当前训练？',
+      '退出后将返回场景广场。',
+      [
+        { text: '继续训练', style: 'cancel' },
+        { text: '确认退出', style: 'destructive', onPress: onExit },
+      ],
+      { cancelable: true },
+    );
+  };
 
   useEffect(() => {
     phaseRef.current = phase;
@@ -489,6 +518,7 @@ function IeltsPart2Session({
                       : '请等待考官说明 Part 2 规则。'}
               </Text>
             </View>
+            <HeaderIconButton accessibilityLabel="退出雅思训练" color={ieltsPalette.purpleDark} icon="close" onPress={confirmExit} />
             {sessionError ? <Text style={styles.intakeError}>{sessionError}</Text> : null}
             {session.startupError ? <Text style={styles.intakeError}>{session.startupError}</Text> : null}
           </View>
@@ -1203,6 +1233,7 @@ export function IeltsFlow({ onExit, onViewDetails, analytics }: { onExit: () => 
           cueCard={cueCard}
           examiner={examiner}
           ieltsId={ieltsId}
+          onExit={onExit}
           onFinish={finishSession}
           voiceId={voiceId}
         />
@@ -1216,6 +1247,7 @@ export function IeltsFlow({ onExit, onViewDetails, analytics }: { onExit: () => 
         ieltsId={ieltsId}
         autoAdvance={fullMock}
         voiceId={voiceId}
+        onExit={onExit}
         onFinish={finishSession}
       />
     );
@@ -1646,6 +1678,7 @@ const styles = StyleSheet.create({
   ieltsSetupStartButton: { borderColor: ieltsPalette.purple, backgroundColor: ieltsPalette.purple, shadowColor: ieltsPalette.purple, shadowOffset: { width: 0, height: 6 }, shadowOpacity: 0.2, shadowRadius: 14, elevation: 4 },
   ieltsStageScreen: { backgroundColor: ieltsPalette.canvas },
   ieltsCallScreen: { flex: 1, paddingHorizontal: 22, paddingTop: 24, paddingBottom: 22, backgroundColor: ieltsPalette.canvas },
+  ieltsSessionHeader: { height: 38, alignItems: 'flex-end', justifyContent: 'center' },
   part2Screen: { flex: 1, backgroundColor: ieltsPalette.canvas },
   part2KeyboardView: { flex: 1 },
   part2Content: { flexGrow: 1, paddingHorizontal: 14, paddingTop: 12, paddingBottom: 120, gap: 12 },

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2051,6 +2051,7 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
   const [readError, setReadError] = useState("");
   const [flowAdvancing, setFlowAdvancing] = useState(false);
   const [flowError, setFlowError] = useState("");
+  const [exitOpen, setExitOpen] = useState(false);
   const lessonItems = generatedMode
     ? (learningGroup === "words" ? generatedWordItems : generatedPhraseItems)
     : learningItems;
@@ -2061,6 +2062,7 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
   const score = readScores[readIndex] ?? null;
   const readEvaluation = readEvaluations[readIndex] ?? null;
   const completeStep = (id) => setCompletedSteps((current) => current.includes(id) ? current : [...current, id]);
+  const exitConfirmation = exitOpen && <Modal dismissible={false}><p className="eyebrow">EXIT TRAINING</p><h2>确定要退出当前训练吗？</h2><p className="modal-lead">退出后将返回上一页。</p><div className="modal-actions"><Button variant="secondary" onClick={() => setExitOpen(false)}>继续训练</Button><Button onClick={onExit}>确认退出</Button></div></Modal>;
   const goToStep = (id) => {
     const targetIndex = steps.findIndex((item) => item.id === id);
     if (targetIndex > unlockedStepIndex) return;
@@ -2223,18 +2225,19 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
   if (!item && displayedStep !== "speak") {
     return (
       <main className="training-page">
-        <header className="training-header"><div><strong>{sceneTitle || "自定义场景"}</strong><span>场景内容加载失败</span></div><button className="training-exit" aria-label="关闭训练" onClick={onExit}><span><X weight="bold" /></span></button></header>
+        <header className="training-header"><div><strong>{sceneTitle || "自定义场景"}</strong><span>场景内容加载失败</span></div><button className="training-exit" aria-label="关闭训练" onClick={() => setExitOpen(true)}><span><X weight="bold" /></span></button></header>
         <section className="training-empty" role="alert">
           <h1>场景学习内容为空</h1>
           <p>后端没有返回当前阶段需要的单词、词组或句子，请返回场景广场重新生成。</p>
           <ExpandingCta direction="back" onClick={onBack}>返回场景广场</ExpandingCta>
         </section>
+        {exitConfirmation}
       </main>
     );
   }
   return (
     <main className={cx("training-page", standaloneSpeak && "training-page--standalone")}>
-      <header className="training-header"><div><strong>{sceneTitle}</strong><span>从语言到真实表达</span></div><button className="training-exit" aria-label="关闭训练" onClick={onExit}><span><X weight="bold" /></span></button></header>
+      <header className="training-header"><div><strong>{sceneTitle}</strong><span>从语言到真实表达</span></div><button className="training-exit" aria-label="关闭训练" onClick={() => setExitOpen(true)}><span><X weight="bold" /></span></button></header>
       {!standaloneSpeak && <nav className="stepper" aria-label="练习进度">
         <span className="stepper__track" aria-hidden="true"><span style={{ width: `${unlockedStepIndex * 50}%` }} /></span>
         {steps.map((stepItem, index) => {
@@ -2252,6 +2255,7 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
       {(step === "speak" || result) && !generatedMode && <CustomSceneConversation sceneId={sceneId} teacher={teacher} speed={speed} ended={Boolean(result)} onSessionStarted={(startedSessionId) => onStageChange?.("session", startedSessionId)} onComplete={onComplete} />}
       {result && <ResultModal completed={result.completed} evaluation={result.evaluation} onBack={onBack} onAssets={onAssets} />}
       {!result && readFeedback && <ReadScoreModal feedback={readFeedback} item={readItems[readFeedback.index]} onClose={() => setReadFeedback(null)} />}
+      {exitConfirmation}
     </main>
   );
 }


### PR DESCRIPTION
## Summary

- Add exit confirmation for Web custom scene training.
- Add exit confirmation for mobile custom scene training.
- Add exit confirmation to mobile IELTS Part 1, Part 2, and Part 3 sessions.
- Preserve the existing exit behavior after confirmation.

## Details

Users can now click the top-right close button and choose either:

- Continue training
- Confirm exit

The existing session cleanup, navigation, scoring, reporting, and next-question behavior remain unchanged.

## Validation

- Web production build passed.
- Web route checks passed.
- Web realtime event checks passed.
- Mobile lint passed with 0 errors.
- Mobile test suite passed: 46 suites / 218 tests.
- Mobile TypeScript check passed.
- `git diff --check` passed.

Close #109 