### PR TITLE
fix: lock generated scene text and align pronunciation voices

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/ai/qwen/QwenTtsProvider.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/ai/qwen/QwenTtsProvider.java
@@ -33,6 +33,14 @@ import tools.jackson.databind.ObjectMapper;
 @Component
 public class QwenTtsProvider extends TtsProvider {
 
+	private static final Map<String, String> PRODUCT_VOICE_MAPPING = Map.of(
+			"Katerina", "Katerina",
+			"Aiden", "Aiden",
+			"Dolce", "Dolce",
+			"Harvey", "Neil",
+			"Raymond", "Ryan",
+			"Tina", "Serena");
+
 	private static final int MAX_TEXT_LENGTH = 5_000;
 	private static final int DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024;
 	private static final int DEFAULT_MAX_AUDIO_BYTES = 10 * 1024 * 1024;
@@ -136,6 +144,11 @@ public class QwenTtsProvider extends TtsProvider {
 
 	@Override
 	public byte[] generateSpeechAudio(String text, String token) {
+		return generateSpeechAudio(text, token, voice);
+	}
+
+	@Override
+	public byte[] generateSpeechAudio(String text, String token, String requestedVoice) {
 		String credential = ProviderCredentialOverride.currentOr(apiKey);
 		if (credential.isBlank()) {
 			throw retryableFailure(
@@ -143,21 +156,23 @@ public class QwenTtsProvider extends TtsProvider {
 					"Set DASHSCOPE_API_KEY before calling Qwen TTS");
 		}
 		String normalizedText = trim(text);
-		return cachedSynthesize(normalizedText, credential);
+		String qwenVoice = resolveVoice(requestedVoice);
+		return cachedSynthesize(normalizedText, credential, qwenVoice);
 	}
 
-	private byte[] cachedSynthesize(String text, String credential) {
+	private byte[] cachedSynthesize(String text, String credential, String qwenVoice) {
+		String cacheKey = qwenVoice + ":" + text;
 		long now = System.nanoTime();
-		CachedAudio cached = audioCache.get(text);
+		CachedAudio cached = audioCache.get(cacheKey);
 		if (cached != null && now - cached.createdAtNanos() < CACHE_TTL_NANOS) {
 			return cached.audio();
 		}
 		if (cached != null) {
-			audioCache.remove(text, cached);
+			audioCache.remove(cacheKey, cached);
 		}
 
 		CompletableFuture<byte[]> pending = new CompletableFuture<>();
-		CompletableFuture<byte[]> existing = inFlightAudio.putIfAbsent(text, pending);
+		CompletableFuture<byte[]> existing = inFlightAudio.putIfAbsent(cacheKey, pending);
 		if (existing != null) {
 			try {
 				return existing.join();
@@ -171,8 +186,8 @@ public class QwenTtsProvider extends TtsProvider {
 		}
 
 		try {
-			byte[] audio = synthesize(text, credential);
-			cacheAudio(text, audio, System.nanoTime());
+			byte[] audio = synthesize(text, credential, qwenVoice);
+			cacheAudio(cacheKey, audio, System.nanoTime());
 			pending.complete(audio);
 			return audio;
 		}
@@ -181,7 +196,7 @@ public class QwenTtsProvider extends TtsProvider {
 			throw exception;
 		}
 		finally {
-			inFlightAudio.remove(text, pending);
+			inFlightAudio.remove(cacheKey, pending);
 		}
 	}
 
@@ -197,7 +212,7 @@ public class QwenTtsProvider extends TtsProvider {
 		audioCache.put(text, new CachedAudio(audio, createdAtNanos));
 	}
 
-	private byte[] synthesize(String textValue, String credential) {
+	private byte[] synthesize(String textValue, String credential, String qwenVoice) {
 		String text = trim(textValue);
 		if (text.isBlank()) {
 			throw nonRetryableFailure(
@@ -215,7 +230,7 @@ public class QwenTtsProvider extends TtsProvider {
 		try {
 			Map<String, Object> input = Map.of(
 					"text", text,
-					"voice", voice,
+					"voice", qwenVoice,
 					"language_type", languageType);
 			HttpRequest synthesisRequest = HttpRequest.newBuilder()
 					.uri(endpoint)
@@ -282,6 +297,12 @@ public class QwenTtsProvider extends TtsProvider {
 					"QWEN_TTS_INTERRUPTED",
 					"Qwen TTS call was interrupted");
 		}
+	}
+
+	private String resolveVoice(String requestedVoice) {
+		String candidate = trim(requestedVoice);
+		if (candidate.isBlank()) return voice;
+		return PRODUCT_VOICE_MAPPING.getOrDefault(candidate, voice);
 	}
 
 	private URI audioUri(byte[] responseBody) throws JacksonException {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/provider/AbstractAiProvider.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/provider/AbstractAiProvider.java
@@ -18,6 +18,18 @@ public abstract class AbstractAiProvider implements AiProvider {
 		return new AiProviderResponse<>(response, null, ProviderUsage.tts(text, response));
 	}
 
+	public AiProviderResponse<byte[]> generateSpeechAudioMeasured(
+			String text,
+			String token,
+			String voice) {
+		byte[] response = generateSpeechAudio(text, token, voice);
+		return new AiProviderResponse<>(response, null, ProviderUsage.tts(text, response));
+	}
+
+	public byte[] generateSpeechAudio(String text, String token, String voice) {
+		return generateSpeechAudio(text, token);
+	}
+
 	public AiProviderResponse<String> convertAudioToTextMeasured(byte[] audio, String token) {
 		String response = convertAudioToText(audio, token);
 		return new AiProviderResponse<>(response, null, ProviderUsage.audioInput(audio, response));

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/provider/AiProviderRegistry.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/provider/AiProviderRegistry.java
@@ -359,6 +359,30 @@ public class AiProviderRegistry {
 				id -> getTtsProvider(id).generateSpeechAudioMeasured(text, credential(id, token)));
 	}
 
+	public byte[] generateSpeechAudioBytes(
+			String modelId,
+			String text,
+			String token,
+			String voice) {
+		return generateSpeechAudioBytes(automaticContext("tts"), modelId, text, token, voice);
+	}
+
+	public byte[] generateSpeechAudioBytes(
+			AiInvocationContext context,
+			String modelId,
+			String text,
+			String token,
+			String voice) {
+		if (modelId == null || modelId.isBlank()) {
+			throw new BusinessException(
+					"AI_TTS_MODEL_REQUIRED",
+					"A voice-specific TTS request requires an explicit model");
+		}
+		return invokeExplicitMeasured(context, AiCapability.TTS, modelId,
+				id -> getTtsProvider(id).generateSpeechAudioMeasured(
+						text, credential(id, token), voice));
+	}
+
 	public String executeLlmTask(String modelId, String prompt, String token) {
 		return executeLlmTask(automaticContext("llm"), modelId, prompt, token);
 	}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/CustomSceneService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/CustomSceneService.java
@@ -89,13 +89,16 @@ public class CustomSceneService {
 				generated.scenePrompt());
 	}
 	public byte[] synthesizeSpeech(String sceneId, String text, String model) {
-		requireOwnedCustomScene(sceneId);
+		CustomSceneDefinition definition = requireOwnedCustomScene(sceneId);
 		if (text == null || text.isBlank()) {
 			throw new BusinessException("TTS_TEXT_REQUIRED", "朗读文本不能为空");
 		}
-		byte[] audio = model == null || model.isBlank()
-				? providerRegistry.generateSpeechAudioBytes(text.strip(), null)
-				: providerRegistry.generateSpeechAudioBytes(model, text.strip(), null);
+		UserProfile profile = profileService.getProfile(definition.userId());
+		byte[] audio = providerRegistry.generateSpeechAudioBytes(
+				AiProviderRegistry.QWEN_TTS,
+				text.strip(),
+				null,
+				profile == null ? null : profile.voiceId());
 		if (audio == null || audio.length == 0) {
 			throw new BusinessException("TTS_AUDIO_EMPTY", "TTS 未返回音频");
 		}

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -789,11 +789,13 @@ function createDefaultTtsPlayer() {
 function ScenePromptInput({
   value,
   onChangeText,
+  editable = true,
   placeholder,
   placeholderTextColor,
 }: {
   value: string;
   onChangeText: (value: string) => void;
+  editable?: boolean;
   placeholder: string;
   placeholderTextColor: string;
 }) {
@@ -837,6 +839,7 @@ function ScenePromptInput({
       ) : null}
       <TextInput
         accessibilityLabel="描述想练习的场景"
+        editable={editable}
         multiline
         maxLength={200}
         onBlur={() => setFocused(false)}
@@ -873,6 +876,7 @@ export function ScenesHome({
   const [generatingSource, setGeneratingSource] = useState<'custom' | string | null>(null);
   const [generationError, setGenerationError] = useState<string | null>(null);
   const generating = generatingSource !== null;
+  const promptLocked = generating || Boolean(preview);
   useEffect(() => {
     if (Platform.OS !== 'android' || !preview) return;
 
@@ -948,6 +952,7 @@ export function ScenesHome({
             </View>
           </View>
           <ScenePromptInput
+            editable={!promptLocked}
             onChangeText={setPrompt}
             placeholder={`你今天想练习什么？例如：${promptExample.prompt}`}
             placeholderTextColor="#8D8D88"
@@ -958,16 +963,16 @@ export function ScenesHome({
             <Pressable
               accessibilityRole="button"
               accessibilityLabel="生成练习场景"
-              disabled={!prompt.trim() || generating}
+              disabled={!prompt.trim() || promptLocked}
               onPress={() => void generatePreview(prompt, 'custom')}
               style={({ pressed }) => [
                 styles.generateButton,
-                prompt.trim() && !generating ? styles.generateButtonReady : styles.generateButtonDisabled,
-                pressed && prompt.trim() && !generating && styles.generateButtonPressed,
+                prompt.trim() && !promptLocked ? styles.generateButtonReady : styles.generateButtonDisabled,
+                pressed && prompt.trim() && !promptLocked && styles.generateButtonPressed,
               ]}
             >
-              <Text style={[styles.generateButtonText, prompt.trim() && !generating ? styles.generateButtonTextActive : styles.generateButtonTextDisabled]}>{generatingSource === 'custom' ? '正在生成…' : '生成练习场景'}</Text>
-              <AppIcon name="arrow-right" size={18} color={prompt.trim() && !generating ? colors.white : '#7896B8'} />
+              <Text style={[styles.generateButtonText, prompt.trim() && !promptLocked ? styles.generateButtonTextActive : styles.generateButtonTextDisabled]}>{generatingSource === 'custom' ? '正在生成…' : '生成练习场景'}</Text>
+              <AppIcon name="arrow-right" size={18} color={prompt.trim() && !promptLocked ? colors.white : '#7896B8'} />
             </Pressable>
           </View>
         </View>

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -173,6 +173,7 @@ describe('ScenesHome backend generation binding', () => {
 
     await waitFor(() => expect(screen.getByText('机场行李托运')).toBeTruthy());
     expect(sceneService.generate).toHaveBeenCalledWith('我想练习机场托运行李');
+    expect(screen.getByLabelText('描述想练习的场景').props.editable).toBe(false);
     expect(screen.getByText('AI 扮演')).toBeTruthy();
     expect(screen.getByText('航空公司工作人员')).toBeTruthy();
     expect(screen.getByText('你将扮演')).toBeTruthy();
@@ -241,6 +242,7 @@ describe('ScenesHome backend generation binding', () => {
     await fireEvent.press(screen.getByLabelText('生成练习场景'));
 
     await waitFor(() => expect(screen.getByText('模型生成超时')).toBeTruthy());
+    expect(screen.getByLabelText('描述想练习的场景').props.editable).toBe(true);
     expect(screen.queryByText('确认进入')).toBeNull();
   });
 

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -176,8 +176,8 @@ async function buildSceneDisplaySummary(scene) {
   return { title, background, aiRole, userRole, learningGoal };
 }
 
-function cachedPronunciationAudio(sceneId, text) {
-  const key = `${sceneId}:${text}`;
+function cachedPronunciationAudio(sceneId, text, voice = "") {
+  const key = `${sceneId}:${voice}:${text}`;
   if (!pronunciationAudioCache.has(key)) {
     if (pronunciationAudioCache.size >= maxPronunciationAudioCacheEntries) {
       pronunciationAudioCache.delete(pronunciationAudioCache.keys().next().value);
@@ -193,14 +193,14 @@ function cachedPronunciationAudio(sceneId, text) {
   return pronunciationAudioCache.get(key);
 }
 
-function prefetchPronunciationAudio(sceneId, items, limit = 2) {
+function prefetchPronunciationAudio(sceneId, items, limit = 2, voice = "") {
   if (!sceneId || !Array.isArray(items) || limit <= 0) return;
   items
     .map((item) => String(item?.englishText || item?.en || "").trim())
     .filter(Boolean)
     .slice(0, limit)
     .forEach((text) => {
-      void cachedPronunciationAudio(sceneId, text).catch(() => undefined);
+      void cachedPronunciationAudio(sceneId, text, voice).catch(() => undefined);
     });
 }
 
@@ -355,7 +355,7 @@ function useTeacherPreviewPlayback() {
   return { failedId, playTeacher, playingId };
 }
 
-function PronunciationAudioButton({ sceneId, text, label = "播放发音" }) {
+function PronunciationAudioButton({ sceneId, text, voice = "", label = "播放发音" }) {
   const audioRef = useRef(null);
   const objectUrlRef = useRef("");
   const [loading, setLoading] = useState(false);
@@ -376,13 +376,13 @@ function PronunciationAudioButton({ sceneId, text, label = "播放发音" }) {
       if (objectUrlRef.current) URL.revokeObjectURL(objectUrlRef.current);
       objectUrlRef.current = "";
     };
-  }, [sceneId, text]);
+  }, [sceneId, text, voice]);
 
   const replay = () => {
     const audio = audioRef.current;
     if (!audio) {
       setLoading(true);
-      cachedPronunciationAudio(sceneId, text)
+      cachedPronunciationAudio(sceneId, text, voice)
         .then((blob) => {
           const objectUrl = URL.createObjectURL(blob);
           const nextAudio = new Audio(objectUrl);
@@ -412,8 +412,8 @@ function PronunciationAudioButton({ sceneId, text, label = "播放发音" }) {
   );
 }
 
-function ScenePlaybackToggle({ sceneId, text, label = "播放发音" }) {
-  return <PronunciationAudioButton sceneId={sceneId} text={text} label={label} />;
+function ScenePlaybackToggle({ sceneId, text, voice = "", label = "播放发音" }) {
+  return <PronunciationAudioButton sceneId={sceneId} text={text} voice={voice} label={label} />;
 }
 
 function MicrophoneToggle({ label = "麦克风", className, onActivate }) {
@@ -1451,7 +1451,7 @@ function sceneCategoryForLabel(label) {
   return Object.entries(sceneCategories).find(([, value]) => value.label === label)?.[0] || "other";
 }
 
-function Scenes({ onStartTraining, onIelts, onInterview }) {
+function Scenes({ onStartTraining, onIelts, onInterview, teacher }) {
   const [prompt, setPrompt] = useState("");
   const promptRef = useRef(null);
   const previewSceneIdRef = useRef("");
@@ -1465,6 +1465,7 @@ function Scenes({ onStartTraining, onIelts, onInterview }) {
     setPrompt(event.currentTarget.value.slice(0, 200));
   };
   const generating = generationSource !== null;
+  const promptLocked = generating || Boolean(preview);
   const generate = async (requestedInput, recommendationId = null) => {
     const fromRecommendation = typeof requestedInput === "string";
     const currentInput = fromRecommendation
@@ -1480,7 +1481,7 @@ function Scenes({ onStartTraining, onIelts, onInterview }) {
       previewSceneIdRef.current = scene.sceneId;
       setPreview(scene);
       setPreviewDisplay(null);
-      prefetchPronunciationAudio(scene.sceneId, scene.wordList, 2);
+      prefetchPronunciationAudio(scene.sceneId, scene.wordList, 2, teacher?.voiceId);
       void buildSceneDisplaySummary(scene).then((display) => {
         if (previewSceneIdRef.current === scene.sceneId) setPreviewDisplay(display);
       });
@@ -1515,9 +1516,9 @@ function Scenes({ onStartTraining, onIelts, onInterview }) {
             <div><p className="eyebrow">CREATE YOUR OWN</p><h2>创建专属场景</h2><p>用一句话描述你想练习的真实情境，AI 会为你整理角色、目标与表达任务。</p></div>
           </div>
           <div className={cx("scene-input", prompt.trim() && "has-content")}>
-            <textarea ref={promptRef} value={prompt} maxLength={200} onChange={syncPrompt} onInput={syncPrompt} onCompositionEnd={syncPrompt} placeholder="你今天想练习什么？例如：第一次去健身房，咨询设施、开放时间和会员体验" />
+            <textarea ref={promptRef} value={prompt} maxLength={200} readOnly={promptLocked} onChange={syncPrompt} onInput={syncPrompt} onCompositionEnd={syncPrompt} placeholder="你今天想练习什么？例如：第一次去健身房，咨询设施、开放时间和会员体验" />
             <div className="scene-input__footer">
-              <div className="example-chips"><small>快速开始</small>{examples.map((example) => <button key={example} onClick={() => setPrompt(example)}>{example}</button>)}</div>
+              <div className="example-chips"><small>快速开始</small>{examples.map((example) => <button key={example} disabled={promptLocked} onClick={() => setPrompt(example)}>{example}</button>)}</div>
               <div className="scene-input__controls"><span>{prompt.length}/200</span><ExpandingCta className={cx("scene-generate", generationSource === "manual" && "is-generating")} disabled={!prompt.trim() || generating} onClick={() => void generate()}><span className="generation-button-state notranslate" translate="no"><span className={cx("generation-button-state__idle", generationSource === "manual" && "is-hidden")}>生成练习场景</span><span className={cx("generation-button-state__loading", generationSource !== "manual" && "is-hidden")}><NewtonsCradle size={22} className="newtons-cradle--inline" label="正在生成练习场景" /><span>正在生成</span></span></span></ExpandingCta></div>
             </div>
             {generationError && <p className="scene-generation-error" role="alert">{generationError}</p>}
@@ -2190,14 +2191,14 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
   useEffect(() => {
     if (!generatedMode || !sceneId || displayedStep === "speak") return;
     if (displayedStep === "read") {
-      prefetchPronunciationAudio(sceneId, readItems.slice(readIndex), 3);
+      prefetchPronunciationAudio(sceneId, readItems.slice(readIndex), 3, teacher?.voiceId);
       return;
     }
     const upcoming = lessonItems.slice(learnIndex);
     if (learningGroup === "words" && upcoming.length < 3) {
       upcoming.push(...generatedPhraseItems.slice(0, 3 - upcoming.length));
     }
-    prefetchPronunciationAudio(sceneId, upcoming, 3);
+    prefetchPronunciationAudio(sceneId, upcoming, 3, teacher?.voiceId);
   }, [
     displayedStep,
     generatedMode,
@@ -2208,6 +2209,7 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
     readIndex,
     readItems,
     sceneId,
+    teacher?.voiceId,
   ]);
   const submitRead = () => {
     const nextScore = readIndex === 1 && score === null ? 68 : 86;
@@ -2295,8 +2297,8 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
       </nav>}
       {flowError && <p className="call-error" role="alert">{flowError}</p>}
       {!result && <>
-      {displayedStep === "learn" && <section className="training-workspace"><aside className="lesson-list"><div><span>{generatedMode ? (learningGroup === "words" ? "场景单词" : "场景词组") : "本组语言"}</span><small>{learnIndex + 1} / {lessonItems.length}</small></div>{lessonItems.map((learningItem, index) => { const itemId = learningItem.id || `${learningGroup}-${index}-${learningItem.en}`; return <button key={itemId} type="button" disabled className={cx(index === learnIndex && "is-active", learnedItems.includes(itemId) && "is-done")}><small>{learningItem.type}</small><strong>{learningItem.en}</strong><span>{learnedItems.includes(itemId) ? <Check weight="bold" /> : index + 1}</span></button>; })}</aside><article className="learn-stage"><small>{item.type}</small><h1>{item.en}</h1><div className="pronunciation"><span>{item.phonetic || ""}</span>{generatedMode ? <PronunciationAudioButton sceneId={sceneId} text={item.en} label={`播放 ${item.en} 的发音`} /> : <AudioToggle mini label={`${item.en} 的发音`} />}</div><p>{item.zh}</p><div className="stage-footer"><ExpandingCta direction="back" disabled={learnIndex === 0 && (!generatedMode || learningGroup === "words")} onClick={previousLearn}>上一个</ExpandingCta><ExpandingCta onClick={nextLearn}>{learnIndex < lessonItems.length - 1 ? "下一个" : generatedMode && learningGroup === "words" && generatedPhraseItems.length > 0 ? "进入词组" : "进入朗读"}</ExpandingCta></div></article></section>}
-      {step === "read" && generatedMode && <section className="training-workspace"><aside className="lesson-list"><div><span>场景句子</span><small>{readIndex + 1} / {readItems.length}</small></div>{readItems.map((readItem, index) => <button key={readItem.id || readItem.en} type="button" disabled className={cx(index === readIndex && "is-active", readEvaluations[index]?.passed && "is-done")}><small>句子</small><strong>{readItem.en}</strong><span>{readEvaluations[index]?.passed ? <Check weight="bold" /> : index + 1}</span></button>)}</aside><article className="read-stage"><h1 className={cx(readEvaluation && "sentence-score-text")}><ScoredSentence sentence={item.en} words={readEvaluation?.words} /></h1><p>{item.zh}</p><SentenceRecorder sentenceId={item.id} busy={readSubmitting} onSubmit={submitGeneratedRead} onError={setReadError} /><h3>{readSubmitting ? "正在评分" : score === null ? "点击麦克风开始朗读" : readEvaluation?.passed ? "朗读通过" : "再试一次"}</h3>{score === null && !readError && <p>再次点击麦克风结束录音并提交评分。</p>}{readError && <p className="sentence-reading-error" role="alert">{readError}</p>}<div className="read-demo"><span>听标准示范</span><PronunciationAudioButton sceneId={sceneId} text={item.en} label={`播放 ${item.en} 的标准发音`} /></div>{score !== null && <div className="sentence-score-summary"><strong>{score}</strong><span>/100</span></div>}<div className="stage-footer read-stage-footer"><ExpandingCta direction="back" disabled={readIndex === 0 || readSubmitting} onClick={() => setReadIndex(readIndex - 1)}>上一句</ExpandingCta><ExpandingCta disabled={!readEvaluation?.passed || readSubmitting} onClick={nextRead}>{readIndex === readItems.length - 1 ? "进入模拟" : "下一句"}</ExpandingCta></div></article></section>}
+      {displayedStep === "learn" && <section className="training-workspace"><aside className="lesson-list"><div><span>{generatedMode ? (learningGroup === "words" ? "场景单词" : "场景词组") : "本组语言"}</span><small>{learnIndex + 1} / {lessonItems.length}</small></div>{lessonItems.map((learningItem, index) => { const itemId = learningItem.id || `${learningGroup}-${index}-${learningItem.en}`; return <button key={itemId} type="button" disabled className={cx(index === learnIndex && "is-active", learnedItems.includes(itemId) && "is-done")}><small>{learningItem.type}</small><strong>{learningItem.en}</strong><span>{learnedItems.includes(itemId) ? <Check weight="bold" /> : index + 1}</span></button>; })}</aside><article className="learn-stage"><small>{item.type}</small><h1>{item.en}</h1><div className="pronunciation"><span>{item.phonetic || ""}</span>{generatedMode ? <PronunciationAudioButton sceneId={sceneId} text={item.en} voice={teacher?.voiceId} label={`播放 ${item.en} 的发音`} /> : <AudioToggle mini label={`${item.en} 的发音`} />}</div><p>{item.zh}</p><div className="stage-footer"><ExpandingCta direction="back" disabled={learnIndex === 0 && (!generatedMode || learningGroup === "words")} onClick={previousLearn}>上一个</ExpandingCta><ExpandingCta onClick={nextLearn}>{learnIndex < lessonItems.length - 1 ? "下一个" : generatedMode && learningGroup === "words" && generatedPhraseItems.length > 0 ? "进入词组" : "进入朗读"}</ExpandingCta></div></article></section>}
+      {step === "read" && generatedMode && <section className="training-workspace"><aside className="lesson-list"><div><span>场景句子</span><small>{readIndex + 1} / {readItems.length}</small></div>{readItems.map((readItem, index) => <button key={readItem.id || readItem.en} type="button" disabled className={cx(index === readIndex && "is-active", readEvaluations[index]?.passed && "is-done")}><small>句子</small><strong>{readItem.en}</strong><span>{readEvaluations[index]?.passed ? <Check weight="bold" /> : index + 1}</span></button>)}</aside><article className="read-stage"><h1 className={cx(readEvaluation && "sentence-score-text")}><ScoredSentence sentence={item.en} words={readEvaluation?.words} /></h1><p>{item.zh}</p><SentenceRecorder sentenceId={item.id} busy={readSubmitting} onSubmit={submitGeneratedRead} onError={setReadError} /><h3>{readSubmitting ? "正在评分" : score === null ? "点击麦克风开始朗读" : readEvaluation?.passed ? "朗读通过" : "再试一次"}</h3>{score === null && !readError && <p>再次点击麦克风结束录音并提交评分。</p>}{readError && <p className="sentence-reading-error" role="alert">{readError}</p>}<div className="read-demo"><span>听标准示范</span><PronunciationAudioButton sceneId={sceneId} text={item.en} voice={teacher?.voiceId} label={`播放 ${item.en} 的标准发音`} /></div>{score !== null && <div className="sentence-score-summary"><strong>{score}</strong><span>/100</span></div>}<div className="stage-footer read-stage-footer"><ExpandingCta direction="back" disabled={readIndex === 0 || readSubmitting} onClick={() => setReadIndex(readIndex - 1)}>上一句</ExpandingCta><ExpandingCta disabled={!readEvaluation?.passed || readSubmitting} onClick={nextRead}>{readIndex === readItems.length - 1 ? "进入模拟" : "下一句"}</ExpandingCta></div></article></section>}
       {step === "read" && !generatedMode && <section className="training-workspace"><aside className="lesson-list"><div><span>完整表达</span><small>{readIndex + 1} / {learningItems.length}</small></div>{learningItems.map((learningItem, index) => <button key={learningItem.en} className={cx(index === readIndex && "is-active", (readScores[index] ?? 0) >= 80 && "is-done")} onClick={() => setReadIndex(index)}><small>句子</small><strong>{learningItem.en}</strong><span>{(readScores[index] ?? 0) >= 80 ? <Check weight="bold" /> : index + 1}</span></button>)}</aside><article className="read-stage"><h1>{item.en}</h1><p>{item.zh}</p><div className="rhythm"><span>节奏重点</span><strong>{item.en.split(" ").slice(0, 4).join(" · ")}</strong></div><MicrophoneToggle label="朗读麦克风" onActivate={submitRead} /><h3>{score === null ? "轮到你说" : score >= 80 ? "朗读通过" : "再试一次"}</h3>{score === null && <p>尽量完整、连贯地说出整句话。</p>}<button type="button" className="read-replay" onClick={playReadDemo}><SpeakerHigh weight="fill" />{heardReadDemos.includes(readIndex) ? "再听一次标准示范" : "听标准示范"}</button>{score >= 80 && <div className="stage-footer read-stage-footer"><span /><ExpandingCta onClick={nextRead}>{readIndex === learningItems.length - 1 ? "进入模拟" : "下一句"}</ExpandingCta></div>}</article></section>}
       </>}
       {(step === "speak" || result) && generatedMode && <CustomSceneConversation sceneId={sceneId} teacher={teacher} speed={speed} ended={Boolean(result)} onSessionStarted={(startedSessionId) => onStageChange?.("session", startedSessionId)} onComplete={onComplete} />}
@@ -3453,7 +3455,7 @@ export function App() {
   let content;
   if (training) content = <Training sceneId={training.sceneId} sessionId={training.sessionId} sceneTitle={sceneTitle} sceneContent={generatedScene} teacher={teacher} speed={conversationSpeed} initialStep={training.initialStep} initialStage={training.stage} standaloneSpeak={training.standaloneSpeak} result={result} onExit={() => setMainPage(training.returnPage || "scenes")} onComplete={completeScenePractice} onBack={() => setMainPage(training.returnPage || "scenes")} onAssets={openCompletedAssetDetail} onStageChange={navigateSceneStage} />;
   else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={(sessionId) => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); recordCompletedPractice("free", sessionId); void synchronizeAchievements({ revealNotifications: true }); }} />;
-  else if (page === "scenes") content = <Scenes onStartTraining={startTraining} onLocked={setPaywall} onIelts={selectIelts} onInterview={selectInterview} />;
+  else if (page === "scenes") content = <Scenes teacher={teacher} onStartTraining={startTraining} onLocked={setPaywall} onIelts={selectIelts} onInterview={selectInterview} />;
   else if (page === "assets") content = <Assets sceneId={assetSceneId} initialView={assetView} initialRecordTitle={sceneTitle} onOpenRecord={openCompletedAssetDetail} onCloseRecord={() => navigate(paths.assets.root, { assetView: "home", assetSceneId: null, authMode })} onIelts={() => selectMainPage("ielts-assets")} onInterview={() => selectMainPage("interview-assets")} onPractice={(scene) => startTraining(scene, "speak", { standaloneSpeak: false, returnPage: "assets" })} />;
   else if (page === "ielts") content = <IeltsTrainingCenter route={ieltsRoute} onNavigate={navigateIelts} onExit={() => setMainPage("scenes")} onAssets={() => navigateIelts(paths.ielts.assets.root)} />;
   else if (page === "ielts-assets") content = <IeltsAssets route={ieltsRoute} onNavigate={navigateIelts} onBack={() => setMainPage("scenes")} onBackToAssets={() => setMainPage("assets")} onBackToInterview={() => selectMainPage("interview-assets")} onTraining={() => navigateIelts(paths.ielts.root)} />;


### PR DESCRIPTION
## Summary

- Lock custom scene text editing during generation and preview on Web and mobile.
- Restore editing when generation fails.
- Route custom scene pronunciation through Qwen TTS with teacher voice mapping.
- Include voice identity in the pronunciation audio cache key.

## Root Cause

Custom scene input remained editable after generation because the UI only guarded the loading state and did not treat the generated preview as a locked state.

Pronunciation audio was cached only by scene and text. When the selected teacher changed, previously cached audio could be reused. In addition, custom scene pronunciation did not explicitly pass the selected teacher voice to the Qwen TTS provider.

## Changes

- Added prompt locking for the mobile custom scene flow.
- Added prompt locking and disabled quick-start examples for the Web custom scene flow.
- Added mobile regression coverage for both successful preview locking and failed-generation recovery.
- Added voice-aware Qwen TTS generation.
- Added product teacher-to-Qwen voice mapping.
- Updated Web pronunciation prefetching and playback to include the selected teacher voice.
- Updated pronunciation cache keys to prevent cross-voice reuse.

## Validation

- Mobile scene tests: 8 passed.
- Web production build: passed.
- Web authentication contract tests: 20 passed.
- Backend AI provider registry tests: 12 passed.
- `git diff --check`: passed.

Close #119 