### PR TITLE
fix(mobile): stabilize scene realtime audio flow

### DIFF
--- a/frontend/mobile/app.json
+++ b/frontend/mobile/app.json
@@ -32,6 +32,7 @@
     "plugins": [
       "expo-router",
       "./plugins/withAndroidDevSupport",
+      "./plugins/withWebRtcPcmTap",
       [
         "expo-splash-screen",
         {

--- a/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTap.kt
+++ b/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTap.kt
@@ -1,0 +1,198 @@
+package com.unispeaking.mobile.audio
+
+import android.content.Context
+import android.media.AudioFormat
+import com.oney.WebRTCModule.WebRTCModuleOptions
+import java.io.ByteArrayOutputStream
+import java.io.File
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import org.webrtc.audio.JavaAudioDeviceModule
+
+/**
+ * Captures a copy of the PCM frames already owned by WebRTC. This deliberately
+ * avoids opening a second Android AudioRecord, which can steal or degrade the
+ * VOICE_COMMUNICATION input used by realtime VAD and barge-in.
+ */
+object WebRtcPcmTap {
+  private const val TARGET_SAMPLE_RATE = 16_000
+  private const val SILENCE_FRAME_MS = 20
+  private const val SILENCE_PADDING_MS = 200
+  private const val SILENCE_RMS_THRESHOLD = 0.006
+
+  private val lock = Any()
+  private var recording = false
+  private var finalized = false
+  private var sampleRate = 0
+  private var channelCount = 0
+  private var audioFormat = 0
+  private var segment = ByteArrayOutputStream()
+
+  fun install(context: Context) {
+    val audioDeviceModule = JavaAudioDeviceModule.builder(context)
+      .setEnableVolumeLogger(false)
+      .setSamplesReadyCallback { samples ->
+        accept(
+          samples.audioFormat,
+          samples.channelCount,
+          samples.sampleRate,
+          samples.data,
+        )
+      }
+      .createAudioDeviceModule()
+    WebRTCModuleOptions.getInstance().audioDeviceModule = audioDeviceModule
+  }
+
+  fun startSegment() = synchronized(lock) {
+    segment.reset()
+    sampleRate = 0
+    channelCount = 0
+    audioFormat = 0
+    recording = true
+    finalized = false
+  }
+
+  fun stopSegment() = synchronized(lock) {
+    recording = false
+    finalized = segment.size() > 0
+  }
+
+  fun releaseSegment() = synchronized(lock) {
+    recording = false
+    finalized = false
+    segment.reset()
+    sampleRate = 0
+    channelCount = 0
+    audioFormat = 0
+  }
+
+  fun takeSegment(cacheDir: File): String? {
+    val captured: ByteArray
+    val sourceRate: Int
+    val sourceChannels: Int
+    val sourceFormat: Int
+    synchronized(lock) {
+      if (!finalized || segment.size() == 0) return null
+      captured = segment.toByteArray()
+      sourceRate = sampleRate
+      sourceChannels = channelCount
+      sourceFormat = audioFormat
+      recording = false
+      finalized = false
+      segment.reset()
+    }
+    if (
+      sourceFormat != AudioFormat.ENCODING_PCM_16BIT ||
+      sourceRate <= 0 ||
+      sourceChannels <= 0
+    ) return null
+
+    val mono = decodeMonoPcm16(captured, sourceChannels)
+    if (mono.isEmpty()) return null
+    val resampled = trimSilence(resample(mono, sourceRate))
+    if (resampled.isEmpty()) return null
+    val wav = encodeWav(resampled)
+    val output = File.createTempFile("scene-turn-", ".wav", cacheDir)
+    output.writeBytes(wav)
+    return output.toURI().toString()
+  }
+
+  private fun accept(format: Int, channels: Int, rate: Int, data: ByteArray) {
+    if (data.isEmpty()) return
+    synchronized(lock) {
+      if (!recording) return
+      if (segment.size() == 0) {
+        audioFormat = format
+        channelCount = channels
+        sampleRate = rate
+      }
+      if (format != audioFormat || channels != channelCount || rate != sampleRate) return
+      segment.write(data)
+    }
+  }
+
+  private fun decodeMonoPcm16(bytes: ByteArray, channels: Int): ShortArray {
+    val sampleCount = bytes.size / 2
+    val frameCount = sampleCount / channels
+    val input = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN)
+    val mono = ShortArray(frameCount)
+    for (frame in 0 until frameCount) {
+      var sum = 0
+      for (channel in 0 until channels) sum += input.short.toInt()
+      mono[frame] = (sum / channels)
+        .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+        .toShort()
+    }
+    return mono
+  }
+
+  private fun resample(input: ShortArray, sourceRate: Int): ShortArray {
+    if (sourceRate == TARGET_SAMPLE_RATE) return input
+    val outputLength = maxOf(
+      1,
+      kotlin.math.round(input.size.toDouble() * TARGET_SAMPLE_RATE / sourceRate).toInt(),
+    )
+    val output = ShortArray(outputLength)
+    val ratio = sourceRate.toDouble() / TARGET_SAMPLE_RATE
+    for (index in output.indices) {
+      val sourcePosition = index * ratio
+      val left = kotlin.math.floor(sourcePosition).toInt().coerceIn(0, input.lastIndex)
+      val right = minOf(left + 1, input.lastIndex)
+      val fraction = sourcePosition - left
+      output[index] = kotlin.math.round(
+        input[left] * (1.0 - fraction) + input[right] * fraction,
+      )
+        .toInt()
+        .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+        .toShort()
+    }
+    return output
+  }
+
+  private fun trimSilence(input: ShortArray): ShortArray {
+    val frameSize = TARGET_SAMPLE_RATE * SILENCE_FRAME_MS / 1_000
+    val padding = TARGET_SAMPLE_RATE * SILENCE_PADDING_MS / 1_000
+    var firstActive = -1
+    var lastActive = -1
+    var offset = 0
+    while (offset < input.size) {
+      val end = minOf(offset + frameSize, input.size)
+      var squareSum = 0.0
+      for (index in offset until end) {
+        val normalized = input[index].toDouble() / Short.MAX_VALUE
+        squareSum += normalized * normalized
+      }
+      val rms = kotlin.math.sqrt(squareSum / (end - offset))
+      if (rms >= SILENCE_RMS_THRESHOLD) {
+        if (firstActive < 0) firstActive = offset
+        lastActive = end
+      }
+      offset = end
+    }
+    if (firstActive < 0) return input
+    return input.copyOfRange(
+      maxOf(0, firstActive - padding),
+      minOf(input.size, lastActive + padding),
+    )
+  }
+
+  private fun encodeWav(samples: ShortArray): ByteArray {
+    val dataLength = samples.size * 2
+    val output = ByteBuffer.allocate(44 + dataLength).order(ByteOrder.LITTLE_ENDIAN)
+    output.put("RIFF".toByteArray(Charsets.US_ASCII))
+    output.putInt(36 + dataLength)
+    output.put("WAVE".toByteArray(Charsets.US_ASCII))
+    output.put("fmt ".toByteArray(Charsets.US_ASCII))
+    output.putInt(16)
+    output.putShort(1)
+    output.putShort(1)
+    output.putInt(TARGET_SAMPLE_RATE)
+    output.putInt(TARGET_SAMPLE_RATE * 2)
+    output.putShort(2)
+    output.putShort(16)
+    output.put("data".toByteArray(Charsets.US_ASCII))
+    output.putInt(dataLength)
+    samples.forEach(output::putShort)
+    return output.array()
+  }
+}

--- a/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTapModule.kt
+++ b/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTapModule.kt
@@ -1,0 +1,39 @@
+package com.unispeaking.mobile.audio
+
+import com.facebook.react.bridge.Promise
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.ReactContextBaseJavaModule
+import com.facebook.react.bridge.ReactMethod
+
+class WebRtcPcmTapModule(
+  private val reactContext: ReactApplicationContext,
+) : ReactContextBaseJavaModule(reactContext) {
+  override fun getName() = "WebRtcPcmTap"
+
+  @ReactMethod
+  fun startSegment(promise: Promise) {
+    WebRtcPcmTap.startSegment()
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun stopSegment(promise: Promise) {
+    WebRtcPcmTap.stopSegment()
+    promise.resolve(null)
+  }
+
+  @ReactMethod
+  fun takeSegment(promise: Promise) {
+    try {
+      promise.resolve(WebRtcPcmTap.takeSegment(reactContext.cacheDir))
+    } catch (error: Exception) {
+      promise.reject("WEBRTC_PCM_TAP_FAILED", "无法生成实时对话评分录音", error)
+    }
+  }
+
+  @ReactMethod
+  fun releaseSegment(promise: Promise) {
+    WebRtcPcmTap.releaseSegment()
+    promise.resolve(null)
+  }
+}

--- a/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTapPackage.kt
+++ b/frontend/mobile/plugins/android/webrtc-pcm-tap/WebRtcPcmTapPackage.kt
@@ -1,0 +1,14 @@
+package com.unispeaking.mobile.audio
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class WebRtcPcmTapPackage : ReactPackage {
+  override fun createNativeModules(reactContext: ReactApplicationContext): List<NativeModule> =
+    listOf(WebRtcPcmTapModule(reactContext))
+
+  override fun createViewManagers(reactContext: ReactApplicationContext): List<ViewManager<*, *>> =
+    emptyList()
+}

--- a/frontend/mobile/plugins/withWebRtcPcmTap.js
+++ b/frontend/mobile/plugins/withWebRtcPcmTap.js
@@ -1,0 +1,89 @@
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  withDangerousMod,
+  withMainApplication,
+} = require('@expo/config-plugins');
+
+const IMPORT_ANCHOR = 'import expo.modules.ExpoReactHostFactory';
+const IMPORTS = `${IMPORT_ANCHOR}
+import com.unispeaking.mobile.audio.WebRtcPcmTap
+import com.unispeaking.mobile.audio.WebRtcPcmTapPackage`;
+const PACKAGE_ANCHOR = '// Packages that cannot be autolinked yet can be added manually here, for example:';
+const PACKAGE_REGISTRATION = `${PACKAGE_ANCHOR}
+          add(WebRtcPcmTapPackage())`;
+const ON_CREATE_ANCHOR = `override fun onCreate() {
+    super.onCreate()`;
+const INSTALLATION = `${ON_CREATE_ANCHOR}
+    WebRtcPcmTap.install(this)`;
+
+function addMainApplicationSetup(contents) {
+  let next = contents;
+
+  if (!next.includes('import com.unispeaking.mobile.audio.WebRtcPcmTap')) {
+    if (!next.includes(IMPORT_ANCHOR)) {
+      throw new Error('Could not locate the ExpoReactHostFactory import in MainApplication.kt');
+    }
+    next = next.replace(IMPORT_ANCHOR, IMPORTS);
+  }
+
+  if (!next.includes('add(WebRtcPcmTapPackage())')) {
+    if (!next.includes(PACKAGE_ANCHOR)) {
+      throw new Error('Could not locate the manual package anchor in MainApplication.kt');
+    }
+    next = next.replace(PACKAGE_ANCHOR, PACKAGE_REGISTRATION);
+  }
+
+  if (!next.includes('WebRtcPcmTap.install(this)')) {
+    if (!next.includes(ON_CREATE_ANCHOR)) {
+      throw new Error('Could not locate onCreate in MainApplication.kt');
+    }
+    next = next.replace(ON_CREATE_ANCHOR, INSTALLATION);
+  }
+
+  return next;
+}
+
+module.exports = function withWebRtcPcmTap(config) {
+  const withApplication = withMainApplication(config, (nextConfig) => {
+    if (nextConfig.modResults.language !== 'kt') {
+      throw new Error('WebRtcPcmTap currently requires a Kotlin MainApplication');
+    }
+    nextConfig.modResults.contents = addMainApplicationSetup(
+      nextConfig.modResults.contents,
+    );
+    return nextConfig;
+  });
+
+  return withDangerousMod(withApplication, [
+    'android',
+    async (nextConfig) => {
+      const packageName = nextConfig.android?.package;
+      if (!packageName) {
+        throw new Error('android.package is required to install WebRtcPcmTap');
+      }
+      const destination = path.join(
+        nextConfig.modRequest.platformProjectRoot,
+        'app',
+        'src',
+        'main',
+        'java',
+        ...packageName.split('.'),
+        'audio',
+      );
+      const sources = path.join(__dirname, 'android', 'webrtc-pcm-tap');
+      fs.mkdirSync(destination, { recursive: true });
+      for (const file of [
+        'WebRtcPcmTap.kt',
+        'WebRtcPcmTapModule.kt',
+        'WebRtcPcmTapPackage.kt',
+      ]) {
+        fs.copyFileSync(path.join(sources, file), path.join(destination, file));
+      }
+      return nextConfig;
+    },
+  ]);
+};
+
+module.exports.addMainApplicationSetup = addMainApplicationSetup;

--- a/frontend/mobile/src/features/audio/WebRtcTurnAudioCapture.ts
+++ b/frontend/mobile/src/features/audio/WebRtcTurnAudioCapture.ts
@@ -1,0 +1,66 @@
+import { NativeModules, Platform } from 'react-native';
+
+import type { TurnAudioCapturePort } from './TurnAudioCapture';
+
+export type WebRtcPcmTapPort = {
+  startSegment(): Promise<void>;
+  stopSegment(): Promise<void>;
+  takeSegment(): Promise<string | null>;
+  releaseSegment(): Promise<void>;
+};
+
+export function createWebRtcTurnAudioCapture(
+  nativeTap: WebRtcPcmTapPort,
+): TurnAudioCapturePort {
+  let active = false;
+  let finalized = false;
+  let startPromise: Promise<void> | null = null;
+  let stopPromise: Promise<void> | null = null;
+
+  return {
+    async start() {
+      if (active || finalized || startPromise) return;
+      startPromise = Promise.resolve(nativeTap.startSegment());
+      try {
+        await startPromise;
+        active = true;
+      } finally {
+        startPromise = null;
+      }
+    },
+    stop() {
+      if (!active) return false;
+      active = false;
+      finalized = true;
+      stopPromise = Promise.resolve(nativeTap.stopSegment());
+      return true;
+    },
+    async take() {
+      if (startPromise) await startPromise;
+      if (active) {
+        active = false;
+        finalized = true;
+        stopPromise = Promise.resolve(nativeTap.stopSegment());
+      }
+      if (stopPromise) await stopPromise;
+      const uri = finalized ? await nativeTap.takeSegment() : null;
+      finalized = false;
+      stopPromise = null;
+      return uri;
+    },
+    async release() {
+      if (startPromise) await startPromise.catch(() => undefined);
+      await nativeTap.releaseSegment().catch(() => undefined);
+      active = false;
+      finalized = false;
+      startPromise = null;
+      stopPromise = null;
+    },
+  };
+}
+
+export function createNativeWebRtcTurnAudioCapture(): TurnAudioCapturePort | null {
+  if (Platform.OS !== 'android') return null;
+  const nativeTap = NativeModules.WebRtcPcmTap as WebRtcPcmTapPort | undefined;
+  return nativeTap ? createWebRtcTurnAudioCapture(nativeTap) : null;
+}

--- a/frontend/mobile/src/features/audio/__tests__/WebRtcTurnAudioCapture.test.ts
+++ b/frontend/mobile/src/features/audio/__tests__/WebRtcTurnAudioCapture.test.ts
@@ -1,0 +1,44 @@
+import { createWebRtcTurnAudioCapture } from '../WebRtcTurnAudioCapture';
+
+describe('createWebRtcTurnAudioCapture', () => {
+  it('segments the microphone samples already owned by WebRTC', async () => {
+    let finishStop!: () => void;
+    const nativeTap = {
+      startSegment: jest.fn(async () => undefined),
+      stopSegment: jest.fn(() => new Promise<void>((resolve) => {
+        finishStop = resolve;
+      })),
+      takeSegment: jest.fn(async () => 'file:///webrtc-turn.wav'),
+      releaseSegment: jest.fn(async () => undefined),
+    };
+    const capture = createWebRtcTurnAudioCapture(nativeTap);
+
+    await capture.start();
+    expect(capture.stop()).toBe(true);
+    const audio = capture.take();
+    expect(nativeTap.takeSegment).not.toHaveBeenCalled();
+    finishStop();
+
+    await expect(audio).resolves.toBe('file:///webrtc-turn.wav');
+    expect(nativeTap.startSegment).toHaveBeenCalledTimes(1);
+    expect(nativeTap.stopSegment).toHaveBeenCalledTimes(1);
+    expect(nativeTap.takeSegment).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases an active segment without producing a WAV', async () => {
+    const nativeTap = {
+      startSegment: jest.fn(async () => undefined),
+      stopSegment: jest.fn(async () => undefined),
+      takeSegment: jest.fn(async () => 'file:///unused.wav'),
+      releaseSegment: jest.fn(async () => undefined),
+    };
+    const capture = createWebRtcTurnAudioCapture(nativeTap);
+
+    await capture.start();
+    await capture.release();
+
+    expect(nativeTap.releaseSegment).toHaveBeenCalledTimes(1);
+    expect(nativeTap.takeSegment).not.toHaveBeenCalled();
+    expect(capture.stop()).toBe(false);
+  });
+});

--- a/frontend/mobile/src/features/realtime/RealtimeSessionController.ts
+++ b/frontend/mobile/src/features/realtime/RealtimeSessionController.ts
@@ -181,6 +181,12 @@ function assistantResponseInvitesReply(text: string) {
   return /[?\uFF1F]$/.test(terminalText);
 }
 
+function isBenignResponseCancellationError(message: string) {
+  return /(?:cancel(?:lation)?[^.]*no active response|no active response|response[^.]*not active|already (?:been )?cancel)/i.test(
+    message,
+  );
+}
+
 function buildSessionUpdate(
   eventId: string,
   response: RealtimeSessionStartResponse,
@@ -617,6 +623,19 @@ export class RealtimeSessionController {
         return;
       case 'user.speech.started':
         if (this.options.mode === 'scene' && !this.inputEnabled) return;
+        if (
+          this.options.mode === 'scene' &&
+          this.machine.state === 'assistant_speaking' &&
+          this.responseInFlight
+        ) {
+          // Do not rely solely on provider-side interrupt_response. Native
+          // WebRTC can surface speech_started before the automatic cancellation
+          // has stopped remote output, so explicitly cancel the active reply.
+          this.dependencies.transport.sendProviderEvent({
+            event_id: this.createEventId(),
+            type: 'response.cancel',
+          });
+        }
         if (this.options.mode === 'scene') {
           this.clearSceneContinuationTimer();
           this.sceneUserTurnPending = true;
@@ -705,6 +724,18 @@ export class RealtimeSessionController {
         }
         return;
       case 'provider.error':
+        if (
+          this.options.mode === 'scene' &&
+          this.machine.state === 'user_speaking' &&
+          isBenignResponseCancellationError(event.message)
+        ) {
+          // Provider-side auto-interrupt may win the race with our explicit
+          // cancellation. Treat an already-cancelled response as success.
+          this.responseInFlight = false;
+          this.currentResponseRequest = null;
+          this.publish();
+          return;
+        }
         if (/conversation already has an active response/i.test(event.message)) {
           if (!this.pendingResponseRequest && this.currentResponseRequest) {
             this.pendingResponseRequest = this.currentResponseRequest;

--- a/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionController.test.ts
+++ b/frontend/mobile/src/features/realtime/__tests__/RealtimeSessionController.test.ts
@@ -1310,6 +1310,14 @@ describe('RealtimeSessionController', () => {
       JSON.stringify({ type: 'input_audio_buffer.speech_started' }),
     );
     expect(controller.getSnapshot().state).toBe('user_speaking');
+    expect(dependencies.transport.sendProviderEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'response.cancel' }),
+    );
+    await controller.handleProviderMessage(JSON.stringify({
+      type: 'error',
+      error: { message: 'Cancellation failed: no active response found' },
+    }));
+    expect(controller.getSnapshot().state).toBe('user_speaking');
     await controller.handleProviderMessage(
       JSON.stringify({ type: 'response.done', response: { status: 'cancelled' } }),
     );

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -28,6 +28,7 @@ import { SceneService, type GeneratedScene } from '@/features/scenes/SceneServic
 import { SceneTrainingController, type SceneTrainingSnapshot } from '@/features/scenes/SceneTrainingController';
 import { WavRecorder } from '@/features/audio/WavRecorder';
 import { createTurnAudioCapture } from '@/features/audio/TurnAudioCapture';
+import { createNativeWebRtcTurnAudioCapture } from '@/features/audio/WebRtcTurnAudioCapture';
 import { SceneSpeechClient, TtsPlayer } from '@/features/audio/TtsPlayer';
 import {
   useFreeChatSession,
@@ -288,7 +289,12 @@ function createDefaultSceneController(
       sessionApi: new RealtimeSessionApi(apiClient),
       sessionSocket: new SessionMessageSocket({ baseUrl: backendUrl, tokenStore }),
       sceneDialogue: new SceneDialogueApi(apiClient, sceneId),
-      turnAudioCapture: createTurnAudioCapture(new WavRecorder()),
+      // Android scoring must copy the PCM frames already captured by WebRTC.
+      // Opening AudioStudio here creates a second AudioRecord and degrades VAD,
+      // barge-in, and the scoring WAV on physical devices such as OnePlus.
+      turnAudioCapture:
+        createNativeWebRtcTurnAudioCapture() ??
+        createTurnAudioCapture(new WavRecorder()),
     },
     {
       mode: 'scene',
@@ -640,13 +646,18 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
         unlockedStage={displayedUnlockedStage}
         onCollapsedChange={setProgressCollapsed}
         onSelect={(nextStage) => {
-          setRecording(false);
-          setDemoPlaying(false);
-          if (scene && trainingController) {
-            void trainingController.selectStage(nextStage).catch(() => undefined);
-            return;
-          }
-          setStage(nextStage);
+          void (async () => {
+            clearReadRecordingTimer();
+            setRecording(false);
+            setDemoPlaying(false);
+            ttsPlayer?.stop();
+            await wavRecorder?.cancel().catch(() => undefined);
+            if (scene && trainingController) {
+              await trainingController.selectStage(nextStage).catch(() => undefined);
+              return;
+            }
+            setStage(nextStage);
+          })();
         }}
       />
 
@@ -763,10 +774,22 @@ export function Training({ id, scene, analytics, trainingController: injectedTra
               accessibilityRole="button"
               disabled={!displayedReadPassed || trainingTransitioning}
               onPress={() => {
-                if (scene && trainingController) void trainingController.next().catch(() => undefined);
-                else { setUnlockedStage(2); setStage('speak'); }
-                setRecording(false);
-                setDemoPlaying(false);
+                void (async () => {
+                  clearReadRecordingTimer();
+                  setRecording(false);
+                  setDemoPlaying(false);
+                  ttsPlayer?.stop();
+                  // Await the native recorder shutdown before WebRTC mounts.
+                  // Otherwise Android can leave the realtime microphone in a
+                  // preparing state or route it through the wrong capture path.
+                  await wavRecorder?.cancel().catch(() => undefined);
+                  if (scene && trainingController) {
+                    await trainingController.next().catch(() => undefined);
+                  } else {
+                    setUnlockedStage(2);
+                    setStage('speak');
+                  }
+                })();
               }}
               style={[styles.primaryPillButton, (!displayedReadPassed || trainingTransitioning) && styles.primaryPillDisabled]}
             >

--- a/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ScenesScreen.test.tsx
@@ -283,6 +283,69 @@ describe('ScenesHome backend generation binding', () => {
 });
 
 describe('Training backend content binding', () => {
+  it('fully releases reading audio before entering the realtime speak stage', async () => {
+    const lifecycle: string[] = [];
+    const service = {
+      createFlow: jest.fn(async () => ({
+        sceneId: scene.sceneId,
+        stage: 'SENTENCE_LEARNING' as const,
+        completed: false,
+      })),
+      getContent: jest.fn(async () => scene.sentenceList.slice(0, 1)),
+      advanceStage: jest.fn(async (_sceneId: string, stage: SceneFlowStage) => {
+        if (stage === 'SENTENCE_LEARNING') {
+          lifecycle.push('advance-stage');
+          return new Promise<never>(() => undefined);
+        }
+        return {
+          sceneId: scene.sceneId,
+          stage: (
+            stage === 'WORD_LEARNING'
+              ? 'PHRASE_LEARNING'
+              : stage === 'PHRASE_LEARNING'
+                ? 'SENTENCE_LEARNING'
+                : 'DIALOGUE'
+          ) as SceneFlowStage,
+          completed: false,
+        };
+      }),
+      evaluateSentence: jest.fn(async () => ({
+        overallScore: 88,
+        passed: true,
+        words: [],
+      })),
+    };
+    const controller = new SceneTrainingController(service);
+    const wavRecorder = {
+      start: jest.fn(async () => undefined),
+      stop: jest.fn(async () => 'file:///sentence.wav'),
+      cancel: jest.fn(async () => {
+        lifecycle.push('release-reading-audio');
+      }),
+    };
+    const screen = await render(
+      <Training
+        initialStage="read"
+        scene={scene}
+        trainingController={controller}
+        wavRecorder={wavRecorder}
+        ttsPlayer={{ play: jest.fn(async () => undefined), stop: jest.fn() }}
+        onBack={jest.fn()}
+        onFinish={jest.fn()}
+      />,
+    );
+
+    await waitFor(() => expect(screen.getByLabelText('开始朗读')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('开始朗读'));
+    await fireEvent.press(screen.getByLabelText('结束朗读'));
+    await waitFor(() => expect(screen.getByText('朗读通过')).toBeTruthy());
+    await fireEvent.press(screen.getByText('知道了'));
+    await fireEvent.press(screen.getByText('进入模拟'));
+
+    await waitFor(() => expect(service.advanceStage).toHaveBeenCalledTimes(3));
+    expect(lifecycle).toEqual(['release-reading-audio', 'advance-stage']);
+  });
+
   it('renders and advances through generated words, phrases and sentences', async () => {
     const service = {
       createFlow: jest.fn(async () => ({


### PR DESCRIPTION
## Summary

- reuse the WebRTC microphone PCM for asynchronous scene-turn scoring instead of opening a competing Android AudioRecord
- explicitly cancel the active Realtime response when mobile VAD detects barge-in
- fully release reading-stage audio before entering the realtime speaking stage
- package the native WebRTC PCM tap as an Expo config plugin so clean prebuilds preserve the fix

## Root cause

Mobile scene practice opened WebRTC at 48 kHz for realtime conversation and AudioStudio at 16 kHz for WAV scoring at the same time. On the OnePlus test device the two Android recording sessions competed for the microphone route, which caused premature VAD stops, delayed interruption, short or invalid scoring audio, and the initial AI preparing state.

## Validation

- completed a full scene flow on a OnePlus 8T and received an 82-point report without the insufficient-valid-speech error
- confirmed only one WebRTC recording chain remains active during scene dialogue
- 15 mobile test suites, 94 tests passed
- mobile TypeScript check passed
- mobile lint passed with 0 errors
- clean Expo Android prebuild passed
- Android arm64 debug build and physical-device installation passed

No Web or backend implementation files are changed.