### PR TITLE
fix(web): 修复 Realtime 重复会话连接失败与资源残留

### DIFF
--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import {
   buildResponseCreateEvent,
   buildScenarioResponseRequest,
@@ -11,6 +12,8 @@ import {
   isActiveResponseConflict,
   normalizeProviderEvent,
   normalizeBaseUrl,
+  releaseRealtimeTransport,
+  waitForIceGathering,
   websocketUrl,
 } from "../src/websocket/realtimeClient.js";
 
@@ -279,5 +282,107 @@ assert.equal(turnAudioCapture.start(), true);
 assert.equal(segmentStartCount, 2);
 assert.equal(await turnAudioCapture.take(), expectedAudio);
 assert.equal(segmentStopCount, 2);
+
+const transportCalls = [];
+releaseRealtimeTransport({
+  audioSender: {
+    replaceTrack(track) {
+      transportCalls.push(["sender", track]);
+      return Promise.resolve();
+    },
+  },
+  localStream: {
+    getTracks: () => [{ stop: () => transportCalls.push(["local-track"]) }],
+  },
+  remoteStreams: [{
+    getTracks: () => [{ stop: () => transportCalls.push(["remote-track"]) }],
+  }],
+  channels: [{
+    onopen: () => {},
+    onmessage: () => {},
+    onerror: () => {},
+    onclose: () => {},
+    close: () => transportCalls.push(["channel"]),
+  }],
+  peer: {
+    ontrack: () => {},
+    ondatachannel: () => {},
+    onconnectionstatechange: () => {},
+    close: () => transportCalls.push(["peer"]),
+  },
+});
+assert.deepEqual(transportCalls, [
+  ["sender", null],
+  ["local-track"],
+  ["remote-track"],
+  ["channel"],
+  ["peer"],
+]);
+
+const previousWindow = globalThis.window;
+globalThis.window = {
+  setTimeout: globalThis.setTimeout,
+  clearTimeout: globalThis.clearTimeout,
+};
+try {
+  const partialGathering = await waitForIceGathering({
+    iceGatheringState: "gathering",
+    signalingState: "stable",
+    localDescription: {
+      sdp: "v=0\r\na=candidate:1 1 UDP 1 192.0.2.1 5000 typ host\r\n",
+    },
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  }, { timeoutMs: 5 });
+  assert.equal(partialGathering.complete, false);
+  assert.equal(partialGathering.timedOut, true);
+  assert.equal(partialGathering.candidates.host, 1);
+
+  await assert.rejects(
+    waitForIceGathering({
+      iceGatheringState: "gathering",
+      signalingState: "stable",
+      localDescription: { sdp: "v=0\r\n" },
+      addEventListener: () => {},
+      removeEventListener: () => {},
+    }, { timeoutMs: 5 }),
+    (error) => {
+      assert.equal(error.code, "WEBRTC_ICE_GATHERING_NO_CANDIDATE");
+      assert.deepEqual(Object.keys(error.realtimeDiagnostics).sort(), ["candidates", "iceGatheringState"]);
+      return true;
+    },
+  );
+} finally {
+  globalThis.window = previousWindow;
+}
+
+const realtimeSource = await readFile(
+  new URL("../src/websocket/realtimeClient.js", import.meta.url),
+  "utf8",
+);
+const stopSource = realtimeSource.slice(
+  realtimeSource.indexOf("async function performStop"),
+  realtimeSource.indexOf("function stop(options"),
+);
+assert.ok(
+  stopSource.indexOf("releaseCurrentTransport();")
+    < stopSource.indexOf("await waitForPendingOperations"),
+  "realtime transport must be released before business operations drain",
+);
+assert.match(realtimeSource, /let lifecycleState = "idle";/);
+assert.match(realtimeSource, /if \(startPromise\) return startPromise;/);
+assert.doesNotMatch(realtimeSource, /console\.warn\([^\n]*(?:offerSdp|answerSdp|accessToken|credential)/);
+
+const appSource = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
+const freeChatStopSource = appSource.slice(
+  appSource.indexOf("const stopConversation = async () =>"),
+  appSource.indexOf("useEffect(() =>", appSource.indexOf("const stopConversation = async () =>")),
+);
+assert.ok(
+  freeChatStopSource.indexOf("await client?.stop") < freeChatStopSource.indexOf("setInCall(false)"),
+  "free chat must remain non-restartable until client.stop completes",
+);
+assert.match(freeChatStopSource, /stopPromiseRef\.current/);
+assert.match(freeChatStopSource, /detachRemoteAudio\(\)/);
 
 console.log("Realtime event normalization checks passed.");

--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -385,4 +385,23 @@ assert.ok(
 assert.match(freeChatStopSource, /stopPromiseRef\.current/);
 assert.match(freeChatStopSource, /detachRemoteAudio\(\)/);
 
+assert.match(appSource, /const detachSceneRemoteAudio = \(\) => \{/);
+assert.match(appSource, /sceneAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);\s+detachSceneRemoteAudio\(\);/);
+
+const ieltsSource = await readFile(
+  new URL("../src/component/ielts/IeltsModule.jsx", import.meta.url),
+  "utf8",
+);
+assert.match(ieltsSource, /const finishingRef = useRef\(false\);/);
+assert.match(ieltsSource, /if \(finishingRef\.current\) return;\s+finishingRef\.current = true;/);
+assert.match(ieltsSource, /ieltsAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);[\s\S]*?detachIeltsRemoteAudio\(\);[\s\S]*?clientRef\.current = null;/);
+
+const interviewSource = await readFile(
+  new URL("../src/component/interview/InterviewModule.jsx", import.meta.url),
+  "utf8",
+);
+assert.match(interviewSource, /const detachInterviewRemoteAudio = \(\) => \{/);
+assert.match(interviewSource, /interviewAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);\s+detachInterviewRemoteAudio\(\);/);
+assert.match(interviewSource, /const abandon = async \(\) => \{\s+if \(endingRef\.current\) return;\s+endingRef\.current = true;/);
+
 console.log("Realtime event normalization checks passed.");

--- a/frontend/web/src/component/ielts/IeltsModule.jsx
+++ b/frontend/web/src/component/ielts/IeltsModule.jsx
@@ -494,6 +494,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   const [partThreeRemaining, setPartThreeRemaining] = useState(null);
   const remoteAudioRef = useRef(null);
   const clientRef = useRef(null);
+  const finishingRef = useRef(false);
   const finishRef = useRef(null);
   const sessionIdRef = useRef(null);
   const ieltsAnalyticsRef = useRef(null);
@@ -506,6 +507,12 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   const transcriptRef = useRef(null);
   const subtitleQueueRef = useRef([]);
   const subtitleFrameRef = useRef(null);
+  const detachIeltsRemoteAudio = () => {
+    const audio = remoteAudioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.srcObject = null;
+  };
 
   const partTwoQuestion = generated?.content?.part2?.[0] || training?.questions?.[0] || null;
   const partTwoQuestionText = partTwoQuestion?.question || partTwoQuestion?.questionText || "";
@@ -835,6 +842,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
         subtitleFrameRef.current = null;
       }
       subtitleQueueRef.current = [];
+      detachIeltsRemoteAudio();
       clientRef.current = null;
       void client.stop({ notifyBackend: false, reason: "component_unmount", emitEnded: false });
     };
@@ -847,13 +855,15 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   }, [ending]);
 
   const finish = async () => {
-    if (ending) return;
+    if (finishingRef.current) return;
+    finishingRef.current = true;
     setEnding(true);
     setError("");
     clearPartTwoTimer();
     clearPartTwoCompletionTimer();
     clearPartTwoSilenceTimer();
     clearPartThreeTimer();
+    detachIeltsRemoteAudio();
     try {
       setStatus("正在结束本次练习…");
       const client = clientRef.current;
@@ -898,13 +908,17 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
       setStatus("结束失败");
       setError("结束练习失败，请稍后重试");
       setEnding(false);
+      finishingRef.current = false;
     }
   };
   finishRef.current = finish;
 
   const abandon = async () => {
+    if (finishingRef.current) return;
+    finishingRef.current = true;
     const client = clientRef.current;
     clientRef.current = null;
+    detachIeltsRemoteAudio();
     await client?.stop({ notifyBackend: false, reason: "user_exit", emitEnded: false });
     ieltsAnalyticsRef.current?.abandon("USER_EXIT");
     onExit();

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -513,6 +513,12 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
   const transcriptRef = useRef(null);
   const onEndInterviewRef = useRef(onEndInterview);
   const teacherNameRef = useRef(teacher?.name || "面试官");
+  const detachInterviewRemoteAudio = () => {
+    const audio = remoteAudioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.srcObject = null;
+  };
   useEffect(() => { onEndInterviewRef.current = onEndInterview; });
   useEffect(() => { teacherNameRef.current = teacher?.name || "面试官"; });
 
@@ -585,6 +591,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
       setEnding(true);
       setClosing(false);
       setStatus("面试已结束，正在生成报告");
+      detachInterviewRemoteAudio();
       onEndInterviewRef.current?.(sceneId, sessionIdRef.current, event.reportStatus || null);
     } else if (event.type === "local.interview_end_error") {
       setError(event.message || "面试自动结束失败");
@@ -682,6 +689,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
       cancelled = true;
       document.removeEventListener("visibilitychange", syncVisibility);
       interviewAnalyticsRef.current?.abandon("COMPONENT_UNMOUNT");
+      detachInterviewRemoteAudio();
       clientRef.current = null;
       void client.stop({ notifyBackend: false, reason: "component_unmount", emitEnded: false });
     };
@@ -713,6 +721,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     setEnding(true);
     setError("");
     setStatus("正在结束面试并生成报告");
+    detachInterviewRemoteAudio();
     try {
       const completion = await clientRef.current?.stop({ reason: "user_stop" });
       clientRef.current = null;
@@ -727,8 +736,11 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
   };
 
   const abandon = async () => {
+    if (endingRef.current) return;
+    endingRef.current = true;
     const client = clientRef.current;
     clientRef.current = null;
+    detachInterviewRemoteAudio();
     await client?.stop({ notifyBackend: false, reason: "user_exit", emitEnded: false });
     interviewAnalyticsRef.current?.abandon("USER_EXIT");
     onExit();

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -1704,6 +1704,12 @@ function CustomSceneConversation({
     lines,
     translated,
   });
+  const detachSceneRemoteAudio = () => {
+    const audio = remoteAudioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.srcObject = null;
+  };
 
   const updateLine = ({ id, who, text = "", delta = "", final = false }) => {
     const content = String(text || delta || "");
@@ -1786,6 +1792,7 @@ function CustomSceneConversation({
       setEnding(true);
     } else if (event.type === "local.ended" && event.reason === "state_machine") {
       sceneAnalyticsRef.current?.complete();
+      detachSceneRemoteAudio();
       clientRef.current = null;
       onComplete(
         true,
@@ -1794,6 +1801,7 @@ function CustomSceneConversation({
       );
     } else if (event.type === "local.scenario_completion_error") {
       sceneAnalyticsRef.current?.complete();
+      detachSceneRemoteAudio();
       clientRef.current = null;
       setError(event.message || "场景自动结束失败");
       onComplete(true, null, sessionIdRef.current);
@@ -1814,8 +1822,7 @@ function CustomSceneConversation({
     if (ended) {
       setEnding(true);
       setStatus("模拟对话已结束");
-      remoteAudioRef.current?.pause();
-      if (remoteAudioRef.current) remoteAudioRef.current.srcObject = null;
+      detachSceneRemoteAudio();
       return undefined;
     }
     let cancelled = false;
@@ -1852,6 +1859,7 @@ function CustomSceneConversation({
       cancelled = true;
       document.removeEventListener("visibilitychange", syncVisibility);
       sceneAnalyticsRef.current?.abandon("COMPONENT_UNMOUNT");
+      detachSceneRemoteAudio();
       clientRef.current = null;
       void client.stop({ notifyBackend: false, reason: "component_unmount", emitEnded: false });
     };
@@ -1874,6 +1882,7 @@ function CustomSceneConversation({
     endingRef.current = true;
     setEnding(true);
     setStatus("正在生成本次报告");
+    detachSceneRemoteAudio();
     try {
       const completion = await clientRef.current?.stop({ reason });
       clientRef.current = null;

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -1094,6 +1094,8 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
   const clientRef = useRef(null);
   const sessionIdRef = useRef("");
   const clientGenerationRef = useRef(0);
+  const startPromiseRef = useRef(null);
+  const stopPromiseRef = useRef(null);
   const freeChatAnalyticsRef = useRef(null);
   const remoteAudioRef = useRef(null);
   const { transcriptRef, handleTranscriptScroll } = useTranscriptAutoFollow({
@@ -1101,6 +1103,12 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
     lines,
     translated,
   });
+  const detachRemoteAudio = () => {
+    const audio = remoteAudioRef.current;
+    if (!audio) return;
+    audio.pause();
+    audio.srcObject = null;
+  };
   const toggleTranslation = async (index) => {
     const line = lines[index];
     if (!line) return;
@@ -1238,8 +1246,10 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
       return;
     }
     if (event.type === "local.ended") {
+      if (stopPromiseRef.current) return;
       freeChatAnalyticsRef.current?.complete();
       const completedSessionId = sessionIdRef.current;
+      detachRemoteAudio();
       setInCall(false);
       setSubtitles(false);
       setPaused(false);
@@ -1247,6 +1257,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
       setCallStatus("准备开始");
       clientRef.current = null;
       sessionIdRef.current = "";
+      clientGenerationRef.current += 1;
       onSessionEnded?.(completedSessionId);
       return;
     }
@@ -1287,36 +1298,46 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
   };
 
   const startConversation = async () => {
-    freeChatAnalyticsRef.current = analytics.training({ mode: "FREE_CHAT", pageCode: "conversation" });
-    freeChatAnalyticsRef.current.attempt();
-    await onBeforeStart?.();
-    setInCall(true);
-    setPaused(false);
-    setSubtitles(true);
-    setLines([]);
-    setTranslated([]);
-    setCallError("");
-    setCallState("connecting");
-    setCallStatus("正在请求麦克风");
-    const client = getClient();
-    const startGeneration = clientGenerationRef.current;
-    try {
-      const startedSession = await client.start({
-        voice: teacher.voiceId,
-        speechSpeed: speedCodeByLabel[speed] || "NATURAL",
-      });
-      if (clientRef.current !== client || clientGenerationRef.current !== startGeneration) return;
-      if (startedSession?.sessionId) {
-        freeChatAnalyticsRef.current.started();
-        sessionIdRef.current = startedSession.sessionId;
-        onSessionStarted?.(startedSession.sessionId);
+    if (startPromiseRef.current || stopPromiseRef.current) return;
+    let operation;
+    operation = (async () => {
+      freeChatAnalyticsRef.current = analytics.training({ mode: "FREE_CHAT", pageCode: "conversation" });
+      freeChatAnalyticsRef.current.attempt();
+      await onBeforeStart?.();
+      setInCall(true);
+      setPaused(false);
+      setSubtitles(true);
+      setLines([]);
+      setTranslated([]);
+      setCallError("");
+      setCallState("connecting");
+      setCallStatus("正在请求麦克风");
+      const client = getClient();
+      const startGeneration = clientGenerationRef.current;
+      try {
+        const startedSession = await client.start({
+          voice: teacher.voiceId,
+          speechSpeed: speedCodeByLabel[speed] || "NATURAL",
+        });
+        if (clientRef.current !== client || clientGenerationRef.current !== startGeneration) return;
+        if (startedSession?.sessionId) {
+          freeChatAnalyticsRef.current.started();
+          sessionIdRef.current = startedSession.sessionId;
+          onSessionStarted?.(startedSession.sessionId);
+        }
+      } catch (error) {
+        if (clientRef.current !== client) return;
+        freeChatAnalyticsRef.current.fail("REALTIME_ERROR");
+        setCallState("error");
+        setCallError(realtimeFailureMessage(error));
+        setCallStatus("连接失败");
       }
-    } catch (error) {
-      if (clientRef.current !== client) return;
-      freeChatAnalyticsRef.current.fail("REALTIME_ERROR");
-      setCallState("error");
-      setCallError(realtimeFailureMessage(error));
-      setCallStatus("连接失败");
+    })();
+    startPromiseRef.current = operation;
+    try {
+      await operation;
+    } finally {
+      if (startPromiseRef.current === operation) startPromiseRef.current = null;
     }
   };
 
@@ -1336,19 +1357,33 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
   };
 
   const stopConversation = async () => {
+    if (stopPromiseRef.current) return stopPromiseRef.current;
     const client = clientRef.current;
     const completedSessionId = sessionIdRef.current;
-    clientRef.current = null;
-    sessionIdRef.current = "";
-    clientGenerationRef.current += 1;
-    setInCall(false);
-    setSubtitles(false);
-    setPaused(false);
-    setCallState("idle");
-    setCallStatus("准备开始");
-    await client?.stop({ reason: "user_stop" });
-    freeChatAnalyticsRef.current?.complete();
-    onSessionEnded?.(completedSessionId);
+    setCallState("ending");
+    setCallStatus("正在结束对话");
+    setPaused(true);
+    detachRemoteAudio();
+    let operation;
+    operation = (async () => {
+      await client?.stop({ reason: "user_stop" });
+      if (clientRef.current === client) clientRef.current = null;
+      sessionIdRef.current = "";
+      clientGenerationRef.current += 1;
+      setInCall(false);
+      setSubtitles(false);
+      setPaused(false);
+      setCallState("idle");
+      setCallStatus("准备开始");
+      freeChatAnalyticsRef.current?.complete();
+      onSessionEnded?.(completedSessionId);
+    })();
+    stopPromiseRef.current = operation;
+    try {
+      await operation;
+    } finally {
+      if (stopPromiseRef.current === operation) stopPromiseRef.current = null;
+    }
   };
 
   useEffect(() => {
@@ -1358,6 +1393,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
     return () => {
       document.removeEventListener("visibilitychange", syncVisibility);
       freeChatAnalyticsRef.current?.abandon("COMPONENT_UNMOUNT");
+      detachRemoteAudio();
       const client = clientRef.current;
       clientRef.current = null;
       clientGenerationRef.current += 1;
@@ -1396,7 +1432,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
         {subtitles && <CallTranscript lines={lines} translated={translated} onToggleTranslation={toggleTranslation} transcriptRef={transcriptRef} onScroll={handleTranscriptScroll} emptyStatus={callStatus} />}
         {callError && <p className="call-error">{callError}</p>}
       </section>
-      <CallControls paused={paused} onToggleMicrophone={togglePaused} onEnd={stopConversation} disabled={callState === "ended"} subtitles={subtitles} onToggleSubtitles={() => setSubtitles(!subtitles)} />
+      <CallControls paused={paused} onToggleMicrophone={togglePaused} onEnd={stopConversation} disabled={callState === "ending" || callState === "ended"} subtitles={subtitles} onToggleSubtitles={() => setSubtitles(!subtitles)} />
     </main>
   );
 }

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -19,7 +19,7 @@ const DEFAULT_MODEL = "qwen3.5-omni-plus-realtime";
 const DATA_CHANNEL_LABEL = "oai-events";
 const DEFAULT_SPEECH_SPEED = "NATURAL";
 const DEFAULT_ICE_SERVERS = [
-  { urls: "stun:stun.aliyun.com:3478" },
+  { urls: "stun:stun.cloudflare.com:3478" },
   { urls: "stun:stun.l.google.com:19302" },
 ];
 const SCENARIO_CLOSING_TIMEOUT_MS = 20_000;
@@ -187,19 +187,158 @@ function normalizeSdp(sdp) {
   return normalized.endsWith("\r\n") ? normalized : `${normalized}\r\n`;
 }
 
-function waitForIceGathering(peer) {
-  if (peer.iceGatheringState === "complete") return Promise.resolve();
+function candidateType(candidate) {
+  const structuredType = String(candidate?.type || "").toLowerCase();
+  if (["host", "srflx", "prflx", "relay"].includes(structuredType)) return structuredType;
+  const match = String(candidate?.candidate || candidate || "")
+    .match(/\btyp\s+(host|srflx|prflx|relay)\b/i);
+  return match?.[1]?.toLowerCase() || "unknown";
+}
+
+function candidateSummaryFromSdp(sdp) {
+  const summary = { host: 0, srflx: 0, prflx: 0, relay: 0, unknown: 0 };
+  String(sdp || "").split(/\r?\n/).forEach((line) => {
+    if (!line.startsWith("a=candidate:")) return;
+    summary[candidateType(line)] += 1;
+  });
+  return summary;
+}
+
+function candidateTotal(summary) {
+  return Object.values(summary).reduce((total, count) => total + count, 0);
+}
+
+function createRealtimeError(code, message, diagnostics = null) {
+  const error = new Error(message);
+  error.code = code;
+  if (diagnostics) error.realtimeDiagnostics = diagnostics;
+  return error;
+}
+
+export function waitForIceGathering(peer, { timeoutMs = 10_000 } = {}) {
+  const initialCandidates = candidateSummaryFromSdp(peer?.localDescription?.sdp);
+  if (peer?.iceGatheringState === "complete") {
+    return Promise.resolve({
+      complete: true,
+      timedOut: false,
+      candidates: initialCandidates,
+    });
+  }
   return new Promise((resolve, reject) => {
-    const timer = window.setTimeout(() => reject(new Error("ICE 候选收集超时")), 10_000);
-    const previous = peer.onicegatheringstatechange;
-    peer.onicegatheringstatechange = () => {
-      previous?.();
-      if (peer.iceGatheringState === "complete") {
-        window.clearTimeout(timer);
-        resolve();
+    const candidates = { ...initialCandidates };
+    let settled = false;
+    const supportsEventListeners = typeof peer?.addEventListener === "function";
+    const previousGatheringHandler = peer?.onicegatheringstatechange;
+    const previousCandidateHandler = peer?.onicecandidate;
+
+    const cleanup = () => {
+      window.clearTimeout(timer);
+      if (supportsEventListeners) {
+        peer.removeEventListener?.("icegatheringstatechange", handleGatheringState);
+        peer.removeEventListener?.("icecandidate", handleCandidate);
+      } else {
+        peer.onicegatheringstatechange = previousGatheringHandler || null;
+        peer.onicecandidate = previousCandidateHandler || null;
       }
     };
+    const finish = (result, error = null) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      error ? reject(error) : resolve(result);
+    };
+    const currentSummary = () => {
+      const fromDescription = candidateSummaryFromSdp(peer?.localDescription?.sdp);
+      const merged = {};
+      Object.keys(candidates).forEach((type) => {
+        merged[type] = Math.max(candidates[type], fromDescription[type]);
+      });
+      return merged;
+    };
+    const handleGatheringState = (event) => {
+      if (!supportsEventListeners) previousGatheringHandler?.call(peer, event);
+      if (peer?.signalingState === "closed") {
+        finish(null, createRealtimeError("WEBRTC_START_CANCELLED", "实时会话启动已取消"));
+        return;
+      }
+      if (peer?.iceGatheringState === "complete") {
+        finish({ complete: true, timedOut: false, candidates: currentSummary() });
+      }
+    };
+    const handleCandidate = (event) => {
+      if (!supportsEventListeners) previousCandidateHandler?.call(peer, event);
+      if (!event?.candidate) return;
+      candidates[candidateType(event.candidate)] += 1;
+    };
+
+    const timer = window.setTimeout(() => {
+      const summary = currentSummary();
+      const diagnostics = {
+        iceGatheringState: peer?.iceGatheringState || "unknown",
+        candidates: summary,
+      };
+      if (candidateTotal(summary) > 0) {
+        finish({ complete: false, timedOut: true, candidates: summary });
+        return;
+      }
+      finish(null, createRealtimeError(
+        "WEBRTC_ICE_GATHERING_NO_CANDIDATE",
+        "ICE 候选收集超时，未发现可用候选",
+        diagnostics,
+      ));
+    }, timeoutMs);
+
+    if (supportsEventListeners) {
+      peer.addEventListener("icegatheringstatechange", handleGatheringState);
+      peer.addEventListener("icecandidate", handleCandidate);
+    } else {
+      peer.onicegatheringstatechange = handleGatheringState;
+      peer.onicecandidate = handleCandidate;
+    }
+    handleGatheringState();
   });
+}
+
+export function releaseRealtimeTransport({
+  peer = null,
+  channels = [],
+  localStream = null,
+  remoteStreams = [],
+  audioSender = null,
+} = {}) {
+  try {
+    const replacement = audioSender?.replaceTrack?.(null);
+    replacement?.catch?.(() => undefined);
+  } catch {
+    // The sender may already have been detached by the browser.
+  }
+  localStream?.getTracks?.().forEach((track) => {
+    try { track.stop(); } catch { /* already stopped */ }
+  });
+  remoteStreams.forEach((stream) => stream?.getTracks?.().forEach((track) => {
+    try { track.stop(); } catch { /* already stopped */ }
+  }));
+  channels.forEach((dataChannel) => {
+    try {
+      dataChannel.onopen = null;
+      dataChannel.onmessage = null;
+      dataChannel.onerror = null;
+      dataChannel.onclose = null;
+      dataChannel.close?.();
+    } catch {
+      // The data channel may already be closed.
+    }
+  });
+  try {
+    if (peer) {
+      peer.ontrack = null;
+      peer.ondatachannel = null;
+      peer.onconnectionstatechange = null;
+      peer.close?.();
+    }
+  } catch {
+    // The peer connection may already be closed.
+  }
 }
 
 function waitForChannel(channel, peer) {
@@ -210,6 +349,7 @@ function waitForChannel(channel, peer) {
       window.clearTimeout(timer);
       channel.removeEventListener?.("open", handleOpen);
       channel.removeEventListener?.("error", handleError);
+      channel.removeEventListener?.("close", handleClose);
       peer?.removeEventListener?.("iceconnectionstatechange", handleIceState);
     };
     const finish = (error) => {
@@ -220,6 +360,10 @@ function waitForChannel(channel, peer) {
     };
     const handleOpen = () => finish();
     const handleError = () => finish(new Error("实时数据通道连接失败"));
+    const handleClose = () => finish(createRealtimeError(
+      "WEBRTC_START_CANCELLED",
+      "实时会话启动已取消",
+    ));
     const handleIceState = () => {
       const state = peer?.iceConnectionState;
       if (state === "failed" || state === "disconnected") {
@@ -236,8 +380,12 @@ function waitForChannel(channel, peer) {
     channel.onerror = () => {
       handleError();
     };
+    channel.onclose = () => {
+      handleClose();
+    };
     channel.addEventListener?.("open", handleOpen);
     channel.addEventListener?.("error", handleError);
+    channel.addEventListener?.("close", handleClose);
     peer?.addEventListener?.("iceconnectionstatechange", handleIceState);
     handleIceState();
   });
@@ -389,8 +537,10 @@ export function createRealtimeClient({
   const manualTurnResponses = Boolean(customSceneId || ieltsSceneId || interviewSceneId);
   let peer = null;
   let channel = null;
+  let dataChannels = new Set();
   let sessionSocket = null;
   let localStream = null;
+  let remoteStreams = new Set();
   let audioSender = null;
   let sessionId = null;
   let sessionConfig = null;
@@ -404,7 +554,10 @@ export function createRealtimeClient({
   let sessionUpdateRetryTimer = null;
   let initialResponseStarted = false;
   let initialResponseFallbackTimer = null;
+  let startPromise = null;
   let stopPromise = null;
+  let lifecycleState = "idle";
+  let startSequence = 0;
   let segmentRecorder = null;
   let learnerTurnNo = 0;
   let pendingOperations = new Set();
@@ -433,6 +586,54 @@ export function createRealtimeClient({
   let providerSessionBound = false;
 
   const emit = (event) => onEvent(event);
+
+  function releaseCurrentTransport() {
+    const transport = {
+      peer,
+      channels: [...dataChannels],
+      localStream,
+      remoteStreams: [...remoteStreams],
+      audioSender,
+    };
+    peer = null;
+    channel = null;
+    dataChannels = new Set();
+    localStream = null;
+    remoteStreams = new Set();
+    audioSender = null;
+    releaseRealtimeTransport(transport);
+  }
+
+  function assertCurrentStart(attempt) {
+    if (attempt === startSequence && lifecycleState === "starting") return;
+    throw createRealtimeError("WEBRTC_START_CANCELLED", "实时会话启动已取消");
+  }
+
+  function startFailureDiagnostic(error, stage, startedAt, iceResult) {
+    const code = error?.code || (isMicFailure(error)
+      ? "WEBRTC_MICROPHONE_UNAVAILABLE"
+      : {
+        microphone: "WEBRTC_MICROPHONE_UNAVAILABLE",
+        ice_gathering: "WEBRTC_ICE_GATHERING_FAILED",
+        backend_start: "WEBRTC_SIGNALING_FAILED",
+        session_websocket: "SESSION_WEBSOCKET_FAILED",
+        remote_description: "WEBRTC_REMOTE_DESCRIPTION_FAILED",
+        data_channel: "WEBRTC_DATA_CHANNEL_FAILED",
+      }[stage] || "WEBRTC_START_FAILED");
+    return {
+      code,
+      stage,
+      elapsedMs: Math.max(0, Date.now() - startedAt),
+      errorName: error?.name || "Error",
+      iceGatheringState: peer?.iceGatheringState || error?.realtimeDiagnostics?.iceGatheringState || "unknown",
+      iceConnectionState: peer?.iceConnectionState || "unknown",
+      connectionState: peer?.connectionState || "unknown",
+      signalingState: peer?.signalingState || "unknown",
+      dataChannelState: channel?.readyState || "unknown",
+      candidates: iceResult?.candidates || error?.realtimeDiagnostics?.candidates
+        || { host: 0, srflx: 0, prflx: 0, relay: 0, unknown: 0 },
+    };
+  }
 
   function setTrackEnabled() {
     const track = localStream?.getAudioTracks?.()[0];
@@ -1315,35 +1516,44 @@ export function createRealtimeClient({
     }
   }
 
-  async function start({
+  async function performStart({
     voice = DEFAULT_VOICE,
     speechSpeed = DEFAULT_SPEECH_SPEED,
     silenceDurationMs = null,
     turnDetectionType = null,
     interruptResponse = null,
-  } = {}) {
-    if (peer) return { sessionId };
+  } = {}, attempt) {
+    const startedAt = Date.now();
+    let stage = "peer_connection";
+    let iceResult = null;
     emit({ type: "local.connecting" });
 
     try {
       peer = new RTCPeerConnection({ iceServers: defaultIceServers() });
       peer.ontrack = (event) => {
         const stream = event.streams?.[0];
-        if (stream) onRemoteStream(stream);
+        if (stream) {
+          remoteStreams.add(stream);
+          onRemoteStream(stream);
+        }
       };
       peer.onconnectionstatechange = () => {
         emit({ type: "local.connection_state", state: peer?.connectionState });
       };
 
+      stage = "microphone";
       localStream = await navigator.mediaDevices.getUserMedia({
         audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
       });
+      assertCurrentStart(attempt);
       if (customSceneId || ieltsSceneId || interviewSceneId) {
         try {
           segmentRecorder = await withTimeout(
             createPcmWavSegmentRecorder(localStream), 3_000, "录音器初始化超时");
+          assertCurrentStart(attempt);
           turnAudioCapture = createTurnAudioCaptureController(segmentRecorder);
         } catch (recorderError) {
+          if (recorderError?.code === "WEBRTC_START_CANCELLED") throw recorderError;
           segmentRecorder = null;
           turnAudioCapture = null;
           emit({ type: "local.provider_warning", message: "逐轮录音不可用，本轮评分将仅基于文本" });
@@ -1353,22 +1563,33 @@ export function createRealtimeClient({
       audioTrack.enabled = false;
       audioSender = peer.addTrack(audioTrack, localStream);
       await audioSender.replaceTrack(null);
+      assertCurrentStart(attempt);
 
       channel = peer.createDataChannel(DATA_CHANNEL_LABEL);
+      dataChannels.add(channel);
       channel.onmessage = (message) => { void handleProviderEvent(message.data); };
       peer.ondatachannel = (event) => {
         const incoming = event.channel;
+        dataChannels.add(incoming);
         incoming.onmessage = (message) => { void handleProviderEvent(message.data); };
+        incoming.addEventListener?.("close", () => dataChannels.delete(incoming), { once: true });
       };
 
+      stage = "offer";
       const offer = await peer.createOffer();
+      assertCurrentStart(attempt);
       await peer.setLocalDescription(offer);
-      await waitForIceGathering(peer);
+      assertCurrentStart(attempt);
+      stage = "ice_gathering";
+      iceResult = await waitForIceGathering(peer);
+      assertCurrentStart(attempt);
 
+      stage = "backend_start";
       const backend = await postStart({
         offerSdp: peer.localDescription?.sdp || offer.sdp || "",
         voice,
       });
+      assertCurrentStart(attempt);
       sessionId = backend.sessionId;
       providerSessionId = extractProviderSessionId(backend);
       providerSessionBound = Boolean(providerSessionId);
@@ -1406,14 +1627,22 @@ export function createRealtimeClient({
       });
       baseSessionInstructions = sessionConfig.instructions;
 
+      stage = "session_websocket";
       await connectSessionSocket();
+      assertCurrentStart(attempt);
+      stage = "remote_description";
       await peer.setRemoteDescription({ type: "answer", sdp: normalizeSdp(backend.answerSdp) });
+      assertCurrentStart(attempt);
+      stage = "data_channel";
       await waitForChannel(channel, peer);
+      assertCurrentStart(attempt);
       started = true;
       const connectedAudioTrack = localStream?.getAudioTracks?.()[0];
       if (connectedAudioTrack && audioSender?.track !== connectedAudioTrack) {
         await audioSender?.replaceTrack(connectedAudioTrack);
+        assertCurrentStart(attempt);
       }
+      lifecycleState = "active";
       setTrackEnabled();
       sendSessionUpdate();
       sessionUpdateRetryTimer = window.setTimeout(() => {
@@ -1425,17 +1654,43 @@ export function createRealtimeClient({
       emit({ type: "local.connected", sessionId, backend });
       return { sessionId, backend };
     } catch (error) {
+      const diagnostic = startFailureDiagnostic(error, stage, startedAt, iceResult);
+      releaseCurrentTransport();
       await stop({ notifyBackend: false, reason: "start_failed", emitEnded: false });
+      if (diagnostic.code === "WEBRTC_START_CANCELLED") throw error;
       const mic = isMicFailure(error);
-		const message = mic
-		  ? micFailureMessage(error) || "无法访问麦克风"
-		  : realtimeFailureMessage(error);
+      const message = mic
+        ? micFailureMessage(error) || "无法访问麦克风"
+        : realtimeFailureMessage(error);
+      console.warn("realtime.start.failed", diagnostic);
       emit({
         type: mic ? "local.mic_error" : "local.error",
         message,
+        code: diagnostic.code,
+        diagnostic,
       });
       throw mic ? error : new Error(message, { cause: error });
     }
+  }
+
+  function start(options = {}) {
+    if (lifecycleState === "active") return Promise.resolve({ sessionId });
+    if (startPromise) return startPromise;
+    if (stopPromise) {
+      return stopPromise.then(
+        () => start(options),
+        () => start(options),
+      );
+    }
+    lifecycleState = "starting";
+    const attempt = ++startSequence;
+    const operation = performStart(options, attempt);
+    const trackedOperation = operation.finally(() => {
+      if (startPromise === trackedOperation) startPromise = null;
+      if (lifecycleState === "starting") lifecycleState = peer ? "active" : "idle";
+    });
+    startPromise = trackedOperation;
+    return trackedOperation;
   }
 
   function setMuted(value) {
@@ -1546,7 +1801,7 @@ export function createRealtimeClient({
     started = false;
     inputReady = false;
     setTrackEnabled();
-    localStream?.getTracks?.().forEach((track) => track.stop());
+    releaseCurrentTransport();
 
     // IELTS 的整场评分依赖逐轮发音评分已落库；结束会话前给评分请求
     // 足够时间完成，避免总评先于最后一轮 turn_evaluation 查询。
@@ -1567,8 +1822,6 @@ export function createRealtimeClient({
           : sendSessionFrame("end", null, stopTime)
       : Promise.resolve(null);
 
-    try { channel?.close?.(); } catch { /* already closed */ }
-    try { peer?.close?.(); } catch { /* already closed */ }
     let completion = null;
     let completionError = null;
     try {
@@ -1658,8 +1911,10 @@ export function createRealtimeClient({
       if (scenarioAudioDrainTimer) window.clearTimeout(scenarioAudioDrainTimer);
       peer = null;
       channel = null;
+      dataChannels = new Set();
       sessionSocket = null;
       localStream = null;
+      remoteStreams = new Set();
       audioSender = null;
       sessionId = null;
       providerSessionId = null;
@@ -1695,6 +1950,7 @@ export function createRealtimeClient({
       initialResponseStarted = false;
       paused = false;
       muted = false;
+      lifecycleState = "idle";
     }
     if (completionError && (customSceneId || ieltsSceneId || interviewSceneId)) throw completionError;
     if (emitEnded) emit({ type: "local.ended", reason, completion });
@@ -1703,9 +1959,14 @@ export function createRealtimeClient({
 
   function stop(options = {}) {
     if (!stopPromise) {
-      stopPromise = performStop(options).finally(() => {
-        stopPromise = null;
+      startSequence += 1;
+      lifecycleState = "stopping";
+      const operation = performStop(options);
+      const trackedOperation = operation.finally(() => {
+        if (stopPromise === trackedOperation) stopPromise = null;
+        lifecycleState = "idle";
       });
+      stopPromise = trackedOperation;
     }
     return stopPromise;
   }
@@ -1723,6 +1984,6 @@ export function createRealtimeClient({
     waitForEvaluations,
     stop,
     setMuted,
-    isActive: () => Boolean(peer || sessionId),
+    isActive: () => lifecycleState !== "idle" || Boolean(peer || sessionId),
   };
 }


### PR DESCRIPTION
## 背景

Web Realtime 会话存在偶发连接失败，主要表现为：

- 第一次对话可以成功，结束后再次启动容易失败。
- 新浏览器配置首次成功，后续连接失败。
- 重置 Chrome 网站麦克风权限后，下一次连接可以恢复。
- 部分失败发生在 `POST /api/scene-sessions` 之前，后端没有对应会话日志。

排查发现，前端在旧会话尚未完成清理时已经允许用户重新启动，同时 ICE 收集必须在 10 秒内进入 `complete`，否则即使已经存在候选也会直接失败。

## 修改内容

### Realtime 生命周期

- 增加 `idle / starting / active / stopping` 生命周期状态。
- 合并并复用重复的启动和停止 Promise。
- 删除仅根据 `peer` 判断会话已启动的模糊短路。
- 支持在启动过程中安全取消连接。
- 停止会话时优先释放：
  - 本地麦克风轨道
  - 远端媒体轨道
  - RTCRtpSender
  - DataChannel
  - RTCPeerConnection
- 媒体传输资源释放后，再等待消息落库、评分和后端结束请求。

### ICE 建连

- 将不可解析的 `stun.aliyun.com` 替换为 `stun.cloudflare.com`。
- 保留 Google STUN 作为第二候选。
- ICE 收集超时时：
  - 已存在候选：使用当前 SDP 继续信令交换。
  - 没有任何候选：返回 `WEBRTC_ICE_GATHERING_NO_CANDIDATE`。
- 增加 host、srflx、prflx、relay 候选数量统计。

### 安全诊断

增加 Realtime 启动失败阶段和状态诊断，包括：

- 失败阶段
- 耗时
- ICE gathering/connection 状态
- PeerConnection 状态
- DataChannel 状态
- 候选类型数量

诊断信息不包含完整 SDP、JWT、临时凭证、ICE 密码或音频数据。

### 页面生命周期

以下入口统一增加远端音频解绑和幂等结束保护：

- 自由对话
- 自定义场景
- IELTS
- 面试

自由对话在 `client.stop()` 完成之前不会重新显示开始入口，避免旧连接和新连接重叠。

## 测试

已执行并通过：

```bash
npm run check:realtime-events
npm run check:routes
npm run test:analytics
npm run build