### PR TITLE
fix(web): realtime 连接失败后停止会话计时

### DIFF
--- a/frontend/web/scripts/check-call-timer-stop.mjs
+++ b/frontend/web/scripts/check-call-timer-stop.mjs
@@ -5,6 +5,28 @@ const appSource = await readFile(
   new URL("../src/controller/App.jsx", import.meta.url),
   "utf8",
 );
+const interviewSource = await readFile(
+  new URL("../src/component/interview/InterviewModule.jsx", import.meta.url),
+  "utf8",
+);
+const ieltsSource = await readFile(
+  new URL("../src/component/ielts/IeltsModule.jsx", import.meta.url),
+  "utf8",
+);
+
+const freeConversationStart = appSource.indexOf("function Conversation(");
+const freeConversationEnd = appSource.indexOf(
+  "function SceneCategoryTag(",
+  freeConversationStart,
+);
+
+assert.notEqual(freeConversationStart, -1, "Conversation must exist");
+assert.notEqual(freeConversationEnd, -1, "Conversation boundary must exist");
+
+const freeConversationSource = appSource.slice(
+  freeConversationStart,
+  freeConversationEnd,
+);
 
 const conversationStart = appSource.indexOf("function CustomSceneConversation(");
 const conversationEnd = appSource.indexOf(
@@ -26,18 +48,38 @@ const timerSource = appSource.slice(timerStart, timerEnd);
 
 assert.match(
   conversationSource,
-  /<CallTimer paused=\{paused\} state=\{ended \|\| error \? "ended" : "active"\} stopped=\{ending\} \/>/,
+  /<CallTimer paused=\{paused\} state=\{ended \? "ended" : error \? "error" : "active"\} stopped=\{ending\} \/>/,
   "The scene call timer must stop as soon as report generation begins",
 );
 assert.match(
   timerSource,
-  /if \(stopped \|\| state === "ended"\) return undefined;/,
-  "CallTimer must clear its interval when the call stops",
+  /const terminal = stopped \|\| state === "ended" \|\| state === "error";/,
+  "CallTimer must treat realtime failures as terminal",
 );
 assert.match(
   timerSource,
-  /\}, \[state, stopped\]\);/,
-  "CallTimer must react when the stopped state changes",
+  /if \(terminal\) return undefined;/,
+  "CallTimer must clear its interval when the call stops or fails",
+);
+assert.match(
+  freeConversationSource,
+  /setCallState\("error"\);[\s\S]*?<CallTimer state=\{callState\}/,
+  "Free conversation must pass realtime failure state to CallTimer",
+);
+assert.match(
+  interviewSource,
+  /if \(state === "ended" \|\| state === "error"\) return undefined;/,
+  "InterviewTimer must clear its interval after realtime failure",
+);
+assert.match(
+  interviewSource,
+  /<InterviewTimer paused=\{paused\} state=\{ending \? "ended" : error \? "error" : "active"\} \/>/,
+  "Interview session must pass realtime failure state to InterviewTimer",
+);
+assert.match(
+  ieltsSource,
+  /setRealtimeState\("error"\);[\s\S]*?if \(ending \|\| realtimeState === "error"\) return undefined;/,
+  "IELTS timer must stop after realtime connection failure",
 );
 
-console.log("Scene call timer completion check passed.");
+console.log("Realtime call timer stop checks passed.");

--- a/frontend/web/src/component/ielts/IeltsModule.jsx
+++ b/frontend/web/src/component/ielts/IeltsModule.jsx
@@ -486,6 +486,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   const [messages, setMessages] = useState([]);
   const [elapsed, setElapsed] = useState(0);
   const [error, setError] = useState("");
+  const [realtimeState, setRealtimeState] = useState("connecting");
   const [ending, setEnding] = useState(false);
   const [exitOpen, setExitOpen] = useState(false);
   const [partTwoPhase, setPartTwoPhase] = useState(isPartTwo ? "INTRODUCTION" : null);
@@ -707,6 +708,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
         if (cancelled) return;
         if (event.type === "local.connecting") setStatus("正在连接考官…");
         else if (event.type === "local.connected") {
+          setRealtimeState("connected");
           setStatus(isPartTwo ? "考官正在说明 Part 2 准备要求" : "考试进行中");
           if (isPartTwo) client.setMuted(true);
         }
@@ -800,9 +802,11 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
         } else if (event.type === "local.backend_warning") {
           setError("会话记录保存失败，请稍后重试");
         } else if (event.type === "local.mic_error") {
+          setRealtimeState("error");
           setError(event.message || "无法访问麦克风");
           setStatus("麦克风不可用，请检查权限");
         } else if (event.type === "error" || event.type === "local.error") {
+          setRealtimeState("error");
           setError(event.message || event.error?.message || "实时会话发生错误");
           setStatus("连接异常");
         }
@@ -823,6 +827,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
       .catch((startError) => {
         if (!cancelled) {
           ieltsAnalyticsRef.current.fail("REALTIME_ERROR");
+          setRealtimeState("error");
           setError(startError?.message || "无法开始 IELTS 实时会话");
         }
       });
@@ -849,10 +854,10 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   }, [generated?.ieltsId, generated?.voiceId, examiner.id]);
 
   useEffect(() => {
-    if (ending) return undefined;
+    if (ending || realtimeState === "error") return undefined;
     const timer = window.setInterval(() => setElapsed((value) => value + 1), 1000);
     return () => window.clearInterval(timer);
-  }, [ending]);
+  }, [ending, realtimeState]);
 
   const finish = async () => {
     if (finishingRef.current) return;
@@ -951,7 +956,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
             <span className={cx("voice-wave", subtitles && "voice-wave--compact", "is-fallback")} aria-hidden="true">
               {[.28, .52, .78, 1, .72, .48, .3].map((level, index) => <i key={index} className="voice-wave__bar" style={{ "--rest-level": level }} />)}
             </span>
-            <time className="call-presence__time">{isPartTwo ? formatTime(partTwoRemaining) : isPartThree && partThreeRemaining != null ? formatTime(partThreeRemaining) : formatTime(elapsed)}</time>
+            <time className="call-presence__time">{realtimeState === "error" ? "连接失败" : isPartTwo ? formatTime(partTwoRemaining) : isPartThree && partThreeRemaining != null ? formatTime(partThreeRemaining) : formatTime(elapsed)}</time>
             {!subtitles && <span>{status}</span>}
           </div>
         </div>

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -167,15 +167,16 @@ function InterviewWaveform({ active = false, compact = false }) {
 
 function InterviewTimer({ state = "active", paused = false }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
+  const startedAt = useRef(Date.now());
   useEffect(() => {
-    const startedAt = Date.now();
-    const updateElapsed = () => setElapsedSeconds(Math.floor((Date.now() - startedAt) / 1000));
+    const updateElapsed = () => setElapsedSeconds(Math.floor((Date.now() - startedAt.current) / 1000));
     updateElapsed();
+    if (state === "ended" || state === "error") return undefined;
     const interval = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(interval);
-  }, []);
+  }, [state]);
   const duration = `${String(Math.floor(elapsedSeconds / 60)).padStart(2, "0")}:${String(elapsedSeconds % 60).padStart(2, "0")}`;
-  const label = state === "ended" ? "已结束" : paused ? `已暂停 · ${duration}` : duration;
+  const label = state === "error" ? "连接失败" : state === "ended" ? "已结束" : paused ? `已暂停 · ${duration}` : duration;
   return <time className="call-presence__time">{label}</time>;
 }
 
@@ -762,7 +763,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
           <div className="portrait portrait--small interview-call-portrait"><img src={teacher?.image} alt={teacher?.name} /></div>
           <div className="listening-state listening-state--compact">
             <InterviewWaveform active={!ending && !paused && !error} compact />
-            <InterviewTimer paused={paused} state={ending || error ? "ended" : "active"} />
+            <InterviewTimer paused={paused} state={ending ? "ended" : error ? "error" : "active"} />
             {(!ending || closing) && <span>{status}</span>}
           </div>
         </div>

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -446,20 +446,23 @@ const formatCallDuration = (totalSeconds) => {
 function CallTimer({ state = "active", paused = false, stopped = false, className }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const startedAt = useRef(Date.now());
+  const terminal = stopped || state === "ended" || state === "error";
 
   useEffect(() => {
     const updateElapsed = () => {
       setElapsedSeconds(Math.floor((Date.now() - startedAt.current) / 1000));
     };
     updateElapsed();
-    if (stopped || state === "ended") return undefined;
+    if (terminal) return undefined;
     const interval = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(interval);
-  }, [state, stopped]);
+  }, [terminal]);
 
   const duration = formatCallDuration(elapsedSeconds);
   const label = state === "connecting"
     ? "连接中"
+    : state === "error"
+      ? "连接失败"
     : state === "ended"
       ? "已结束"
       : paused
@@ -1939,7 +1942,7 @@ function CustomSceneConversation({
           <div className="portrait portrait--small"><img src={teacher.image} alt={teacher.name} /></div>
           <div className="listening-state listening-state--compact">
             <VoiceWaveform active={!ended && !paused && !ending && !error} compact />
-            <CallTimer paused={paused} state={ended || error ? "ended" : "active"} stopped={ending} />
+            <CallTimer paused={paused} state={ended ? "ended" : error ? "error" : "active"} stopped={ending} />
             <span>{status}</span>
           </div>
         </div>


### PR DESCRIPTION
## 修改内容

- 将 Realtime `error` 状态纳入通用会话计时器的终止状态
- 自由对话和自定义场景连接失败后立即清除计时 interval
- 修正面试计时器仅修改文案但后台仍继续更新的问题
- 为 IELTS 增加独立的 Realtime 状态，避免普通业务错误误停计时
- 扩充计时器回归检查，覆盖四类 Web 实时训练入口

## 验证

- `npm run check:call-timer`
- `npm run check:realtime-events`
- `npm run build`

以上检查均已通过。