### PR TITLE
fix: Stop scene timer during report generation

### DIFF
--- a/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
+++ b/frontend/mobile/src/features/conversation/__tests__/useFreeChatSession.test.tsx
@@ -75,6 +75,7 @@ function SessionProbe({
           user: session.userTranscript,
           assistant: session.assistantTranscript,
           error: session.error,
+          elapsed: session.elapsed,
         })}
       </Text>
       <Pressable accessibilityLabel="mute" onPress={session.toggleMuted} />
@@ -150,6 +151,39 @@ describe('useFreeChatSession', () => {
 
     screen.unmount();
     await waitFor(() => expect(controller.end).toHaveBeenCalledTimes(1));
+  });
+
+  it('stops incrementing elapsed time while the completed session is ending', async () => {
+    jest.useFakeTimers();
+    const controller = createController();
+    const screen = await render(
+      <SessionProbe createController={() => controller} />,
+    );
+
+    await act(async () => {
+      controller.emit({ ...idleSnapshot, state: 'ready' });
+      await Promise.resolve();
+    });
+    await act(() => {
+      jest.advanceTimersByTime(2_000);
+    });
+    expect(screen.getByTestId('snapshot').props.children).toContain(
+      '"elapsed":2',
+    );
+
+    await act(async () => {
+      controller.emit({ ...idleSnapshot, state: 'ending' });
+      await Promise.resolve();
+    });
+    await act(() => {
+      jest.advanceTimersByTime(2_000);
+    });
+    expect(screen.getByTestId('snapshot').props.children).toContain(
+      '"elapsed":2',
+    );
+
+    screen.unmount();
+    jest.useRealTimers();
   });
 
   it('exposes startup errors and performs idempotent cleanup after ending', async () => {

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -9,6 +9,7 @@
     "test:auth": "node --test scripts/check-auth-contract.mjs scripts/check-captcha-config.mjs scripts/check-api-client-auth.mjs",
     "test:analytics": "node --test scripts/check-umami-config.mjs scripts/check-analytics-client.mjs scripts/check-analytics-wiring.mjs",
     "test:assets": "node --test scripts/check-learning-asset-deletion.mjs",
+    "check:call-timer": "node scripts/check-call-timer-stop.mjs",
     "check:feedback-invitation": "node scripts/check-feedback-invitation.mjs",
     "check:realtime-events": "node scripts/check-realtime-events.mjs",
     "check:routes": "node scripts/check-routes.mjs",

--- a/frontend/web/scripts/check-call-timer-stop.mjs
+++ b/frontend/web/scripts/check-call-timer-stop.mjs
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const appSource = await readFile(
+  new URL("../src/controller/App.jsx", import.meta.url),
+  "utf8",
+);
+
+const conversationStart = appSource.indexOf("function CustomSceneConversation(");
+const conversationEnd = appSource.indexOf(
+  "const sentenceWordPattern",
+  conversationStart,
+);
+
+assert.notEqual(conversationStart, -1, "CustomSceneConversation must exist");
+assert.notEqual(conversationEnd, -1, "CustomSceneConversation boundary must exist");
+
+const conversationSource = appSource.slice(conversationStart, conversationEnd);
+const timerStart = appSource.indexOf("function CallTimer(");
+const timerEnd = appSource.indexOf("function CallControls(", timerStart);
+
+assert.notEqual(timerStart, -1, "CallTimer must exist");
+assert.notEqual(timerEnd, -1, "CallTimer boundary must exist");
+
+const timerSource = appSource.slice(timerStart, timerEnd);
+
+assert.match(
+  conversationSource,
+  /<CallTimer paused=\{paused\} state=\{ended \|\| error \? "ended" : "active"\} stopped=\{ending\} \/>/,
+  "The scene call timer must stop as soon as report generation begins",
+);
+assert.match(
+  timerSource,
+  /if \(stopped \|\| state === "ended"\) return undefined;/,
+  "CallTimer must clear its interval when the call stops",
+);
+assert.match(
+  timerSource,
+  /\}, \[state, stopped\]\);/,
+  "CallTimer must react when the stopped state changes",
+);
+
+console.log("Scene call timer completion check passed.");

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -443,16 +443,19 @@ const formatCallDuration = (totalSeconds) => {
   return `${minutes}:${seconds}`;
 };
 
-function CallTimer({ state = "active", paused = false, className }) {
+function CallTimer({ state = "active", paused = false, stopped = false, className }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const startedAt = useRef(Date.now());
 
   useEffect(() => {
-    const startedAt = Date.now();
-    const updateElapsed = () => setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    const updateElapsed = () => {
+      setElapsedSeconds(Math.floor((Date.now() - startedAt.current) / 1000));
+    };
     updateElapsed();
+    if (stopped || state === "ended") return undefined;
     const interval = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(interval);
-  }, []);
+  }, [state, stopped]);
 
   const duration = formatCallDuration(elapsedSeconds);
   const label = state === "connecting"
@@ -1890,7 +1893,7 @@ function CustomSceneConversation({
           <div className="portrait portrait--small"><img src={teacher.image} alt={teacher.name} /></div>
           <div className="listening-state listening-state--compact">
             <VoiceWaveform active={!ended && !paused && !ending && !error} compact />
-            <CallTimer paused={paused} state={ended || error ? "ended" : "active"} />
+            <CallTimer paused={paused} state={ended || error ? "ended" : "active"} stopped={ending} />
             <span>{status}</span>
           </div>
         </div>


### PR DESCRIPTION
## Summary

- freeze the Web scene-call timer as soon as report generation begins
- clear the timer interval for stopped and ended calls while preserving the final elapsed duration
- add Web and mobile regression coverage for completion-time timer behavior

## Root cause

The Web scene conversation switched to its `ending` state when completion started, but that state was not passed to `CallTimer`. The timer interval therefore continued updating while the UI displayed “场景对话完成，正在生成报告”.

## Impact

The displayed duration now stops immediately when scene practice completes instead of increasing during report generation. Mobile completion behavior is protected by a matching elapsed-time regression test.

## Validation

- `npm run check:call-timer`
- `npm run build`
- `npm test -- --runInBand src/features/conversation/__tests__/useFreeChatSession.test.tsx src/screens/__tests__/ScenesScreen.test.tsx`
- `npm run lint` (0 errors; existing warnings remain)
