### PR TITLE
fix(mobile): prevent untranslated scene preview flash

### DIFF
--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -71,6 +71,13 @@ const stages = [
 
 type TrainingStage = (typeof stages)[number]['key'];
 
+const chineseCharacterPattern = /[\u3400-\u9fff]/;
+
+function previewText(value: string, fallback: string, maxLength: number) {
+  const source = String(value ?? '').trim();
+  return chineseCharacterPattern.test(source) ? source.slice(0, maxLength) : fallback;
+}
+
 function StageProgressRail({
   stage,
   unlockedStage,
@@ -1048,16 +1055,18 @@ export function ScenesHome({
             </Pressable>
             <Text style={styles.previewEyebrow}>场景已准备好</Text>
             <View style={styles.previewTitleRow}>
-            <Text style={styles.previewTitle}>{previewDisplay?.title || preview.title}</Text>
+              <Text style={styles.previewTitle}>
+                {previewDisplay?.title || previewText(preview.title, '正在整理场景…', 18)}
+              </Text>
               <SceneCategoryTag category={sceneCategoryForLabel(preview.label)} />
             </View>
             <Text style={styles.previewLead}>场景已生成，确认后即可开始练习。</Text>
             <View style={styles.previewSummary}>
               {[
-                ['场景简介', previewDisplay?.background || preview.background],
-                ['AI 扮演', previewDisplay?.aiRole || preview.aiRole],
-                ['你将扮演', previewDisplay?.userRole || preview.userRole],
-                ['练习重点', previewDisplay?.learningGoal || preview.learningGoal],
+                ['场景简介', previewDisplay?.background || previewText(preview.background, '正在整理中文摘要…', 58)],
+                ['AI 扮演', previewDisplay?.aiRole || previewText(preview.aiRole, '正在整理…', 22)],
+                ['你将扮演', previewDisplay?.userRole || previewText(preview.userRole, '正在整理…', 22)],
+                ['练习重点', previewDisplay?.learningGoal || previewText(preview.learningGoal, '正在整理中文摘要…', 42)],
                 ['预计用时', `${preview.estimatedMinutes} 分钟`],
               ].map(([label, value]) => (
                 <View key={label} style={styles.previewSummaryRow}>

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -8,6 +8,12 @@ import type {
 } from '@/features/realtime/RealtimeSessionController';
 import type { FreeChatControllerPort } from '@/features/conversation/useFreeChatSession';
 
+const mockTranslateScene = jest.fn();
+
+jest.mock('@/features/conversation/TranscriptTranslationApi', () => ({
+  createTranscriptTranslationApi: () => ({ translateScene: mockTranslateScene }),
+}));
+
 jest.mock('react-native-reanimated', () => {
   const { View } = require('react-native');
   return {
@@ -165,6 +171,45 @@ describe('ScenesHome backend generation binding', () => {
     await fireEvent.press(screen.getByText('开始练习'));
     expect(onStartScene).toHaveBeenCalledTimes(1);
     expect(onOpen).toHaveBeenCalledWith({ name: 'training', scene });
+  });
+
+  it('does not show untranslated English in the preview', async () => {
+    const resolveTranslations: Array<(value: string) => void> = [];
+    mockTranslateScene.mockImplementation(
+      () => new Promise<string>((resolve) => resolveTranslations.push(resolve)),
+    );
+    const englishScene = {
+      ...scene,
+      title: 'Coffee Shop Order',
+      background: 'Order a coffee and customize the drink.',
+      aiRole: 'Barista',
+      userRole: 'Customer',
+      learningGoal: 'Practice ordering and confirming details.',
+    };
+    const screen = await render(
+      <ScenesHome
+        onOpen={jest.fn()}
+        sceneService={{ generate: jest.fn(async () => englishScene) }}
+      />,
+    );
+
+    await fireEvent.changeText(
+      screen.getByLabelText('描述想练习的场景'),
+      '咖啡店点单',
+    );
+    await fireEvent.press(screen.getByLabelText('生成练习场景'));
+
+    await waitFor(() => expect(screen.getByText('正在整理场景…')).toBeTruthy());
+    expect(screen.queryByText('Coffee Shop Order')).toBeNull();
+    expect(screen.queryByText('Barista')).toBeNull();
+    expect(screen.getAllByText('正在整理中文摘要…')).toHaveLength(2);
+    expect(screen.getAllByText('正在整理…')).toHaveLength(2);
+
+    await act(async () => {
+      resolveTranslations.forEach((resolve) => resolve('咖啡店点单'));
+    });
+    await waitFor(() => expect(screen.getAllByText('咖啡店点单').length).toBeGreaterThan(0));
+    expect(mockTranslateScene).toHaveBeenCalled();
   });
 
   it('shows a generation error without opening a fake preview', async () => {


### PR DESCRIPTION
## Summary

- Prevent the mobile custom-scene preview modal from briefly displaying untranslated English content.
- Show Chinese placeholders while asynchronous translations are pending.
- Add a regression test covering the untranslated and translated states.

## Root Cause

The mobile preview modal was rendered immediately after scene generation and used the raw scene fields as fallbacks. Some generated fields can be English, while the translation requests complete asynchronously afterward. This caused a brief English flash before the modal updated with Chinese text.

## Changes

- Added local Chinese-content detection for the mobile scene preview.
- Displayed Chinese placeholders for untranslated English fields.
- Preserved the existing asynchronous translation flow.
- Added a regression test to verify that untranslated English is not shown.

## Scope

- Mobile frontend only.
- No backend or Web changes.

## Validation

- Mobile test suite: 46 suites passed, 220 tests passed.
- TypeScript check passed.
- Web production build passed.
- `git diff --check` passed.

Close #117 