### PR TITLE
fix: improve quality issue tracing and evaluation fallback

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueAdminService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueAdminService.java
@@ -16,8 +16,10 @@ import org.springframework.transaction.annotation.Transactional;
 public class QualityIssueAdminService {
 	private static final String ISSUE_SELECT = """
 			SELECT q.*,
-			       (SELECT COUNT(DISTINCT e.user_id) FROM quality_issue_events e
-			        WHERE e.issue_id = q.issue_id AND e.user_id IS NOT NULL) AS affected_users
+			       (SELECT COUNT(DISTINCT COALESCE(e.user_id::text, 'anon:' || e.anonymous_id))
+			        FROM quality_issue_events e
+			        WHERE e.issue_id = q.issue_id
+			          AND (e.user_id IS NOT NULL OR NULLIF(e.anonymous_id, '') IS NOT NULL)) AS affected_users
 			FROM quality_issues q
 			""";
 
@@ -34,8 +36,10 @@ public class QualityIssueAdminService {
 				    COUNT(*) FILTER (WHERE severity = 'CRITICAL' AND status NOT IN ('VERIFIED', 'IGNORED')) AS critical_issues,
 				    COUNT(*) FILTER (WHERE issue_type = 'OPTIMIZATION' AND status NOT IN ('VERIFIED', 'IGNORED')) AS optimizations,
 				    COALESCE(SUM(occurrence_count) FILTER (WHERE last_seen_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'), 0) AS events_7d,
-				    (SELECT COUNT(DISTINCT user_id) FROM quality_issue_events
-				     WHERE user_id IS NOT NULL AND occurred_at >= CURRENT_TIMESTAMP - INTERVAL '7 days') AS affected_users_7d,
+			    (SELECT COUNT(DISTINCT COALESCE(user_id::text, 'anon:' || anonymous_id))
+			     FROM quality_issue_events
+			     WHERE occurred_at >= CURRENT_TIMESTAMP - INTERVAL '7 days'
+			       AND (user_id IS NOT NULL OR NULLIF(anonymous_id, '') IS NOT NULL)) AS affected_users_7d,
 				    COUNT(*) FILTER (WHERE status IN ('RESOLVED', 'VERIFIED')
 				                     AND updated_at >= CURRENT_TIMESTAMP - INTERVAL '7 days') AS resolved_7d
 				FROM quality_issues

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
@@ -85,7 +85,7 @@ public class QualityIssueTelemetrySink implements ClientTelemetrySink {
 					    resolved_at = CASE WHEN status IN ('RESOLVED', 'VERIFIED') THEN NULL ELSE resolved_at END,
 					    updated_at = CURRENT_TIMESTAMP
 					WHERE issue_id = ?
-					""", occurredAt, occurredAt, occurredAt, issueId);
+					""", timestamp(occurredAt), timestamp(occurredAt), timestamp(occurredAt), issueId);
 		}
 	}
 

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
@@ -12,6 +12,9 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import tools.jackson.core.JacksonException;
@@ -106,7 +109,21 @@ public class QualityIssueTelemetrySink implements ClientTelemetrySink {
 		fields.put("error_name", error.getClass().getSimpleName());
 		fields.put("message", error.getMessage());
 		fields.put("stack", stackSummary(error));
+		String authenticatedUserId = authenticatedUserId();
+		if (authenticatedUserId != null) fields.put("user_id", authenticatedUserId);
 		write(new ClientTelemetryRecord(fields));
+	}
+
+	private String authenticatedUserId() {
+		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+		if (authentication == null || !(authentication.getPrincipal() instanceof Jwt jwt)) return null;
+		String subject = jwt.getSubject();
+		try {
+			return subject == null ? null : UUID.fromString(subject).toString();
+		}
+		catch (IllegalArgumentException ignored) {
+			return null;
+		}
 	}
 
 	private int insertEvent(

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/admin/quality/QualityIssueTelemetrySink.java
@@ -5,6 +5,7 @@ import com.unispeaking.telemetry.ClientTelemetrySink;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.LinkedHashMap;
@@ -71,7 +72,7 @@ public class QualityIssueTelemetrySink implements ClientTelemetrySink {
 				RETURNING issue_id
 				""", UUID.class,
 				fingerprint, platform, severity, title(eventType, apiPath, httpStatus, message), message,
-				errorCode, apiPath, httpStatus, release, occurredAt, occurredAt);
+				errorCode, apiPath, httpStatus, release, timestamp(occurredAt), timestamp(occurredAt));
 
 		int inserted = insertEvent(issueId, fields, platform, eventType, occurredAt);
 		if (inserted == 1) {
@@ -148,7 +149,11 @@ public class QualityIssueTelemetrySink implements ClientTelemetrySink {
 				text(fields, "api_method"), integer(fields, "http_status"), text(fields, "outcome"),
 				text(fields, "error_code"), text(fields, "error_name"), text(fields, "device_model"),
 				text(fields, "os_name"), text(fields, "os_version"), text(fields, "network_type"),
-				number(fields, "duration_ms"), attributesJson(fields), occurredAt);
+				number(fields, "duration_ms"), attributesJson(fields), timestamp(occurredAt));
+	}
+
+	private Timestamp timestamp(Instant value) {
+		return Timestamp.from(value == null ? Instant.now() : value);
 	}
 
 	private boolean isActionable(Map<String, Object> fields) {

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/evaluation/EvaluationProcessor.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/evaluation/EvaluationProcessor.java
@@ -1174,6 +1174,18 @@ public class EvaluationProcessor {
 					List.of()));
 			return result;
 		}
+		if (command.audio() == null || command.audio().length == 0) {
+			DialogueTurnEvaluationResult result =
+					UnavailableTurnEvaluationPolicy.createResult(
+						command.turnNo(), command.transcript());
+			turnEvaluationRepository.upsert(toCustomTurn(
+					session, result, List.of()));
+			LOGGER.info(
+					"custom turn pronunciation unavailable; preserving transcript "
+							+ "sessionId={} turnNo={} reason=audio_missing",
+					session.getId(), command.turnNo());
+			return result;
+		}
 
 		PcmWavValidator.validate(command.audio());
 		PronunciationAssessmentResult assessment = AiInvocationContexts.call(
@@ -1219,6 +1231,18 @@ public class EvaluationProcessor {
 					session,
 					result,
 					List.of()));
+			return result;
+		}
+		if (command.audio() == null || command.audio().length == 0) {
+			DialogueTurnEvaluationResult result =
+					UnavailableTurnEvaluationPolicy.createResult(
+						command.turnNo(), command.transcript());
+			turnEvaluationRepository.upsert(toCustomTurn(
+					session, result, List.of()));
+			LOGGER.info(
+					"IELTS turn pronunciation unavailable; preserving transcript "
+							+ "sessionId={} turnNo={} reason=audio_missing",
+					session.getId(), command.turnNo());
 			return result;
 		}
 

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -1194,16 +1194,19 @@ export function createRealtimeClient({
       closingResponseRequested = true;
       armScenarioCompletionTimeout();
     }
-    try {
-      sendProviderEvent(buildResponseCreateEvent({
-        id: eventId(closing ? "closing_response" : "turn_response"),
-        instructions,
-      }));
-    } catch (error) {
-      responsePending = false;
-      if (closing) closingResponseRequested = false;
-      throw error;
-    }
+	try {
+	  sendProviderEvent(buildResponseCreateEvent({
+	    id: eventId(closing ? "closing_response" : "turn_response"),
+	    instructions,
+	  }));
+	} catch (error) {
+	  responsePending = false;
+	  if (closing) closingResponseRequested = false;
+	  // A remote close can race the readyState check. Treat that as a
+	  // normal disconnected turn; the next connected turn can retry safely.
+	  if (!isRealtimeChannelOpen(channel)) return false;
+	  throw error;
+	}
     return true;
   }
 
@@ -1939,9 +1942,6 @@ export function createRealtimeClient({
   }
 
   function requestResponse() {
-    if (!channel || channel.readyState !== "open") {
-      throw new Error("实时数据通道尚未连接");
-    }
     return requestTurnResponse();
   }
 


### PR DESCRIPTION
Closes #145

## Changes
- Count affected users by user_id or anonymous_id.
- Include authenticated user IDs in backend quality events.
- Gracefully preserve transcript when audio is unavailable.
- Avoid realtime-channel close race errors.

## Verification
- Backend compile passed.
- Quality controller and telemetry tests passed.
- Web realtime event checks and production build passed.