### PR TITLE
fix: simplify IELTS and interview entry copy

### DIFF
--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -972,8 +972,8 @@ export function ScenesHome({
             >
               <Image source={require('../../assets/images/specialty/ielts.png')} style={[styles.specialtyOptionIcon, styles.specialtyIeltsIcon]} />
               <View style={styles.specialtyOptionCopy}>
-                <Text style={[styles.specialtyOptionTitle, styles.specialtyIeltsTitle]}>雅思口语</Text>
-                <Text numberOfLines={1} style={[styles.specialtyOptionNote, styles.specialtyIeltsNote]}>模考与评分</Text>
+                <Text adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={1} style={[styles.specialtyOptionEyebrow, styles.specialtyIeltsEyebrow]}>IELTS SPEAKING</Text>
+                <Text adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={1} style={[styles.specialtyOptionTitle, styles.specialtyIeltsTitle]}>雅思口语</Text>
               </View>
             </Pressable>
             <Pressable
@@ -988,8 +988,8 @@ export function ScenesHome({
             >
               <Image source={require('../../assets/images/specialty/interview.png')} style={[styles.specialtyOptionIcon, styles.specialtyInterviewIcon]} />
               <View style={styles.specialtyOptionCopy}>
-                <Text style={[styles.specialtyOptionTitle, styles.specialtyInterviewTitle]}>英文面试</Text>
-                <Text numberOfLines={1} style={[styles.specialtyOptionNote, styles.specialtyInterviewNote]}>岗位模拟追问</Text>
+                <Text adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={1} style={[styles.specialtyOptionEyebrow, styles.specialtyInterviewEyebrow]}>ENGLISH INTERVIEW</Text>
+                <Text adjustsFontSizeToFit minimumFontScale={0.75} numberOfLines={1} style={[styles.specialtyOptionTitle, styles.specialtyInterviewTitle]}>英文面试</Text>
               </View>
             </Pressable>
           </View>
@@ -1254,12 +1254,12 @@ const styles = StyleSheet.create({
   specialtyIeltsIcon: { backgroundColor: '#E8DEFF' },
   specialtyInterviewIcon: { backgroundColor: '#DCEEFF' },
   specialtyOptionCopy: { minWidth: 0, flex: 1 },
-  specialtyOptionTitle: { color: colors.ink, fontSize: 19, lineHeight: 24, fontWeight: '600' },
-  specialtyOptionNote: { marginTop: 4, color: colors.subtle, fontSize: 12, lineHeight: 17, fontWeight: '300' },
+  specialtyOptionEyebrow: { marginBottom: 4, fontSize: 9, lineHeight: 12, fontWeight: '700', letterSpacing: 0 },
+  specialtyOptionTitle: { color: colors.ink, fontSize: 18, lineHeight: 23, fontWeight: '600', letterSpacing: 0 },
+  specialtyIeltsEyebrow: { color: '#7B7485' },
   specialtyIeltsTitle: { color: '#292331' },
-  specialtyIeltsNote: { color: '#8C8498' },
+  specialtyInterviewEyebrow: { color: '#718091' },
   specialtyInterviewTitle: { color: '#202833' },
-  specialtyInterviewNote: { color: '#83909E' },
   recommendationHeader: { marginTop: 22, marginBottom: 9, paddingHorizontal: 15, flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'space-between' },
   recommendationHeading: { marginTop: 3, color: colors.ink, fontSize: 23, fontWeight: '600', letterSpacing: -0.7 },
   recommendationList: { gap: 8 },

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -129,6 +129,15 @@ describe('ScenesHome backend generation binding', () => {
       />,
     );
 
+    expect(screen.getByText('IELTS SPEAKING')).toBeTruthy();
+    expect(screen.getByText('ENGLISH INTERVIEW')).toBeTruthy();
+    expect(screen.getByText('雅思口语').props.numberOfLines).toBe(1);
+    expect(screen.getByText('雅思口语').props.adjustsFontSizeToFit).toBe(true);
+    expect(screen.getByText('英文面试').props.numberOfLines).toBe(1);
+    expect(screen.getByText('英文面试').props.adjustsFontSizeToFit).toBe(true);
+    expect(screen.queryByText('模考与评分')).toBeNull();
+    expect(screen.queryByText('岗位模拟追问')).toBeNull();
+
     await fireEvent.press(screen.getByLabelText('进入雅思口语'));
     expect(onOpenIelts).toHaveBeenCalledTimes(1);
     await fireEvent.press(screen.getByLabelText('进入英文面试'));

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -501,7 +501,6 @@ svg { display: block; }
 .specialty-card__copy { min-width: 0; display: grid; }
 .specialty-card__copy small { margin-bottom: 7px; color: currentColor; font-size: 10px; font-weight: 750; opacity: .58; }
 .specialty-card__copy strong { font-size: 24px; line-height: 1.15; }
-.specialty-card__copy > span { margin-top: 8px; overflow: hidden; color: currentColor; font-size: 13px; line-height: 1.5; opacity: .62; white-space: nowrap; text-overflow: ellipsis; }
 .specialty-card__action { width: 40px; height: 40px; display: grid; place-items: center; justify-self: end; border: 1px solid currentColor; border-radius: 50%; opacity: .72; transition: color .2s, background .2s, transform .2s; }
 .specialty-card:hover .specialty-card__action { border-color: var(--specialty-accent); color: #fff; background: var(--specialty-accent); transform: translateX(2px); opacity: 1; }
 .specialty-card__action svg { width: 17px; height: 17px; }
@@ -566,7 +565,6 @@ svg { display: block; }
   .specialty-card { min-height: 118px; padding: 14px; grid-template-columns: 74px minmax(0, 1fr) 38px; gap: 13px; }
   .specialty-card__art { width: 74px; height: 74px; }
   .specialty-card__copy strong { font-size: 20px; }
-  .specialty-card__copy > span { font-size: 12px; }
   .specialty-card__action { width: 36px; height: 36px; }
   .scene-card-cta { width: 36px; height: 36px; }
 }
@@ -576,7 +574,6 @@ svg { display: block; }
   .specialty-card__art { width: 64px; height: 64px; border-radius: 12px; }
   .specialty-card__copy small { margin-bottom: 4px; font-size: 9px; }
   .specialty-card__copy strong { font-size: 18px; white-space: nowrap; }
-  .specialty-card__copy > span { margin-top: 5px; font-size: 11px; }
   .specialty-card__action { width: 32px; height: 32px; }
   .specialty-card__action svg { width: 15px; height: 15px; }
   .recommendation-list > article { min-height: 132px; grid-template-columns: 38px minmax(0, 1fr); grid-template-rows: auto auto 1fr auto; }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -1490,12 +1490,12 @@ function Scenes({ onStartTraining, onIelts, onInterview }) {
           <div className="specialty-training__grid">
             <button type="button" className="specialty-card specialty-card--ielts" onClick={onIelts}>
               <span className="specialty-card__art"><img src="/specialty/ielts.png" alt="" /></span>
-              <span className="specialty-card__copy"><small>IELTS SPEAKING</small><strong>雅思口语</strong><span>Part 1 / 2 / 3 专项练习与全真模考</span></span>
+              <span className="specialty-card__copy"><small>IELTS SPEAKING</small><strong>雅思口语</strong></span>
               <span className="specialty-card__action" aria-hidden="true"><ArrowRight weight="bold" /></span>
             </button>
             <button type="button" className="specialty-card specialty-card--interview" onClick={onInterview}>
               <span className="specialty-card__art"><img src="/specialty/interview.png" alt="" /></span>
-              <span className="specialty-card__copy"><small>ENGLISH INTERVIEW</small><strong>英文面试</strong><span>结合 JD 与简历，完成岗位模拟追问</span></span>
+              <span className="specialty-card__copy"><small>ENGLISH INTERVIEW</small><strong>英文面试</strong></span>
               <span className="specialty-card__action" aria-hidden="true"><ArrowRight weight="bold" /></span>
             </button>
           </div>


### PR DESCRIPTION
## What changed

- Removed the descriptions beneath the IELTS and interview entry titles on Web.
- Aligned the mobile cards with the Web structure by showing only the English eyebrow and Chinese title.
- Added bounded single-line font scaling so the mobile Chinese titles do not wrap.
- Added regression coverage for the mobile card copy and title behavior.

## Why

The Web and mobile specialty entry cards used inconsistent content structures, and the mobile Chinese titles wrapped on narrow screens.

## Impact

IELTS and interview entry cards now present the same concise hierarchy on Web and mobile while remaining readable on smaller mobile screens.

## Validation

- `cd frontend/web && npm run build`
- `cd frontend/mobile && npx tsc --noEmit`
- `cd frontend/mobile && npm test -- --runInBand src/screens/__tests__/ScenesScreen.test.tsx`
