### PR TITLE
fix: custom scene learning flow navigation

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParser.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParser.java
@@ -151,11 +151,11 @@ public final class IflytekSuntoneAssessmentParser {
 					: phoneme;
 			JsonNode span =
 					requiredObject(rawPhoneme, "span");
-			int start = requiredNonNegativeInteger(
-					span,
-					"start");
-			int end = requiredNonNegativeInteger(span, "end");
-			if (end <= start) {
+			int start = requiredInteger(span, "start");
+			int end = requiredInteger(span, "end");
+			boolean unmatched = start == -1 && end == -1;
+			if (!unmatched
+					&& (start < 0 || end < 0 || end <= start)) {
 				throw invalid();
 			}
 			phonemes.add(new PronunciationPhonemeResult(
@@ -301,16 +301,6 @@ public final class IflytekSuntoneAssessmentParser {
 			throw invalid();
 		}
 		return value.intValue();
-	}
-
-	private int requiredNonNegativeInteger(
-			JsonNode parent,
-			String field) {
-		int value = requiredInteger(parent, field);
-		if (value < 0) {
-			throw invalid();
-		}
-		return value;
 	}
 
 	private EvaluationException invalid() {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/persistence/codec/evaluation/EvaluationJsonbCodec.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/persistence/codec/evaluation/EvaluationJsonbCodec.java
@@ -210,16 +210,26 @@ public final class EvaluationJsonbCodec {
 			requireText(phoneme.get("expected_phoneme"));
 			requireText(phoneme.get("actual_phoneme"));
 			requireScore(phoneme.get("pronunciation_score"));
-			requirePositiveSpan(
+			requireValidSpan(
 					phoneme.get("start_position"),
 					phoneme.get("end_position"));
 		}
 	}
 
-	private void requirePositiveSpan(JsonNode start, JsonNode end) {
-		requireIndex(start);
-		requireIndex(end);
-		if (end.intValue() <= start.intValue()) {
+	private void requireValidSpan(JsonNode start, JsonNode end) {
+		if (start == null
+				|| end == null
+				|| !start.isIntegralNumber()
+				|| !end.isIntegralNumber()
+				|| !start.canConvertToInt()
+				|| !end.canConvertToInt()) {
+			throw persistenceFailure();
+		}
+		int startPosition = start.intValue();
+		int endPosition = end.intValue();
+		boolean unmatched = startPosition == -1 && endPosition == -1;
+		if (!unmatched
+				&& (startPosition < 0 || endPosition <= startPosition)) {
 			throw persistenceFailure();
 		}
 	}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/controller/CustomSceneController.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/controller/CustomSceneController.java
@@ -87,7 +87,12 @@ public class CustomSceneController {
 	@PostMapping("/flows/advance")
 	public ApiResponse<SceneFlowResponse> advanceStage(
 			@RequestBody AdvanceSceneStageRequest request) {
-		sceneFlowService.next(request.sceneId());
+		if (request.stage() == null) {
+			sceneFlowService.next(request.sceneId());
+		}
+		else {
+			sceneFlowService.next(request.sceneId(), request.stage());
+		}
 		return ApiResponse.success(sceneFlowService.response(request.sceneId()));
 	}
 
@@ -107,7 +112,7 @@ public class CustomSceneController {
 	public ApiResponse<List<LearningContentItem>> getByCurrentStage(
 			@PathVariable String sceneId,
 			@RequestParam(required = false) SceneFlowStage stage) {
-		return ApiResponse.success(sceneFlowService.content(sceneId));
+		return ApiResponse.success(sceneFlowService.content(sceneId, stage));
 	}
 
 	@PostMapping("/{sceneId}/sessions")

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/entity/evaluation/ReadingDetailsJson.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/entity/evaluation/ReadingDetailsJson.java
@@ -162,9 +162,12 @@ public record ReadingDetailsJson(
 			actualPhoneme = requireText(actualPhoneme, "actualPhoneme");
 			pronunciationScore =
 					requireScore(pronunciationScore, "pronunciationScore");
-			if (startPosition < 0 || endPosition <= startPosition) {
+			boolean unmatched = startPosition == -1 && endPosition == -1;
+			if (!unmatched
+					&& (startPosition < 0
+							|| endPosition <= startPosition)) {
 				throw new IllegalArgumentException(
-						"phoneme positions must define a positive duration");
+						"phoneme positions must define a positive duration or be unmatched");
 			}
 		}
 	}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/CustomSceneFlowService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/CustomSceneFlowService.java
@@ -15,6 +15,8 @@ import com.unispeaking.domain.vo.scene.SceneFlowStage;
 import com.unispeaking.domain.vo.scene.SceneType;
 import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +25,7 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 	private final SceneRepository sceneRepository;
 	private final ScenarioDialogueStateMachine dialogueStateMachine;
 	private final RealtimeSessionCoordinator sessionCoordinator;
+	private final Map<String, CustomStage> furthestStages = new ConcurrentHashMap<>();
 
 	public CustomSceneFlowService(
 			SceneRepository sceneRepository,
@@ -40,7 +43,9 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 
 	@Override
 	public CustomStage start(String sceneId) {
-		return super.start(sceneId);
+		CustomStage stage = super.start(sceneId);
+		furthestStages.put(sceneId, stage);
+		return stage;
 	}
 
 	@Override
@@ -50,7 +55,20 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 
 	@Override
 	public CustomStage next(String sceneId) {
-		return super.next(sceneId);
+		return rememberFurthest(sceneId, super.next(sceneId));
+	}
+
+	/** 根据客户端声明的当前学习阶段推进，修正客户端回退后的服务端缓存。 */
+	public CustomStage next(String sceneId, SceneFlowStage expectedCurrentStage) {
+		CustomStage requested = fromLegacyStage(expectedCurrentStage);
+		CustomStage current = current(sceneId);
+		CustomStage furthest = furthestStages.getOrDefault(sceneId, current);
+		if (rank(requested) > rank(furthest)) {
+			throw new BusinessException(
+					"SCENE_FLOW_STAGE_OUT_OF_ORDER",
+					"不能跳过尚未完成的场景学习阶段");
+		}
+		return rememberFurthest(sceneId, super.nextFrom(sceneId, requested));
 	}
 
 	@Override
@@ -61,6 +79,7 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 	@Override
 	public void clear(String sceneId) {
 		super.clear(sceneId);
+		furthestStages.remove(sceneId);
 	}
 
 	private static CustomStage initialStage(
@@ -87,7 +106,23 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 				stage == CustomStage.COMPLETED);
 	}
 	public List<LearningContentItem> content(String sceneId) {
-		CustomStage stage = current(sceneId);
+		return content(sceneId, null);
+	}
+
+	/** 返回客户端请求的阶段内容，不要求服务端当前阶段已经同步。 */
+	public List<LearningContentItem> content(
+			String sceneId,
+			SceneFlowStage requestedStage) {
+		CustomStage current = current(sceneId);
+		CustomStage stage = requestedStage == null
+				? current
+				: fromLegacyStage(requestedStage);
+		CustomStage furthest = furthestStages.getOrDefault(sceneId, current);
+		if (rank(stage) > rank(furthest)) {
+			throw new BusinessException(
+					"SCENE_FLOW_STAGE_OUT_OF_ORDER",
+					"不能访问尚未解锁的场景学习阶段");
+		}
 		SceneGenerationResponse scene = requireScene(sceneId);
 		return switch (stage) {
 			case WORD -> scene.wordList();
@@ -162,5 +197,38 @@ public class CustomSceneFlowService extends SceneFlowService<CustomStage> {
 			case DIALOGUE -> SceneFlowStage.DIALOGUE;
 			case COMPLETED -> SceneFlowStage.COMPLETED;
 		};
+	}
+
+	private static CustomStage fromLegacyStage(SceneFlowStage stage) {
+		return switch (stage) {
+			case WORD_LEARNING -> CustomStage.WORD;
+			case PHRASE_LEARNING -> CustomStage.PHRASE;
+			case SENTENCE_LEARNING -> CustomStage.SENTENCE;
+			case DIALOGUE -> CustomStage.DIALOGUE;
+			case COMPLETED -> CustomStage.COMPLETED;
+			case IELTS_PART_1, IELTS_PART_2, IELTS_PART_3 -> throw new BusinessException(
+					"SCENE_FLOW_STAGE_INVALID",
+					"当前场景不支持 IELTS 阶段");
+		};
+	}
+
+	private static int rank(CustomStage stage) {
+		return switch (stage) {
+			case WORD -> 0;
+			case PHRASE -> 1;
+			case SENTENCE -> 2;
+			case DIALOGUE -> 3;
+			case COMPLETED -> 4;
+		};
+	}
+
+	private CustomStage rememberFurthest(String sceneId, CustomStage stage) {
+		furthestStages.merge(
+				sceneId,
+				stage,
+				(current, candidate) -> rank(candidate) > rank(current)
+						? candidate
+						: current);
+		return stage;
 	}
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/SceneFlowService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/SceneFlowService.java
@@ -54,6 +54,16 @@ public class SceneFlowService<S> {
 		return stage;
 	}
 
+	/**
+	 * 从调用方声明的当前阶段推进流程。
+	 * 客户端可以在已解锁阶段之间回退，服务端缓存需要在下一次推进前同步。
+	 */
+	protected S nextFrom(String sceneId, S expectedCurrentStage) {
+		current(sceneId);
+		stages.put(sceneId, expectedCurrentStage);
+		return next(sceneId);
+	}
+
 	/** 判断场景流程是否已经到达结束阶段。 */
 	public boolean isCompleted(String sceneId) {
 		return completionChecker.test(current(sceneId));

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParserTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParserTest.java
@@ -138,6 +138,47 @@ class IflytekSuntoneAssessmentParserTest {
 				incomplete.errorCode());
 	}
 
+	@Test
+	void preservesUnmatchedPhonemeSpanSentinel() {
+		PronunciationAssessmentResult result =
+				parser.parse(envelope("""
+						{
+						  "result": {
+						    "overall": 82,
+						    "rhythm": 80,
+						    "integrity": 85,
+						    "pronunciation": 81,
+						    "fluency": 83,
+						    "words": [{
+						      "word": "test",
+						      "scores": {
+						        "overall": 82,
+						        "pronunciation": 81
+						      },
+						      "phonemes": [{
+						        "phone": "t",
+						        "phoneme": "t",
+						        "pronunciation": 0,
+						        "span": {"start": -1, "end": -1}
+						      }]
+						    }]
+						  }
+						}
+						"""));
+
+		assertAll(
+				() -> assertEquals(
+						-1,
+						result.words().getFirst()
+								.phonemes().getFirst()
+								.startPosition()),
+				() -> assertEquals(
+						-1,
+						result.words().getFirst()
+								.phonemes().getFirst()
+								.endPosition()));
+	}
+
 	private String envelope(String decodedResult) {
 		String encoded = Base64.getEncoder().encodeToString(
 				decodedResult.getBytes(StandardCharsets.UTF_8));

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneControllerFlowTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneControllerFlowTest.java
@@ -1,0 +1,57 @@
+package com.unispeaking.controller;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.domain.dto.scene.AdvanceSceneStageRequest;
+import com.unispeaking.domain.dto.scene.SceneFlowResponse;
+import com.unispeaking.domain.vo.scene.SceneFlowStage;
+import com.unispeaking.service.asset.LearningAssetService;
+import com.unispeaking.service.evaluation.CustomEvaluationService;
+import com.unispeaking.service.scene.CustomSceneFlowService;
+import com.unispeaking.service.scene.CustomSceneService;
+import com.unispeaking.service.session.CustomSessionService;
+import org.junit.jupiter.api.Test;
+
+class CustomSceneControllerFlowTest {
+
+	@Test
+	void advanceUsesTheClientCurrentStageAfterARewind() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		when(flow.response("scene_1")).thenReturn(new SceneFlowResponse(
+				"scene_1",
+				SceneFlowStage.PHRASE_LEARNING,
+				false));
+		CustomSceneController controller = controller(flow);
+
+		controller.advanceStage(new AdvanceSceneStageRequest(
+				"scene_1",
+				SceneFlowStage.WORD_LEARNING));
+
+		verify(flow).next("scene_1", SceneFlowStage.WORD_LEARNING);
+		verify(flow, never()).next("scene_1");
+	}
+
+	@Test
+	void contentUsesTheExplicitlyRequestedLearningStage() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneController controller = controller(flow);
+
+		controller.getByCurrentStage(
+				"scene_1",
+				SceneFlowStage.WORD_LEARNING);
+
+		verify(flow).content("scene_1", SceneFlowStage.WORD_LEARNING);
+	}
+
+	private CustomSceneController controller(CustomSceneFlowService flow) {
+		return new CustomSceneController(
+				mock(CustomSceneService.class),
+				flow,
+				mock(CustomEvaluationService.class),
+				mock(CustomSessionService.class),
+				mock(LearningAssetService.class));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
@@ -16,6 +16,7 @@ import com.unispeaking.domain.dto.scene.LearningContentItem;
 import com.unispeaking.infrastructure.persistence.repository.evaluation.SceneSentenceReadingRepository;
 import com.unispeaking.common.persistence.codec.evaluation.EvaluationJsonbCodec;
 import com.unispeaking.infrastructure.persistence.entity.evaluation.SentenceEvaluationEntity;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.ReadingDetailsJson;
 import com.unispeaking.infrastructure.persistence.mapper.evaluation.SentenceEvaluationMapper;
 import com.unispeaking.infrastructure.persistence.mapper.scene.SceneSentenceMapper;
 import com.unispeaking.infrastructure.persistence.entity.scene.SceneSentenceEntity;
@@ -83,9 +84,17 @@ class SceneSentenceReadingRepositoryTest {
 		assertEquals("sentence_abc", first.getSentenceId());
 		assertEquals("custom_scene1", first.getSceneId());
 		assertEquals(new BigDecimal("82"), first.getOverallScore());
+		ReadingDetailsJson decoded =
+				codec.decodeReadingDetails(first.getScoreDetail());
 		assertEquals(
 				assessment.overallScore(),
-				codec.decodeReadingDetails(first.getScoreDetail()).overallScore());
+				decoded.overallScore());
+		assertEquals(
+				-1,
+				decoded.words().getFirst().phonemes().get(1).startPosition());
+		assertEquals(
+				-1,
+				decoded.words().getFirst().phonemes().get(1).endPosition());
 	}
 
 	@Test
@@ -170,6 +179,14 @@ class SceneSentenceReadingRepositoryTest {
 						new BigDecimal("83"),
 						0,
 						18);
+		PronunciationPhonemeResult unmatchedPhoneme =
+				new PronunciationPhonemeResult(
+						1,
+						"eɪ",
+						"eɪ",
+						BigDecimal.ZERO,
+						-1,
+						-1);
 		PronunciationWordResult word = new PronunciationWordResult(
 				0,
 				"headache",
@@ -177,7 +194,7 @@ class SceneSentenceReadingRepositoryTest {
 				new BigDecimal("82"),
 				new BigDecimal("83"),
 				false,
-				List.of(phoneme));
+				List.of(phoneme, unmatchedPhoneme));
 		return new PronunciationAssessmentResult(
 				new BigDecimal("82"),
 				new BigDecimal("80"),

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/SceneFlowServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/SceneFlowServiceTest.java
@@ -18,6 +18,7 @@ import com.unispeaking.domain.vo.scene.IeltsContent;
 import com.unispeaking.domain.vo.scene.IeltsMode;
 import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.domain.vo.scene.IeltsStage;
+import com.unispeaking.domain.vo.scene.SceneFlowStage;
 import com.unispeaking.infrastructure.persistence.repository.scene.IeltsPracticeRepository;
 import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
 import com.unispeaking.service.scene.CustomSceneFlowService;
@@ -41,7 +42,7 @@ class SceneFlowServiceTest {
 				.collect(Collectors.toSet());
 
 		assertEquals(
-				Set.of("start", "current", "next", "isCompleted", "clear"),
+				Set.of("start", "current", "next", "nextFrom", "isCompleted", "clear"),
 				methods);
 		assertFalse(SceneFlowService.class.isInterface());
 		assertTrue(SceneFlowService.class.isAssignableFrom(
@@ -86,6 +87,38 @@ class SceneFlowServiceTest {
 		assertEquals(CustomStage.DIALOGUE, service.next(scene.sceneId()));
 		assertEquals(CustomStage.COMPLETED, service.next(scene.sceneId()));
 		assertTrue(service.isCompleted(scene.sceneId()));
+	}
+
+	@Test
+	void customFlowResynchronizesAfterClientReturnsToAnEarlierStage() {
+		SceneRepository repository = mock(SceneRepository.class);
+		SceneGenerationResponse scene = scene("custom_rewind");
+		when(repository.findGeneratedById(scene.sceneId()))
+				.thenReturn(Optional.of(scene));
+		CustomSceneFlowService service = new CustomSceneFlowService(
+				repository,
+				mock(ScenarioDialogueStateMachine.class),
+				mock(RealtimeSessionCoordinator.class));
+
+		service.start(scene.sceneId());
+		service.next(scene.sceneId());
+		service.next(scene.sceneId());
+
+		assertEquals(
+				CustomStage.PHRASE,
+				service.next(scene.sceneId(), SceneFlowStage.WORD_LEARNING));
+		assertEquals(
+				"ask about",
+				service.content(scene.sceneId(), SceneFlowStage.PHRASE_LEARNING)
+						.getFirst().englishText());
+		assertEquals(CustomStage.PHRASE, service.current(scene.sceneId()));
+		assertEquals(
+				"Could you help me?",
+				service.content(scene.sceneId(), SceneFlowStage.SENTENCE_LEARNING)
+						.getFirst().englishText());
+		assertEquals(
+				CustomStage.DIALOGUE,
+				service.next(scene.sceneId(), SceneFlowStage.SENTENCE_LEARNING));
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/SceneServiceContractTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/SceneServiceContractTest.java
@@ -49,6 +49,10 @@ class SceneServiceContractTest {
 	void flowServicesExplicitlyOverrideEverySharedOperation() throws Exception {
 		assertFlowOverrides(CustomSceneFlowService.class, CustomStage.class);
 		assertFlowOverrides(IeltsSceneFlowService.class, IeltsStage.class);
+		assertFalse(Arrays.stream(IeltsSceneFlowService.class.getMethods())
+				.anyMatch(method -> method.getName().equals("next")
+						&& method.getParameterCount() > 1),
+				"IELTS flow must not expose stage rewind or resynchronization");
 	}
 
 	private void assertFlowOverrides(Class<?> service, Class<?> stageType)

--- a/frontend/mobile/src/features/scenes/SceneTrainingController.ts
+++ b/frontend/mobile/src/features/scenes/SceneTrainingController.ts
@@ -51,6 +51,11 @@ type Listener = (snapshot: SceneTrainingSnapshot) => void;
 export class SceneTrainingController {
   private snapshot = initialSnapshot;
   private readonly listeners = new Set<Listener>();
+  private readonly readingResultsByContentId = new Map<string, SentenceEvaluation>();
+  private readonly learningItemsByGroup: Record<'words' | 'phrases', LearningContentItem[]> = {
+    words: [],
+    phrases: [],
+  };
 
   constructor(private readonly service: SceneTrainingServicePort) {}
 
@@ -67,6 +72,9 @@ export class SceneTrainingController {
   }
 
   async start(scene: GeneratedScene, initialStage: 'learn' | 'read' | 'speak' = 'learn') {
+    this.readingResultsByContentId.clear();
+    this.learningItemsByGroup.words = [];
+    this.learningItemsByGroup.phrases = [];
     this.update({
       ...initialSnapshot,
       status: 'loading',
@@ -99,6 +107,7 @@ export class SceneTrainingController {
         return;
       }
       const items = await this.requireContent(scene.sceneId, 'WORD_LEARNING');
+      this.learningItemsByGroup.words = items;
       this.update({
         ...this.snapshot,
         status: 'ready',
@@ -119,11 +128,12 @@ export class SceneTrainingController {
     if (this.snapshot.stage === 'speak') return false;
     if (this.snapshot.index < this.snapshot.items.length - 1) {
       const index = this.snapshot.index + 1;
+      const currentItem = this.snapshot.items[index];
       this.update({
         ...this.snapshot,
         index,
-        currentItem: this.snapshot.items[index],
-        readingResult: null,
+        currentItem,
+        readingResult: this.snapshot.stage === 'read' ? this.readingResultFor(currentItem) : null,
       });
       return true;
     }
@@ -165,14 +175,72 @@ export class SceneTrainingController {
     }
   }
 
+  async selectStage(stage: 'learn' | 'read' | 'speak') {
+    if (this.snapshot.status === 'loading' || this.snapshot.status === 'scoring') {
+      return false;
+    }
+    const restartingLearn = stage === 'learn'
+      && this.snapshot.stage === 'learn'
+      && (this.snapshot.learningGroup === 'phrases' || this.snapshot.index > 0);
+    if (stage === this.snapshot.stage && !restartingLearn) return true;
+    if (stage === 'speak') {
+      if (this.snapshot.unlockedStage < 2) return false;
+      this.update({
+        ...this.snapshot,
+        status: 'ready',
+        stage: 'speak',
+        readingResult: null,
+      });
+      return true;
+    }
+    const scene = this.requireScene();
+    const contentStage = stage === 'learn' ? 'WORD_LEARNING' : 'SENTENCE_LEARNING';
+    this.update({ ...this.snapshot, status: 'loading', error: null });
+    try {
+      const items = await this.requireContent(scene.sceneId, contentStage);
+      if (stage === 'learn') this.learningItemsByGroup.words = items;
+      this.update({
+        ...this.snapshot,
+        status: 'ready',
+        stage,
+        learningGroup: stage === 'learn' ? 'words' : this.snapshot.learningGroup,
+        items,
+        currentItem: items[0],
+        index: 0,
+        readingResult: stage === 'read' ? this.readingResultFor(items[0]) : null,
+      });
+      return true;
+    } catch (error) {
+      this.fail(error);
+      throw error;
+    }
+  }
+
   previous() {
-    if (this.snapshot.index <= 0) return false;
+    if (this.snapshot.index <= 0) {
+      if (this.snapshot.stage !== 'learn' || this.snapshot.learningGroup !== 'phrases') {
+        return false;
+      }
+      const items = this.learningItemsByGroup.words;
+      if (!items.length) return false;
+      const index = items.length - 1;
+      this.update({
+        ...this.snapshot,
+        learningGroup: 'words',
+        items,
+        currentItem: items[index],
+        index,
+        readingResult: null,
+      });
+      return true;
+    }
     const index = this.snapshot.index - 1;
+    const currentItem = this.snapshot.items[index];
     this.update({
       ...this.snapshot,
       index,
-      currentItem: this.snapshot.items[index],
-      readingResult: null,
+      currentItem,
+      readingResult: this.snapshot.stage === 'read' ? this.readingResultFor(currentItem) : null,
     });
     return true;
   }
@@ -190,6 +258,7 @@ export class SceneTrainingController {
         sentence.contentId,
         wavUri,
       );
+      this.readingResultsByContentId.set(sentence.contentId, readingResult);
       this.update({ ...this.snapshot, status: 'ready', readingResult });
       return readingResult;
     } catch (error) {
@@ -210,6 +279,9 @@ export class SceneTrainingController {
         throw new Error(`后端未进入预期训练阶段：${nextStage}`);
       }
       const items = await this.requireContent(sceneId, nextStage);
+      if (nextStage === 'PHRASE_LEARNING') {
+        this.learningItemsByGroup.phrases = items;
+      }
       this.update({
         ...this.snapshot,
         status: 'ready',
@@ -219,8 +291,10 @@ export class SceneTrainingController {
         items,
         currentItem: items[0],
         index: 0,
-        unlockedStage: nextStage === 'SENTENCE_LEARNING' ? 1 : 0,
-        readingResult: null,
+        unlockedStage: nextStage === 'SENTENCE_LEARNING'
+          ? Math.max(this.snapshot.unlockedStage, 1) as 1 | 2
+          : this.snapshot.unlockedStage,
+        readingResult: nextStage === 'SENTENCE_LEARNING' ? this.readingResultFor(items[0]) : null,
       });
     } catch (error) {
       this.fail(error);
@@ -237,6 +311,10 @@ export class SceneTrainingController {
   private requireScene() {
     if (!this.snapshot.scene) throw new Error('场景训练尚未开始');
     return this.snapshot.scene;
+  }
+
+  private readingResultFor(item: LearningContentItem | undefined) {
+    return item ? this.readingResultsByContentId.get(item.contentId) ?? null : null;
   }
 
   private fail(error: unknown) {

--- a/frontend/mobile/src/features/scenes/__tests__/SceneTrainingController.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/SceneTrainingController.test.ts
@@ -27,6 +27,12 @@ const sentence: LearningContentItem = {
   chineseText: '我可以要一杯无咖啡因拿铁吗？',
   phonetic: null,
 };
+const secondSentence: LearningContentItem = {
+  contentId: 'sentence-2',
+  englishText: 'Could you make it extra hot?',
+  chineseText: '可以做得更热一些吗？',
+  phonetic: null,
+};
 const scene: GeneratedScene = {
   sceneId: 'scene-1',
   title: '咖啡店点单',
@@ -145,6 +151,49 @@ describe('SceneTrainingController', () => {
     ]);
   });
 
+  it('treats words and phrases as one learn stage when the learn step is selected', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        stage: 'learn',
+        learningGroup: 'phrases',
+        currentItem: phrase,
+      }),
+    );
+
+    await expect(controller.selectStage('learn')).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        stage: 'learn',
+        learningGroup: 'words',
+        currentItem: word,
+        index: 0,
+      }),
+    );
+    expect(service.advanceStage).toHaveBeenCalledTimes(1);
+  });
+
+  it('moves backward from the first phrase to the last word within the learn stage', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+
+    expect(controller.previous()).toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        stage: 'learn',
+        learningGroup: 'words',
+        currentItem: word,
+        index: 0,
+      }),
+    );
+    expect(service.advanceStage).toHaveBeenCalledTimes(1);
+  });
+
   it('ignores a duplicate next action while a stage transition is pending', async () => {
     const service = createService();
     const controller = new SceneTrainingController(service);
@@ -204,6 +253,71 @@ describe('SceneTrainingController', () => {
     expect(service.advanceStage).toHaveBeenLastCalledWith(
       'scene-1',
       'SENTENCE_LEARNING',
+    );
+  });
+
+  it('restores the passing result when returning to a previously scored sentence', async () => {
+    const service = createService();
+    service.getContent.mockImplementation(async (_sceneId, stage) => {
+      if (stage === 'WORD_LEARNING') return [word];
+      if (stage === 'PHRASE_LEARNING') return [phrase];
+      return [sentence, secondSentence];
+    });
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+    await controller.next();
+
+    await controller.scoreReading('file:///sentence-1.wav');
+    await controller.next();
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ index: 1, readingResult: null }),
+    );
+
+    expect(controller.previous()).toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({
+        index: 0,
+        currentItem: sentence,
+        readingResult: expect.objectContaining({ overallScore: 86, passed: true }),
+      }),
+    );
+  });
+
+  it('can return to an unlocked stage without replaying backend transitions', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+    await controller.next();
+    await controller.scoreReading('file:///sentence.wav');
+    await controller.next();
+
+    await expect(controller.selectStage('read')).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ stage: 'read', currentItem: sentence, unlockedStage: 2 }),
+    );
+    await expect(controller.selectStage('learn')).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ stage: 'learn', learningGroup: 'words', currentItem: word, unlockedStage: 2 }),
+    );
+    await expect(controller.next()).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ stage: 'learn', learningGroup: 'phrases', currentItem: phrase, unlockedStage: 2 }),
+    );
+    expect(service.advanceStage).toHaveBeenCalledTimes(4);
+  });
+
+  it('returns from the first reading sentence to learning', async () => {
+    const service = createService();
+    const controller = new SceneTrainingController(service);
+    await controller.start(scene);
+    await controller.next();
+    await controller.next();
+
+    await expect(controller.selectStage('learn')).resolves.toBe(true);
+    expect(controller.getSnapshot()).toEqual(
+      expect.objectContaining({ stage: 'learn', currentItem: word }),
     );
   });
 });

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert, Animated, BackHandler, Image, PanResponder, Platform, Pressable, StyleSheet, Text, TextInput, View } from 'react-native';
+import { ActivityIndicator, Alert, Animated, BackHandler, Image, PanResponder, Platform, Pressable, ScrollView, StyleSheet, Text, TextInput, View } from 'react-native';
 import { LinearGradient } from 'expo-linear-gradient';
 import Reanimated, {
   cancelAnimation,
@@ -354,6 +354,8 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
   const [readFeedbackOpen, setReadFeedbackOpen] = useState(false);
   const [demoPlaying, setDemoPlaying] = useState(false);
   const demoActive = useRef(false);
+  const [readViewportHeight, setReadViewportHeight] = useState(0);
+  const [overflowingReadContent, setOverflowingReadContent] = useState<string | null>(null);
   const [recording, setRecording] = useState(false);
   const [audioError, setAudioError] = useState<string | null>(null);
   const [completionOpen, setCompletionOpen] = useState(false);
@@ -420,6 +422,8 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
   const learnItem = learnItems[displayedIndex] ?? learnItems[0] ?? learningItems[0];
   const displayedReadIndex = scene && trainingSnapshot ? trainingSnapshot.index : readIndex;
   const readItem = displayedReadItems[displayedReadIndex] ?? displayedReadItems[0] ?? learningItems[3];
+  const readContentKey = `${displayedReadIndex}:${readItem.en}:${readItem.zh}`;
+  const readContentOverflows = overflowingReadContent === readContentKey;
   const displayedReadPassed = scene && trainingSnapshot
     ? Boolean(trainingSnapshot.readingResult?.passed)
     : readPassed;
@@ -639,22 +643,57 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
             <Text style={styles.stageHeading}>场景句子</Text>
             <Text style={styles.stageCount}>{displayedReadIndex + 1} / {displayedReadItems.length}</Text>
           </View>
-          <View style={styles.readCard}>
-            {displayedReadPassed ? <View style={styles.scoreBadge}><Text style={styles.scoreBadgeValue}>{Math.round(trainingSnapshot?.readingResult?.overallScore ?? 86)}</Text><Text style={styles.scoreBadgeMax}>/100</Text></View> : null}
-            <Text style={styles.readSentence}>
-              {displayedReadPassed ? readItem.en : readItem.en}
-            </Text>
-            <Text style={styles.readTranslation}>{readItem.zh}</Text>
-            <Pressable accessibilityRole="button" accessibilityLabel={recording ? '结束朗读' : '开始朗读'} onPress={() => void toggleReadRecording()} style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}>
-              <AppIcon name={recording ? 'microphone' : 'microphone-off'} size={28} color={recording ? '#B94D44' : colors.subtle} />
-            </Pressable>
-            <Text style={styles.readStatus}>{recording ? '正在听你朗读' : displayedReadPassed ? '朗读通过' : '点击麦克风开始朗读'}</Text>
-            <Text style={styles.readInstruction}>{recording ? '再次点击麦克风结束录音并提交评分，最长录制 30 秒。' : displayedReadPassed ? '本句已达到通过标准，可以进入下一步。' : '再次点击麦克风结束录音并提交评分，最长录制 30 秒。'}</Text>
-            {audioError ? <Text style={styles.generationError}>{audioError}</Text> : null}
-            <Pressable accessibilityRole="button" accessibilityLabel="听标准示范" onPress={() => void toggleDemo(readItem.en)} style={styles.readDemoButton}>
-              <Text style={styles.readDemoText}>{demoPlaying ? '正在播放' : '听标准示范'}</Text>
-              <AppIcon name="volume" size={18} color={colors.subtle} />
-            </Pressable>
+          <View
+            onLayout={(event) => {
+              const nextHeight = event.nativeEvent.layout.height;
+              setReadViewportHeight((currentHeight) => currentHeight === nextHeight ? currentHeight : nextHeight);
+            }}
+            style={styles.readCard}
+          >
+            <ScrollView
+              key={readContentKey}
+              accessibilityLabel="朗读内容"
+              alwaysBounceVertical={false}
+              bounces={false}
+              contentContainerStyle={styles.readCardContent}
+              nestedScrollEnabled
+              overScrollMode="never"
+              scrollEnabled={readContentOverflows}
+              showsVerticalScrollIndicator={readContentOverflows}
+              style={styles.readCardScroll}
+            >
+              <View
+                onLayout={(event) => {
+                  const availableHeight = Math.max(0, readViewportHeight - 48);
+                  const overflows = availableHeight > 0 && event.nativeEvent.layout.height > availableHeight + 1;
+                  setOverflowingReadContent((current) => {
+                    const next = overflows ? readContentKey : null;
+                    return current === next ? current : next;
+                  });
+                }}
+                style={[
+                  styles.readCardInner,
+                  { minHeight: Math.max(0, readViewportHeight - 48) },
+                  !readContentOverflows && styles.readCardInnerCentered,
+                ]}
+              >
+                {displayedReadPassed ? <View style={styles.scoreBadge}><Text style={styles.scoreBadgeValue}>{Math.round(trainingSnapshot?.readingResult?.overallScore ?? 86)}</Text><Text style={styles.scoreBadgeMax}>/100</Text></View> : null}
+                <Text style={styles.readSentence}>
+                  {displayedReadPassed ? readItem.en : readItem.en}
+                </Text>
+                <Text style={styles.readTranslation}>{readItem.zh}</Text>
+                <Pressable accessibilityRole="button" accessibilityLabel={recording ? '结束朗读' : '开始朗读'} onPress={() => void toggleReadRecording()} style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}>
+                  <AppIcon name={recording ? 'microphone' : 'microphone-off'} size={28} color={recording ? '#B94D44' : colors.subtle} />
+                </Pressable>
+                <Text style={styles.readStatus}>{recording ? '正在听你朗读' : displayedReadPassed ? '朗读通过' : '点击麦克风开始朗读'}</Text>
+                <Text style={styles.readInstruction}>{recording ? '再次点击麦克风结束录音并提交评分，最长录制 30 秒。' : displayedReadPassed ? '本句已达到通过标准，可以进入下一步。' : '再次点击麦克风结束录音并提交评分，最长录制 30 秒。'}</Text>
+                {audioError ? <Text style={styles.generationError}>{audioError}</Text> : null}
+                <Pressable accessibilityRole="button" accessibilityLabel="听标准示范" onPress={() => void toggleDemo(readItem.en)} style={styles.readDemoButton}>
+                  <Text style={styles.readDemoText}>{demoPlaying ? '正在播放' : '听标准示范'}</Text>
+                  <AppIcon name="volume" size={18} color={colors.subtle} />
+                </Pressable>
+              </View>
+            </ScrollView>
           </View>
           <View style={styles.stageFooterRow}>
             <Pressable accessibilityRole="button" onPress={() => setStage('learn')} style={styles.roundNavButton}>
@@ -1375,33 +1414,37 @@ const styles = StyleSheet.create({
   stageMetaRow: { minHeight: 34, flexDirection: 'row', alignItems: 'flex-end', justifyContent: 'space-between' },
   stageHeading: { marginTop: 3, color: colors.ink, fontSize: 20, lineHeight: 25, fontWeight: '600', letterSpacing: -0.5 },
   stageCount: { color: colors.subtle, fontSize: 11, fontWeight: '500' },
-  languageCard: { flex: 1, minHeight: 250, position: 'relative', paddingHorizontal: 24, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 22, backgroundColor: colors.white },
+  languageCard: { width: '100%', minWidth: 0, minHeight: 0, flex: 1, paddingHorizontal: 24, paddingVertical: 24, position: 'relative', alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 22, backgroundColor: colors.white },
   languageCount: { position: 'absolute', top: 17, right: 18, color: colors.subtle, fontSize: 11, fontWeight: '500' },
   languageType: { color: colors.subtle, fontSize: 10, fontWeight: '600', letterSpacing: 1.4 },
-  languageEnglish: { marginTop: 14, color: colors.ink, fontSize: 34, lineHeight: 40, fontWeight: '600', textAlign: 'center', letterSpacing: -1.2 },
-  pronunciationRow: { minHeight: 34, marginTop: 14, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 10 },
-  phoneticText: { color: colors.muted, fontSize: 16, lineHeight: 24, fontWeight: '300' },
+  languageEnglish: { width: '100%', maxWidth: 350, marginTop: 14, flexShrink: 1, color: colors.ink, fontSize: 34, lineHeight: 40, fontWeight: '600', textAlign: 'center', letterSpacing: -1.2 },
+  pronunciationRow: { width: '100%', minHeight: 34, marginTop: 14, flexDirection: 'row', flexWrap: 'wrap', alignItems: 'center', justifyContent: 'center', gap: 10 },
+  phoneticText: { flexShrink: 1, color: colors.muted, fontSize: 16, lineHeight: 24, fontWeight: '300', textAlign: 'center' },
   speakerButton: { width: 32, height: 32, alignItems: 'center', justifyContent: 'center', borderRadius: 16 },
   speakerButtonActive: { opacity: 0.58, transform: [{ scale: 0.94 }] },
-  languageChinese: { marginTop: 12, color: colors.muted, fontSize: 16, lineHeight: 24, fontWeight: '300', textAlign: 'center' },
+  languageChinese: { width: '100%', maxWidth: 350, marginTop: 12, flexShrink: 1, color: colors.muted, fontSize: 16, lineHeight: 24, fontWeight: '300', textAlign: 'center' },
   stageFooterRow: { minHeight: 52, paddingTop: 10, flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', borderTopWidth: StyleSheet.hairlineWidth, borderTopColor: colors.line },
   roundNavButton: { width: 46, height: 46, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 23, backgroundColor: colors.white },
   roundNavDisabled: { opacity: 0.28 },
   primaryPillButton: { minWidth: 132, height: 46, paddingHorizontal: 20, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 8, borderRadius: 23, backgroundColor: colors.ink },
   primaryPillDisabled: { opacity: 0.28 },
   primaryPillText: { color: colors.white, fontSize: 14, fontWeight: '600' },
-  readCard: { flex: 1, minHeight: 350, paddingHorizontal: 22, paddingVertical: 24, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 22, backgroundColor: colors.white },
+  readCard: { width: '100%', minWidth: 0, minHeight: 0, flex: 1, position: 'relative', overflow: 'hidden', borderWidth: 1, borderColor: colors.line, borderRadius: 22, backgroundColor: colors.white },
+  readCardScroll: { position: 'absolute', top: 0, right: 0, bottom: 0, left: 0 },
+  readCardContent: { paddingHorizontal: 22, paddingVertical: 24 },
+  readCardInner: { width: '100%', position: 'relative', alignItems: 'center' },
+  readCardInnerCentered: { justifyContent: 'center' },
   scoreBadge: { position: 'absolute', top: 16, right: 17, flexDirection: 'row', alignItems: 'baseline' },
   scoreBadgeValue: { color: colors.ink, fontSize: 24, fontWeight: '600' },
   scoreBadgeMax: { color: colors.subtle, fontSize: 9, fontWeight: '500' },
-  readSentence: { maxWidth: 350, color: colors.ink, fontSize: 29, lineHeight: 37, fontWeight: '600', textAlign: 'center', letterSpacing: -1 },
-  readTranslation: { marginTop: 12, color: colors.muted, fontSize: 14, fontWeight: '300', textAlign: 'center' },
+  readSentence: { width: '100%', maxWidth: 350, flexShrink: 1, color: colors.ink, fontSize: 29, lineHeight: 37, fontWeight: '600', textAlign: 'center', letterSpacing: -1 },
+  readTranslation: { width: '100%', maxWidth: 350, marginTop: 12, flexShrink: 1, color: colors.muted, fontSize: 14, lineHeight: 21, fontWeight: '300', textAlign: 'center' },
   scoreCorrect: { color: '#278B5B' },
   scoreIncorrect: { color: '#D65349' },
   readRecordButton: { width: 62, height: 62, marginTop: 28, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 31, backgroundColor: colors.white },
   readRecordButtonActive: { borderColor: '#E2AAA5', backgroundColor: '#FFF7F6', shadowColor: '#C75950', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.12, shadowRadius: 10, elevation: 3 },
   readStatus: { marginTop: 15, color: colors.ink, fontSize: 15, fontWeight: '600' },
-  readInstruction: { marginTop: 7, color: colors.muted, fontSize: 11, lineHeight: 17, fontWeight: '300', textAlign: 'center' },
+  readInstruction: { width: '100%', maxWidth: 350, marginTop: 7, flexShrink: 1, color: colors.muted, fontSize: 11, lineHeight: 17, fontWeight: '300', textAlign: 'center' },
   readDemoButton: { minHeight: 36, marginTop: 18, paddingHorizontal: 10, flexDirection: 'row', alignItems: 'center', gap: 7 },
   readDemoText: { color: colors.subtle, fontSize: 12, fontWeight: '500' },
   sceneCallStage: { flex: 1, minHeight: 0, marginHorizontal: -2 },

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -177,6 +177,45 @@ function StageProgressRail({
   );
 }
 
+function ReadRecordButton({
+  passed,
+  recording,
+  onPress,
+}: {
+  passed: boolean;
+  recording: boolean;
+  onPress: () => void;
+}) {
+  const showSuccess = passed && !recording;
+  const successProgress = useSharedValue(showSuccess ? 1 : 0);
+
+  useEffect(() => {
+    successProgress.value = withTiming(showSuccess ? 1 : 0, {
+      duration: 280,
+      easing: ReanimatedEasing.out(ReanimatedEasing.cubic),
+    });
+  }, [showSuccess, successProgress]);
+
+  const successStyle = useAnimatedStyle(() => ({
+    opacity: successProgress.value,
+    transform: [{ scale: 0.78 + successProgress.value * 0.22 }],
+  }));
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={recording ? '结束朗读' : passed ? '重新朗读' : '开始朗读'}
+      onPress={onPress}
+      style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}
+    >
+      <AppIcon name={recording ? 'microphone' : 'microphone-off'} size={28} color={recording ? '#B94D44' : colors.subtle} />
+      <Reanimated.View pointerEvents="none" style={[styles.readRecordSuccess, successStyle]}>
+        <AppIcon name="check" size={28} color={colors.white} />
+      </Reanimated.View>
+    </Pressable>
+  );
+}
+
 type SceneMetric = { label: string; value: number };
 
 const defaultSceneMetrics: readonly SceneMetric[] = [
@@ -338,6 +377,7 @@ export function SceneCallStage({
 
 export function Training({ id, scene, analytics, trainingController: injectedTrainingController, wavRecorder: injectedWavRecorder, ttsPlayer: injectedTtsPlayer, initialStage = 'learn', onBack, onFinish, onViewDetails }: { id?: string; scene?: GeneratedScene; analytics?: AnalyticsTrackerFactory; trainingController?: SceneTrainingController; wavRecorder?: Pick<WavRecorder, 'start' | 'stop' | 'cancel'>; ttsPlayer?: Pick<TtsPlayer, 'play' | 'stop'>; initialStage?: TrainingStage; onBack: () => void; onFinish: () => void; onViewDetails?: (id: string) => void }) {
   const { setImmersiveLearning } = useLearningStage();
+  const { signOut } = useAppModel();
   const sceneId = scene?.sceneId ?? id ?? recommendations[0].id;
   const scenario = scene
     ? { id: scene.sceneId, title: scene.title }
@@ -364,7 +404,7 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
   const readRecordingTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [trainingController] = useState<SceneTrainingController | null>(() =>
     scene
-      ? injectedTrainingController ?? new SceneTrainingController(createDefaultSceneService())
+      ? injectedTrainingController ?? new SceneTrainingController(createDefaultSceneService(signOut))
       : null,
   );
   const [wavRecorder] = useState<Pick<WavRecorder, 'start' | 'stop' | 'cancel'> | null>(
@@ -500,6 +540,21 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
       setLearnIndex(wordItems.length - 1);
     }
   };
+  const previousRead = () => {
+    ttsPlayer?.stop();
+    demoActive.current = false;
+    setDemoPlaying(false);
+    setRecording(false);
+    if (scene && trainingController) {
+      if (displayedReadIndex > 0) {
+        trainingController.previous();
+      } else {
+        void trainingController.selectStage('learn').catch(() => undefined);
+      }
+      return;
+    }
+    setStage('learn');
+  };
   const clearReadRecordingTimer = () => {
     if (!readRecordingTimer.current) return;
     clearTimeout(readRecordingTimer.current);
@@ -583,7 +638,10 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
         onSelect={(nextStage) => {
           setRecording(false);
           setDemoPlaying(false);
-          if (scene) return;
+          if (scene && trainingController) {
+            void trainingController.selectStage(nextStage).catch(() => undefined);
+            return;
+          }
           setStage(nextStage);
         }}
       />
@@ -682,9 +740,7 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
                   {displayedReadPassed ? readItem.en : readItem.en}
                 </Text>
                 <Text style={styles.readTranslation}>{readItem.zh}</Text>
-                <Pressable accessibilityRole="button" accessibilityLabel={recording ? '结束朗读' : '开始朗读'} onPress={() => void toggleReadRecording()} style={[styles.readRecordButton, recording && styles.readRecordButtonActive]}>
-                  <AppIcon name={recording ? 'microphone' : 'microphone-off'} size={28} color={recording ? '#B94D44' : colors.subtle} />
-                </Pressable>
+                <ReadRecordButton passed={displayedReadPassed} recording={recording} onPress={() => void toggleReadRecording()} />
                 <Text style={styles.readStatus}>{recording ? '正在听你朗读' : displayedReadPassed ? '朗读通过' : '点击麦克风开始朗读'}</Text>
                 <Text style={styles.readInstruction}>{recording ? '再次点击麦克风结束录音并提交评分，最长录制 30 秒。' : displayedReadPassed ? '本句已达到通过标准，可以进入下一步。' : '再次点击麦克风结束录音并提交评分，最长录制 30 秒。'}</Text>
                 {audioError ? <Text style={styles.generationError}>{audioError}</Text> : null}
@@ -696,7 +752,7 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
             </ScrollView>
           </View>
           <View style={styles.stageFooterRow}>
-            <Pressable accessibilityRole="button" onPress={() => setStage('learn')} style={styles.roundNavButton}>
+            <Pressable accessibilityRole="button" accessibilityLabel={displayedReadIndex > 0 ? '上一句' : '返回学习阶段'} onPress={previousRead} style={styles.roundNavButton}>
               <AppIcon name="arrow-left" size={20} />
             </Pressable>
             <Pressable
@@ -805,12 +861,13 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
   );
 }
 
-function createDefaultSceneService() {
+function createDefaultSceneService(onUnauthorized?: () => void | Promise<void>) {
   const tokenStore = new SecureTokenStore();
   return new SceneService(
     new ApiClient({
       baseUrl: getRuntimeConfig().backendUrl,
       tokenStore,
+      onUnauthorized,
     }),
   );
 }
@@ -902,8 +959,9 @@ export function ScenesHome({
   promptExample?: ScenePromptExample;
   sceneService?: Pick<SceneService, 'generate'>;
 }) {
+  const { signOut } = useAppModel();
   const [sceneService] = useState(
-    () => injectedSceneService ?? createDefaultSceneService(),
+    () => injectedSceneService ?? createDefaultSceneService(signOut),
   );
   const [prompt, setPrompt] = useState('');
   const [preview, setPreview] = useState<GeneratedScene | null>(null);
@@ -1434,7 +1492,7 @@ const styles = StyleSheet.create({
   readCardContent: { paddingHorizontal: 22, paddingVertical: 24 },
   readCardInner: { width: '100%', position: 'relative', alignItems: 'center' },
   readCardInnerCentered: { justifyContent: 'center' },
-  scoreBadge: { position: 'absolute', top: 16, right: 17, flexDirection: 'row', alignItems: 'baseline' },
+  scoreBadge: { position: 'absolute', top: 0, right: -6, flexDirection: 'row', alignItems: 'baseline' },
   scoreBadgeValue: { color: colors.ink, fontSize: 24, fontWeight: '600' },
   scoreBadgeMax: { color: colors.subtle, fontSize: 9, fontWeight: '500' },
   readSentence: { width: '100%', maxWidth: 350, flexShrink: 1, color: colors.ink, fontSize: 29, lineHeight: 37, fontWeight: '600', textAlign: 'center', letterSpacing: -1 },
@@ -1442,6 +1500,7 @@ const styles = StyleSheet.create({
   scoreCorrect: { color: '#278B5B' },
   scoreIncorrect: { color: '#D65349' },
   readRecordButton: { width: 62, height: 62, marginTop: 28, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 31, backgroundColor: colors.white },
+  readRecordSuccess: { position: 'absolute', width: 62, height: 62, alignItems: 'center', justifyContent: 'center', borderRadius: 31, backgroundColor: '#278B5B' },
   readRecordButtonActive: { borderColor: '#E2AAA5', backgroundColor: '#FFF7F6', shadowColor: '#C75950', shadowOffset: { width: 0, height: 2 }, shadowOpacity: 0.12, shadowRadius: 10, elevation: 3 },
   readStatus: { marginTop: 15, color: colors.ink, fontSize: 15, fontWeight: '600' },
   readInstruction: { width: '100%', maxWidth: 350, marginTop: 7, flexShrink: 1, color: colors.muted, fontSize: 11, lineHeight: 17, fontWeight: '300', textAlign: 'center' },


### PR DESCRIPTION
## What changed

- Allow custom-scene clients to move back to previously unlocked learning stages while keeping the backend flow synchronized with the stage selected by the client.
- Treat words and phrases as one top-level Learn step on mobile, with working progress-rail navigation and previous-item behavior across the internal word and phrase substages.
- Restore per-sentence reading results when navigating back, keep completed stages unlocked, and show the passed-reading state consistently.
- Improve long-content layout behavior and propagate unauthorized scene API responses through the existing sign-out flow.
- Accept XFYUN's `-1/-1` unmatched-phoneme span sentinel when parsing and persisting pronunciation details.

## Why

The custom-scene backend previously exposed only forward advancement. After the mobile client added navigation back to completed stages, the backend still advanced from its cached furthest stage, causing the client and server to disagree about whether the user was in words, phrases, sentences, or dialogue.

Words and phrases are separate backend substages but represent the same Learn step in the mobile progress rail. The mobile controller now preserves that distinction internally while presenting a single navigable Learn stage.

## Scope

- Custom-scene learning only. IELTS remains forward-only.
- No database schema or migration changes.
- No scoring formula, dimension, weight, pass threshold, or evaluation-flow changes.
- The XFYUN change is response-format compatibility only; the separately diagnosed zero-score issue is not addressed in this PR.

## Verification

- `npx jest src/features/scenes/__tests__/SceneTrainingController.test.ts src/screens/__tests__/ScenesScreen.test.tsx --runInBand` (18 tests passed)
- `npx tsc --noEmit`
- `./mvnw -q -Dtest=IflytekSuntoneAssessmentParserTest,SceneSentenceReadingRepositoryTest,SceneFlowServiceTest,SceneServiceContractTest,CustomSceneControllerFlowTest test`
- `git diff --check upstream/main...HEAD`
