### PR TITLE
feat: add learning asset filters and synchronize record presentation

### DIFF
--- a/frontend/mobile/src/features/scenes/LearningAssetService.ts
+++ b/frontend/mobile/src/features/scenes/LearningAssetService.ts
@@ -60,10 +60,18 @@ type LearningAssetDetail = {
   } | null;
   latestReport: DialogueReport | null;
   reportHistory: { createdAt: string }[];
+  createdAt?: string;
 };
 
 function displayDate(value: string | null | undefined) {
-  return value?.slice(0, 10) || '待练习';
+  if (!value) return '待练习';
+  const dateParts = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (dateParts) {
+    return `${dateParts[1]}年${Number(dateParts[2])}月${Number(dateParts[3])}日`;
+  }
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return '待练习';
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
 }
 
 function mapExpressions(
@@ -150,7 +158,7 @@ export class LearningAssetService {
     return {
       id: value.sceneId,
       title: value.title,
-      date: displayDate(latestHistory?.createdAt),
+      date: displayDate(latestHistory?.createdAt ?? value.createdAt),
       status: value.latestSessionId ? '已完成' : '待练习',
       score: value.latestReport?.finalScore ?? null,
       category: sceneCategoryForLabel(value.label),

--- a/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/LearningAssetService.test.ts
@@ -109,7 +109,7 @@ describe('LearningAssetService', () => {
       expect.objectContaining({
         id: 'scene/airport',
         title: '机场行李托运',
-        date: '2026-08-05',
+        date: '2026年8月5日',
         status: '已完成',
         score: 88,
         category: 'transit',

--- a/frontend/mobile/src/screens/AssetsScreen.tsx
+++ b/frontend/mobile/src/screens/AssetsScreen.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Modal, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Modal, Pressable, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { ArrowLeftIcon } from 'phosphor-react-native/src/icons/ArrowLeft';
 import { ArrowRightIcon } from 'phosphor-react-native/src/icons/ArrowRight';
 import { BookOpenTextIcon } from 'phosphor-react-native/src/icons/BookOpenText';
@@ -12,6 +12,7 @@ import { LearningAssetsHeader } from '@/components/LearningAssetsHeader';
 import { AppButton, AppScreen, Card, HeaderIconButton, PageHeader, Pill } from '@/components/ui';
 import { SceneCategoryTag } from '@/components/SceneCategoryTag';
 import type { LearningExpression, SceneLearningRecord } from '@/data/learningAssets';
+import { sceneCategories, type SceneCategory } from '@/data/sceneCategories';
 import { LearningAssetService } from '@/features/scenes/LearningAssetService';
 import { SceneSpeechClient, TtsPlayer } from '@/features/audio/TtsPlayer';
 import { SecureTokenStore } from '@/infrastructure/auth/SecureTokenStore';
@@ -34,6 +35,7 @@ function createLearningAssetService(): LearningAssetService {
 }
 
 const PAGE_SIZE = 8;
+const sceneCategoryEntries = Object.entries(sceneCategories) as [SceneCategory, (typeof sceneCategories)[SceneCategory]][];
 
 function SceneRecordRow({ record, onPress }: { record: SceneLearningRecord; onPress: () => void }) {
   return (
@@ -47,6 +49,36 @@ function SceneRecordRow({ record, onPress }: { record: SceneLearningRecord; onPr
       </View>
       <Text style={styles.recordScore}>{record.score === null ? '待练习' : `${Math.round(record.score)} 分`}</Text>
       <ArrowRightIcon color={colors.subtle} size={18} weight="bold" />
+    </Pressable>
+  );
+}
+
+function CategoryFilter({
+  category,
+  active,
+  onPress,
+}: {
+  category: SceneCategory | 'all';
+  active: boolean;
+  onPress: () => void;
+}) {
+  const palette = category === 'all' ? null : sceneCategories[category];
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={category === 'all' ? '显示全部学习资产' : `按${palette?.label}筛选`}
+      accessibilityState={{ selected: active }}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.categoryFilter,
+        category === 'all' ? styles.categoryFilterAll : { backgroundColor: active ? palette?.backgroundColor : colors.soft },
+        active && (category === 'all' ? styles.categoryFilterAllActive : { borderColor: palette?.backgroundColor }),
+        pressed && styles.pressed,
+      ]}
+    >
+      <Text style={[styles.categoryFilterText, category === 'all' ? active && styles.categoryFilterTextActive : { color: active ? palette?.textColor : colors.muted }]}>
+        {category === 'all' ? '全部' : palette?.label}
+      </Text>
     </Pressable>
   );
 }
@@ -68,21 +100,29 @@ export function AssetsScreen({
   const [sceneRecords, setSceneRecords] = useState<SceneLearningRecord[] | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [reloadKey, setReloadKey] = useState(0);
+  const [selectedCategory, setSelectedCategory] = useState<SceneCategory | 'all'>('all');
+  const [page, setPage] = useState(0);
 
   useEffect(() => {
     let active = true;
-    void assetService.listRecords().then(
-      (records) => {
-        if (active) setSceneRecords(records);
-      },
-      (cause: unknown) => {
-        if (active) {
-          setError(cause instanceof Error ? cause.message : '学习资产加载失败');
-        }
-      },
-    );
+    const loadRecords = () => {
+      void assetService.listRecords().then(
+        (records) => {
+          if (active) {
+            setSceneRecords(records);
+            setError(null);
+          }
+        },
+        (cause: unknown) => {
+          if (active) setError(cause instanceof Error ? cause.message : '学习资产加载失败');
+        },
+      );
+    };
+    loadRecords();
+    const refreshTimer = setInterval(loadRecords, 5000);
     return () => {
       active = false;
+      clearInterval(refreshTimer);
     };
   }, [assetService, reloadKey]);
 
@@ -93,10 +133,17 @@ export function AssetsScreen({
   };
 
   const records = sceneRecords ?? [];
-  const [page, setPage] = useState(0);
-  const pageCount = Math.max(1, Math.ceil(records.length / PAGE_SIZE));
+  const filteredRecords = selectedCategory === 'all'
+    ? records
+    : records.filter((record) => record.category === selectedCategory);
+  const pageCount = Math.max(1, Math.ceil(filteredRecords.length / PAGE_SIZE));
   const currentPage = Math.min(page, pageCount - 1);
-  const visibleRecords = records.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE);
+  const visibleRecords = filteredRecords.slice(currentPage * PAGE_SIZE, (currentPage + 1) * PAGE_SIZE);
+
+  const selectCategory = (category: SceneCategory | 'all') => {
+    setSelectedCategory(category);
+    setPage(0);
+  };
 
   return (
     <AppScreen
@@ -106,6 +153,18 @@ export function AssetsScreen({
       <View style={styles.assetIntro}>
         <Text style={styles.assetHeadingSubtitle}>把场景练习中真正用过的表达，留在这里继续复习。</Text>
       </View>
+      <ScrollView
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        style={styles.categoryFiltersScroll}
+        contentContainerStyle={styles.categoryFilters}
+        accessibilityLabel="学习资产标签筛选"
+      >
+        <CategoryFilter category="all" active={selectedCategory === 'all'} onPress={() => selectCategory('all')} />
+        {sceneCategoryEntries.map(([category]) => (
+          <CategoryFilter key={category} category={category} active={selectedCategory === category} onPress={() => selectCategory(category)} />
+        ))}
+      </ScrollView>
       <Card style={styles.recordsCard}>
         {visibleRecords.map((record) => <SceneRecordRow key={record.id} record={record} onPress={() => onOpenRecord(record)} />)}
         {sceneRecords === null && !error ? (
@@ -128,8 +187,15 @@ export function AssetsScreen({
             <Text style={styles.emptyText}>完成一次场景训练后，语言资产和最近对话会保存在这里。</Text>
           </View>
         ) : null}
+        {sceneRecords && sceneRecords.length > 0 && filteredRecords.length === 0 ? (
+          <View style={styles.empty}>
+            <BookOpenTextIcon color={colors.subtle} size={30} />
+            <Text style={styles.emptyTitle}>没有匹配的学习资产</Text>
+            <Text style={styles.emptyText}>换一个标签，继续查看其他场景学习记录。</Text>
+          </View>
+        ) : null}
       </Card>
-      {pageCount > 1 ? (
+      {filteredRecords.length > 0 && pageCount > 1 ? (
         <View style={styles.pagination}>
           <Pressable
             accessibilityRole="button"
@@ -389,6 +455,13 @@ const styles = StyleSheet.create({
   mainContent: {},
   assetIntro: { alignItems: 'flex-start' },
   assetHeadingSubtitle: { color: colors.muted, fontSize: 15, lineHeight: 23, fontWeight: '300' },
+  categoryFiltersScroll: { height: 44, flexGrow: 0 },
+  categoryFilters: { alignItems: 'center', gap: 8, paddingVertical: 6, paddingRight: 8 },
+  categoryFilter: { height: 32, minHeight: 32, alignSelf: 'center', paddingHorizontal: 13, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: 'transparent', borderRadius: 16 },
+  categoryFilterAll: { borderColor: colors.line, backgroundColor: colors.white },
+  categoryFilterAllActive: { borderColor: colors.ink, backgroundColor: colors.ink },
+  categoryFilterText: { fontSize: 12, fontWeight: '500' },
+  categoryFilterTextActive: { color: colors.white },
   recordsCard: { paddingHorizontal: 16, paddingVertical: 2 },
   pagination: { flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 16 },
   paginationButton: { width: 40, height: 40, alignItems: 'center', justifyContent: 'center', borderWidth: 1, borderColor: colors.line, borderRadius: 20, backgroundColor: colors.white },

--- a/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AssetsScreen.test.tsx
@@ -7,7 +7,7 @@ import { AssetsScreen, SceneAssetDetail, SceneAssetDetailLoader } from '../Asset
 const summaryRecord: SceneLearningRecord = {
   id: 'scene/airport',
   title: '机场行李托运',
-  date: '2026-08-05',
+  date: '2026年8月5日',
   status: '已完成',
   score: 88.6,
   practiceCount: 2,
@@ -77,6 +77,41 @@ describe('AssetsScreen backend binding', () => {
       expect(screen.getByText('资产服务暂时不可用')).toBeTruthy(),
     );
     expect(screen.getByText('重新加载')).toBeTruthy();
+  });
+
+  it('filters records by category before paginating and can return to all records', async () => {
+    const foodRecord = { ...summaryRecord, id: 'scene/food', title: '咖啡店点单', category: 'food' as const };
+    const transitRecord = { ...summaryRecord, id: 'scene/transit', title: '机场行李托运', category: 'transit' as const };
+    const service = {
+      listRecords: jest.fn(async () => [foodRecord, transitRecord]),
+      getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
+    };
+    const screen = await render(
+      <AssetsScreen assetService={service} onOpenRecord={jest.fn()} onOpenIelts={jest.fn()} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('咖啡店点单')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('按餐饮筛选'));
+    expect(screen.getByText('咖啡店点单')).toBeTruthy();
+    expect(screen.queryByText('机场行李托运')).toBeNull();
+    await fireEvent.press(screen.getByText('全部'));
+    expect(screen.getByText('机场行李托运')).toBeTruthy();
+  });
+
+  it('shows an empty state when a category has no records', async () => {
+    const service = {
+      listRecords: jest.fn(async () => [summaryRecord]),
+      getRecord: jest.fn(async () => detailRecord),
+      deleteRecord: jest.fn(async () => undefined),
+    };
+    const screen = await render(
+      <AssetsScreen assetService={service} onOpenRecord={jest.fn()} onOpenIelts={jest.fn()} />,
+    );
+
+    await waitFor(() => expect(screen.getByText('机场行李托运')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('按餐饮筛选'));
+    expect(screen.getByText('没有匹配的学习资产')).toBeTruthy();
   });
 });
 

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -739,6 +739,13 @@ svg { display: block; }
 .assets-page:not(.asset-conversation-page):not(.asset-module-placeholder) .page-header { width: min(1600px, 100%); margin-bottom: 14px; }
 .assets-page:not(.asset-conversation-page):not(.asset-module-placeholder) .page-header h1 { margin-bottom: 8px; font-size: 50px; }
 .assets-page:not(.asset-conversation-page):not(.asset-module-placeholder) .page-header > div > p:last-child { font-size: 15px; }
+.asset-category-filters { width: 100%; max-width: 1600px; display: flex; align-items: center; gap: 8px; margin: 0 auto 14px; padding: 2px 0; overflow-x: auto; scrollbar-width: none; }
+.asset-category-filters::-webkit-scrollbar { display: none; }
+.asset-category-filter { flex: 0 0 auto; min-height: 34px; padding: 0 14px; border: 1px solid var(--line); border-radius: 999px; background: var(--soft); color: var(--muted); font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; transition: border-color .2s, background .2s, color .2s, transform .2s; }
+.asset-category-filter:hover { border-color: #aaa9a4; color: var(--ink); }
+.asset-category-filter:active { transform: scale(.97); }
+.asset-category-filter.is-active { color: var(--ink); background: #fff; border-color: var(--ink); }
+.asset-category-filter--all.is-active { color: #fff; background: var(--ink); border-color: var(--ink); }
 .asset-module-menu { position: relative; z-index: 8; }
 .asset-module-menu__trigger { min-height: 48px; display: flex; align-items: center; gap: 9px; padding: 0 16px; border: 1px solid var(--line); border-radius: 999px; background: #fff; color: var(--ink); font: inherit; font-size: 14px; font-weight: 700; cursor: pointer; transition: border-color .22s, background .22s, transform .22s; }
 .asset-module-menu__trigger:hover { border-color: #aaa9a4; background: #f8f8f5; }
@@ -780,7 +787,7 @@ svg { display: block; }
 .asset-list--history .asset-list__heading strong { font-size: 17px; }
 .asset-list--history .asset-list__heading span { color: var(--ink); font-size: 15px; font-weight: 500; }
 .asset-list--history > button {
-  min-height: 94px;
+  min-height: 104px;
   margin: 0;
   padding: 16px 20px;
   display: grid;
@@ -797,6 +804,13 @@ svg { display: block; }
 .asset-list--history > button small,
 .asset-list--history > button em { margin: 0; color: #858580; font-size: 10px; }
 .asset-list--history > button strong { margin: 0; font-size: 16px; }
+.asset-record-topline, .asset-record-bottomline { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.asset-record-topline strong { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.asset-record-category { flex: 0 0 auto; padding: 4px 7px; border-radius: 5px; background: var(--soft); color: var(--muted); font-size: 10px; line-height: 1; }
+.asset-record-bottomline em { flex: 0 0 auto; color: var(--muted); font-size: 10px; font-style: normal; }
+.asset-record-score { position: absolute; right: 44px; bottom: 16px; color: var(--muted); font-size: 11px; font-weight: 700; }
+.asset-record-arrow { position: absolute; right: 20px; top: 50%; width: 16px; height: 16px; color: #9a9a95; transform: translateY(-50%); }
+.asset-list--history > button { position: relative; }
 
 .asset-detail { min-width: 0; padding: 30px 32px 26px; overflow: hidden; }
 .asset-detail > header { min-height: 132px; display: flex; align-items: flex-start; justify-content: space-between; gap: 24px; padding-bottom: 25px; border-bottom: 1px solid var(--line); }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2405,6 +2405,13 @@ function AssetModulePlaceholder({ module, onBack }) {
   );
 }
 
+function formatAssetDate(value) {
+  if (!value) return "待练习";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "待练习";
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日`;
+}
+
 function Assets({ sceneId, onPractice, onIelts, onInterview, onOpenRecord, onCloseRecord, initialView = "home", initialRecordTitle }) {
   const [records, setRecords] = useState([]);
   const [selectedId, setSelectedId] = useState(sceneId || "");
@@ -2415,11 +2422,18 @@ function Assets({ sceneId, onPractice, onIelts, onInterview, onOpenRecord, onClo
   const [deleting, setDeleting] = useState(false);
   const [deleteError, setDeleteError] = useState("");
   const [reservedModule, setReservedModule] = useState(null);
-  const visibleRecords = records;
+  const [selectedCategory, setSelectedCategory] = useState("all");
+  const filteredRecords = useMemo(() => (
+    selectedCategory === "all"
+      ? records
+      : records.filter((record) => record.label === sceneCategories[selectedCategory]?.label)
+  ), [records, selectedCategory]);
+  const visibleRecords = filteredRecords;
   const selected = visibleRecords.find((record) => record.sceneId === selectedId)
     || visibleRecords.find((record) => record.title === initialRecordTitle)
     || visibleRecords[0]
     || null;
+  const selectedDate = selected?.latestPracticedAt || selected?.createdAt || null;
 
   useEffect(() => {
     let cancelled = false;
@@ -2444,11 +2458,18 @@ function Assets({ sceneId, onPractice, onIelts, onInterview, onOpenRecord, onClo
   }, [sceneId]);
 
   useEffect(() => {
+    if (!visibleRecords.some((record) => record.sceneId === selectedId)) {
+      setSelectedId(visibleRecords[0]?.sceneId || "");
+    }
+  }, [selectedId, visibleRecords]);
+
+  useEffect(() => {
     const targetSceneId = sceneId || selected?.sceneId;
     if (!targetSceneId) {
       setDetail(null);
       return undefined;
     }
+    setDetail(null);
     let cancelled = false;
     getLearningAsset(targetSceneId)
       .then((asset) => {
@@ -2501,19 +2522,31 @@ function Assets({ sceneId, onPractice, onIelts, onInterview, onOpenRecord, onClo
     <main className="page assets-page">
       <PageHeader title="学习资产" subtitle="把场景练习中真正用过的表达，留在这里继续复习。" action={<AssetModuleMenu onIelts={onIelts} onInterview={onInterview} />} />
       {assetError && <p className="call-error" role="alert">{assetError}</p>}
+      <nav className="asset-category-filters" aria-label="学习资产标签筛选">
+        <button type="button" className={cx("asset-category-filter", selectedCategory === "all" && "is-active", "asset-category-filter--all")} onClick={() => setSelectedCategory("all")} aria-pressed={selectedCategory === "all"}>全部</button>
+        {Object.entries(sceneCategories).map(([key, category]) => {
+          const active = selectedCategory === key;
+          return <button key={key} type="button" className={cx("asset-category-filter", active && "is-active")} onClick={() => setSelectedCategory(key)} aria-pressed={active} style={active ? { backgroundColor: category.backgroundColor, borderColor: category.backgroundColor, color: category.textColor } : undefined}>{category.label}</button>;
+        })}
+      </nav>
       <section className="asset-layout">
         <aside className="asset-list asset-list--history" aria-label="场景训练历史">
           <div className="asset-list__heading"><strong>训练记录</strong><span>{visibleRecords.length} 条</span></div>
-          {visibleRecords.map((record) => <button key={record.sceneId} className={selected?.sceneId === record.sceneId ? "is-active" : ""} onClick={() => setSelectedId(record.sceneId)}><small>{record.latestPracticedAt ? new Date(record.latestPracticedAt).toLocaleDateString("zh-CN") : "尚未练习"} · {record.label || "其他"}</small><strong>{record.title}</strong><em>{record.wordCount + record.phraseCount + record.sentenceCount} 个语言资产 · {record.practiceCount ? `已练习 ${record.practiceCount} 次` : "待练习"}{record.latestScore !== null && record.latestScore !== undefined && ` · ${Math.round(Number(record.latestScore))}`}</em></button>)}
-          {!visibleRecords.length && <div className="asset-list__empty">{loading ? "正在加载学习资产" : "暂无场景学习资产"}</div>}
+          {visibleRecords.map((record) => <button key={record.sceneId} className={selected?.sceneId === record.sceneId ? "is-active" : ""} onClick={() => setSelectedId(record.sceneId)}>
+            <span className="asset-record-topline"><strong>{record.title}</strong><span className="asset-record-category" style={(() => { const palette = sceneCategories[sceneCategoryForLabel(record.label)]; return { backgroundColor: palette.backgroundColor, color: palette.textColor }; })()}>{record.label || "其他"}</span></span>
+            <span className="asset-record-bottomline"><small>{formatAssetDate(record.latestPracticedAt || record.createdAt)}</small><em>{record.latestSessionId ? "已完成" : "待练习"}</em></span>
+            {record.latestSessionId && record.latestScore !== null && record.latestScore !== undefined && <span className="asset-record-score">{Math.round(Number(record.latestScore))} 分</span>}
+            <CaretRight className="asset-record-arrow" aria-hidden="true" />
+          </button>)}
+          {!visibleRecords.length && <div className="asset-list__empty">{loading ? "正在加载学习资产" : selectedCategory !== "all" ? "没有匹配的学习资产" : "暂无场景学习资产"}</div>}
         </aside>
         <article className="asset-detail">
           {selected && <header>
-            <div><p className="eyebrow">{selected.label || "其他"}</p><h2>{selected.title}</h2><p>{selected.latestPracticedAt ? `${new Date(selected.latestPracticedAt).toLocaleDateString("zh-CN")} · 已完成 ${selected.practiceCount} 次模拟` : "尚未完成模拟对话"}</p></div>
+            <div><p className="eyebrow">{selected.label || "其他"}</p><h2>{selected.title}</h2><p>{formatAssetDate(selectedDate)} · {selected.latestSessionId ? "已完成" : "待练习"}</p></div>
             <div className="asset-detail__actions"><AnimatedDeleteButton onClick={() => { setDeleteError(""); setDeleteOpen(true); }} /><ExpandingCta className="teacher-cta asset-open-button" onClick={() => onOpenRecord(selected.sceneId)}>打开当前学习资产</ExpandingCta></div>
           </header>}
           <div className="asset-items" aria-label="已保存的单词、短语和句子">
-            {items.map((item) => <div key={`${item.type}-${item.contentId}`}><span className="tag">{item.type}</span><p><strong>{item.englishText}</strong><small>{item.chineseText}</small></p><ScenePlaybackToggle sceneId={selected.sceneId} text={item.englishText} label={`播放 ${item.englishText} 的发音`} /></div>)}
+            {selected && items.map((item) => <div key={`${item.type}-${item.contentId}`}><span className="tag">{item.type}</span><p><strong>{item.englishText}</strong><small>{item.chineseText}</small></p><ScenePlaybackToggle sceneId={selected.sceneId} text={item.englishText} label={`播放 ${item.englishText} 的发音`} /></div>)}
             {selected && !items.length && <div className="asset-list__empty">正在读取该场景的语言资产</div>}
           </div>
         </article>


### PR DESCRIPTION
## Summary

- add horizontal category filters to mobile and web learning assets
- align web training records with the mobile presentation
- display category-specific colors for asset labels
- unify practice dates and the “待练习” status
- refresh mobile learning assets periodically after scene changes
- handle empty filter results without rendering errors

## Details

Learning asset records now support filtering by the existing scene categories on both platforms. The mobile filter uses a compact horizontally scrollable layout, while the web filter remains a single horizontal row.

Web training records now follow the mobile information hierarchy:

- scene title and category label
- practice date and status
- score when available
- navigation affordance

When a scene has not been practiced, both platforms display its creation date and use “待练习” as the status.

The mobile asset list refreshes every five seconds so newly created or partially completed custom scenes appear without requiring the app to restart or navigate away.

## Validation

- Web production build passed
- Mobile TypeScript check passed
- Mobile learning asset tests passed: 13 tests
- `git diff --check` passed

Close #124 