### PR TITLE
fix(web)：支持场景重新建联并修正会话计时

### DIFF
--- a/frontend/web/scripts/check-call-timer-stop.mjs
+++ b/frontend/web/scripts/check-call-timer-stop.mjs
@@ -48,7 +48,7 @@ const timerSource = appSource.slice(timerStart, timerEnd);
 
 assert.match(
   conversationSource,
-  /<CallTimer paused=\{paused\} state=\{ended \? "ended" : error \? "error" : "active"\} stopped=\{ending\} \/>/,
+  /<CallTimer paused=\{paused\} state=\{ended \? "ended" : error \? "error" : realtimeState\} stopped=\{ending\} \/>/,
   "The scene call timer must stop as soon as report generation begins",
 );
 assert.match(
@@ -58,7 +58,17 @@ assert.match(
 );
 assert.match(
   timerSource,
-  /if \(terminal\) return undefined;/,
+  /const startedAt = useRef\(null\);[\s\S]*?const running = !terminal && state !== "connecting";/,
+  "CallTimer must wait for a successful realtime connection before recording its start time",
+);
+assert.match(
+  timerSource,
+  /if \(!running\) return undefined;[\s\S]*?startedAt\.current \?\?= Date\.now\(\);/,
+  "CallTimer must start only after realtime leaves the connecting state",
+);
+assert.match(
+  timerSource,
+  /return \(\) => window\.clearInterval\(interval\);/,
   "CallTimer must clear its interval when the call stops or fails",
 );
 assert.match(
@@ -67,19 +77,24 @@ assert.match(
   "Free conversation must pass realtime failure state to CallTimer",
 );
 assert.match(
-  interviewSource,
-  /if \(state === "ended" \|\| state === "error"\) return undefined;/,
-  "InterviewTimer must clear its interval after realtime failure",
+  conversationSource,
+  /setRealtimeState\("connecting"\);[\s\S]*?event\.type === "local\.connected"[\s\S]*?setRealtimeState\("connected"\);/,
+  "Custom scene timing must begin only after local.connected",
 );
 assert.match(
   interviewSource,
-  /<InterviewTimer paused=\{paused\} state=\{ending \? "ended" : error \? "error" : "active"\} \/>/,
-  "Interview session must pass realtime failure state to InterviewTimer",
+  /const running = state !== "connecting" && state !== "ended" && state !== "error";[\s\S]*?if \(!running\) return undefined;/,
+  "InterviewTimer must wait for a successful realtime connection",
+);
+assert.match(
+  interviewSource,
+  /event\.type === "local\.connected"[\s\S]*?setRealtimeState\("connected"\);[\s\S]*?<InterviewTimer paused=\{paused\} state=\{ending \? "ended" : error \? "error" : realtimeState\} \/>/,
+  "Interview session must start its timer from local.connected",
 );
 assert.match(
   ieltsSource,
-  /setRealtimeState\("error"\);[\s\S]*?if \(ending \|\| realtimeState === "error"\) return undefined;/,
-  "IELTS timer must stop after realtime connection failure",
+  /setRealtimeState\("connected"\);[\s\S]*?if \(ending \|\| realtimeState !== "connected"\) return undefined;/,
+  "IELTS timer must run only after realtime connects",
 );
 
 console.log("Realtime call timer stop checks passed.");

--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -573,6 +573,30 @@ assert.match(freeChatStopSource, /detachRemoteAudio\(\)/);
 
 assert.match(appSource, /const detachSceneRemoteAudio = \(\) => \{/);
 assert.match(appSource, /sceneAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);\s+detachSceneRemoteAudio\(\);/);
+const customSceneConversationSource = appSource.slice(
+  appSource.indexOf("function CustomSceneConversation("),
+  appSource.indexOf("const sentenceWordPattern"),
+);
+assert.match(
+  customSceneConversationSource,
+  /const \[connectionFailed, setConnectionFailed\] = useState\(false\);/,
+  "custom scene must track retryable connection failures",
+);
+assert.match(
+  customSceneConversationSource,
+  /if \(!connectionFailed \|\| reconnecting \|\| !client\) return;\s+void connectRealtime\(client, \{ retry: true \}\);/,
+  "custom scene reconnect must reuse the current realtime client and prevent duplicate attempts",
+);
+assert.match(
+  customSceneConversationSource,
+  /\{reconnecting \? "正在重新连接" : "重新连接"\}/,
+  "custom scene must expose an explicit reconnect action after startup failure",
+);
+assert.doesNotMatch(
+  customSceneConversationSource,
+  /setTimeout\([^)]*connectRealtime/,
+  "custom scene reconnect must remain user initiated",
+);
 
 const ieltsSource = await readFile(
   new URL("../src/component/ielts/IeltsModule.jsx", import.meta.url),

--- a/frontend/web/src/component/ielts/IeltsModule.jsx
+++ b/frontend/web/src/component/ielts/IeltsModule.jsx
@@ -854,7 +854,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
   }, [generated?.ieltsId, generated?.voiceId, examiner.id]);
 
   useEffect(() => {
-    if (ending || realtimeState === "error") return undefined;
+    if (ending || realtimeState !== "connected") return undefined;
     const timer = window.setInterval(() => setElapsed((value) => value + 1), 1000);
     return () => window.clearInterval(timer);
   }, [ending, realtimeState]);
@@ -956,7 +956,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
             <span className={cx("voice-wave", subtitles && "voice-wave--compact", "is-fallback")} aria-hidden="true">
               {[.28, .52, .78, 1, .72, .48, .3].map((level, index) => <i key={index} className="voice-wave__bar" style={{ "--rest-level": level }} />)}
             </span>
-            <time className="call-presence__time">{realtimeState === "error" ? "连接失败" : isPartTwo ? formatTime(partTwoRemaining) : isPartThree && partThreeRemaining != null ? formatTime(partThreeRemaining) : formatTime(elapsed)}</time>
+            <time className="call-presence__time">{realtimeState === "connecting" ? "连接中" : realtimeState === "error" ? "连接失败" : isPartTwo ? formatTime(partTwoRemaining) : isPartThree && partThreeRemaining != null ? formatTime(partThreeRemaining) : formatTime(elapsed)}</time>
             {!subtitles && <span>{status}</span>}
           </div>
         </div>

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -167,16 +167,18 @@ function InterviewWaveform({ active = false, compact = false }) {
 
 function InterviewTimer({ state = "active", paused = false }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const startedAt = useRef(Date.now());
+  const startedAt = useRef(null);
+  const running = state !== "connecting" && state !== "ended" && state !== "error";
   useEffect(() => {
+    if (!running) return undefined;
+    startedAt.current ??= Date.now();
     const updateElapsed = () => setElapsedSeconds(Math.floor((Date.now() - startedAt.current) / 1000));
     updateElapsed();
-    if (state === "ended" || state === "error") return undefined;
     const interval = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(interval);
-  }, [state]);
+  }, [running]);
   const duration = `${String(Math.floor(elapsedSeconds / 60)).padStart(2, "0")}:${String(elapsedSeconds % 60).padStart(2, "0")}`;
-  const label = state === "error" ? "连接失败" : state === "ended" ? "已结束" : paused ? `已暂停 · ${duration}` : duration;
+  const label = state === "connecting" ? "连接中" : state === "error" ? "连接失败" : state === "ended" ? "已结束" : paused ? `已暂停 · ${duration}` : duration;
   return <time className="call-presence__time">{label}</time>;
 }
 
@@ -504,6 +506,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
   const [paused, setPaused] = useState(false);
   const [ending, setEnding] = useState(false);
   const [closing, setClosing] = useState(false);
+  const [realtimeState, setRealtimeState] = useState("connecting");
   const [lines, setLines] = useState([]);
   const [exitOpen, setExitOpen] = useState(false);
   const clientRef = useRef(null);
@@ -539,9 +542,12 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
   };
 
   const handleEvent = (event) => {
-    if (event.type === "local.connecting") setStatus("正在连接面试官");
-    else if (event.type === "local.connected") {
+    if (event.type === "local.connecting") {
+      setRealtimeState("connecting");
+      setStatus("正在连接面试官");
+    } else if (event.type === "local.connected") {
       interviewAnalyticsRef.current?.started();
+      setRealtimeState("connected");
       setStatus("正在建立面试会话");
       sessionIdRef.current = event.sessionId || "";
     } else if (event.type === "session.updated" || event.type === "local.greeting_timeout") {
@@ -599,9 +605,11 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     } else if (event.type === "local.backend_warning") {
       setError(event.message || "会话记录保存失败，请稍后重试");
     } else if (event.type === "local.mic_error") {
+      setRealtimeState("error");
       setError(event.message || "无法访问麦克风");
       setStatus("麦克风不可用，请检查权限");
     } else if (event.type === "error" || event.type === "local.error") {
+      setRealtimeState("error");
       setError(event.message || event.error?.message || "实时会话发生错误");
       setStatus("连接异常");
     }
@@ -680,6 +688,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     }).catch((startError) => {
       if (!cancelled) {
         interviewAnalyticsRef.current.fail("REALTIME_ERROR");
+        setRealtimeState("error");
         setError(startError instanceof Error ? startError.message : "无法开始面试会话");
       }
     });
@@ -763,7 +772,7 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
           <div className="portrait portrait--small interview-call-portrait"><img src={teacher?.image} alt={teacher?.name} /></div>
           <div className="listening-state listening-state--compact">
             <InterviewWaveform active={!ending && !paused && !error} compact />
-            <InterviewTimer paused={paused} state={ending ? "ended" : error ? "error" : "active"} />
+            <InterviewTimer paused={paused} state={ending ? "ended" : error ? "error" : realtimeState} />
             {(!ending || closing) && <span>{status}</span>}
           </div>
         </div>

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
+  ArrowClockwise,
   ArrowRight,
   BookOpenText,
   Briefcase,
@@ -1699,6 +1700,8 @@ function CustomSceneConversation({
   const [error, setError] = useState("");
   const [paused, setPaused] = useState(false);
   const [ending, setEnding] = useState(false);
+  const [connectionFailed, setConnectionFailed] = useState(false);
+  const [reconnecting, setReconnecting] = useState(false);
   const [lines, setLines] = useState([]);
   const [translated, setTranslated] = useState([]);
   const clientRef = useRef(null);
@@ -1707,6 +1710,7 @@ function CustomSceneConversation({
   const endingRef = useRef(false);
   const scenarioCompletedRef = useRef(false);
   const sceneAnalyticsRef = useRef(null);
+  const connectionPromiseRef = useRef(null);
   const { transcriptRef, handleTranscriptScroll } = useTranscriptAutoFollow({
     lines,
     translated,
@@ -1744,6 +1748,7 @@ function CustomSceneConversation({
     if (event.type === "local.connecting") setStatus("正在连接模型");
     else if (event.type === "local.connected") {
       sceneAnalyticsRef.current?.started();
+      setConnectionFailed(false);
       setStatus("正在建立模型会话");
       sessionIdRef.current = event.sessionId || "";
       onSessionStarted?.(event.sessionId);
@@ -1825,6 +1830,53 @@ function CustomSceneConversation({
     }
   };
 
+  const connectRealtime = (client, { retry = false } = {}) => {
+    if (!client || clientRef.current !== client || endingRef.current) {
+      return Promise.resolve();
+    }
+    if (connectionPromiseRef.current) return connectionPromiseRef.current;
+
+    let operation;
+    operation = (async () => {
+      sceneAnalyticsRef.current = analytics.training({ mode: "SCENE", pageCode: "scene-training" });
+      sceneAnalyticsRef.current.attempt();
+      setConnectionFailed(false);
+      setReconnecting(retry);
+      setError("");
+      setPaused(false);
+      setStatus(retry ? "正在重新连接场景" : "正在连接场景");
+      try {
+        await client.start({
+          voice: teacher.voiceId,
+          speechSpeed: speedCodeByLabel[speed] || "NATURAL",
+        });
+        if (clientRef.current !== client) return;
+        sceneAnalyticsRef.current.started();
+      } catch (startError) {
+        if (clientRef.current !== client) return;
+        sceneAnalyticsRef.current.fail("REALTIME_ERROR");
+        setConnectionFailed(true);
+        setError(realtimeFailureMessage(startError));
+        setStatus("连接失败");
+      } finally {
+        if (clientRef.current === client) setReconnecting(false);
+      }
+    })();
+    const trackedOperation = operation.finally(() => {
+      if (connectionPromiseRef.current === trackedOperation) {
+        connectionPromiseRef.current = null;
+      }
+    });
+    connectionPromiseRef.current = trackedOperation;
+    return trackedOperation;
+  };
+
+  const reconnectConversation = () => {
+    const client = clientRef.current;
+    if (!connectionFailed || reconnecting || !client) return;
+    void connectRealtime(client, { retry: true });
+  };
+
   useEffect(() => {
     if (ended) {
       setEnding(true);
@@ -1833,8 +1885,6 @@ function CustomSceneConversation({
       return undefined;
     }
     let cancelled = false;
-    sceneAnalyticsRef.current = analytics.training({ mode: "SCENE", pageCode: "scene-training" });
-    sceneAnalyticsRef.current.attempt();
     const client = createRealtimeClient({
       sceneId,
       sceneType: "custom",
@@ -1848,17 +1898,7 @@ function CustomSceneConversation({
       },
     });
     clientRef.current = client;
-    void client.start({
-      voice: teacher.voiceId,
-      speechSpeed: speedCodeByLabel[speed] || "NATURAL",
-    }).then(() => {
-      if (!cancelled) sceneAnalyticsRef.current.started();
-    }).catch((startError) => {
-      if (!cancelled) {
-        sceneAnalyticsRef.current.fail("REALTIME_ERROR");
-        setError(startError instanceof Error ? startError.message : "无法开始场景对话");
-      }
-    });
+    void connectRealtime(client);
     const syncVisibility = () => sceneAnalyticsRef.current?.setVisible(document.visibilityState === "visible");
     document.addEventListener("visibilitychange", syncVisibility);
     syncVisibility();
@@ -1868,6 +1908,7 @@ function CustomSceneConversation({
       sceneAnalyticsRef.current?.abandon("COMPONENT_UNMOUNT");
       detachSceneRemoteAudio();
       clientRef.current = null;
+      connectionPromiseRef.current = null;
       void client.stop({ notifyBackend: false, reason: "component_unmount", emitEnded: false });
     };
   }, [sceneId, ended]);
@@ -1956,6 +1997,17 @@ function CustomSceneConversation({
           emptyStatus={status}
         />
         {error && <p className="call-error" role="alert">{error}</p>}
+        {(connectionFailed || reconnecting) && (
+          <Button
+            type="button"
+            variant="secondary"
+            disabled={reconnecting}
+            icon={<ArrowClockwise weight="bold" />}
+            onClick={reconnectConversation}
+          >
+            {reconnecting ? "正在重新连接" : "重新连接"}
+          </Button>
+        )}
       </section>
       <CallControls
         paused={paused}

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -446,18 +446,20 @@ const formatCallDuration = (totalSeconds) => {
 
 function CallTimer({ state = "active", paused = false, stopped = false, className }) {
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const startedAt = useRef(Date.now());
+  const startedAt = useRef(null);
   const terminal = stopped || state === "ended" || state === "error";
+  const running = !terminal && state !== "connecting";
 
   useEffect(() => {
+    if (!running) return undefined;
+    startedAt.current ??= Date.now();
     const updateElapsed = () => {
       setElapsedSeconds(Math.floor((Date.now() - startedAt.current) / 1000));
     };
     updateElapsed();
-    if (terminal) return undefined;
     const interval = window.setInterval(updateElapsed, 1000);
     return () => window.clearInterval(interval);
-  }, [terminal]);
+  }, [running]);
 
   const duration = formatCallDuration(elapsedSeconds);
   const label = state === "connecting"
@@ -1702,6 +1704,7 @@ function CustomSceneConversation({
   const [ending, setEnding] = useState(false);
   const [connectionFailed, setConnectionFailed] = useState(false);
   const [reconnecting, setReconnecting] = useState(false);
+  const [realtimeState, setRealtimeState] = useState("connecting");
   const [lines, setLines] = useState([]);
   const [translated, setTranslated] = useState([]);
   const clientRef = useRef(null);
@@ -1745,10 +1748,13 @@ function CustomSceneConversation({
   };
 
   const handleEvent = (event) => {
-    if (event.type === "local.connecting") setStatus("正在连接模型");
-    else if (event.type === "local.connected") {
+    if (event.type === "local.connecting") {
+      setRealtimeState("connecting");
+      setStatus("正在连接模型");
+    } else if (event.type === "local.connected") {
       sceneAnalyticsRef.current?.started();
       setConnectionFailed(false);
+      setRealtimeState("connected");
       setStatus("正在建立模型会话");
       sessionIdRef.current = event.sessionId || "";
       onSessionStarted?.(event.sessionId);
@@ -1822,9 +1828,11 @@ function CustomSceneConversation({
     } else if (event.type === "local.turn_evaluation_error") {
       setError(event.message);
     } else if (event.type === "local.mic_error") {
+      setRealtimeState("error");
       setError(event.message || "无法访问麦克风");
       setStatus("麦克风不可用，请检查权限");
     } else if (event.type === "error" || event.type === "local.error") {
+      setRealtimeState("error");
       setError(event.message || event.error?.message || "实时会话发生错误");
       setStatus("连接异常");
     }
@@ -1844,6 +1852,7 @@ function CustomSceneConversation({
       setReconnecting(retry);
       setError("");
       setPaused(false);
+      setRealtimeState("connecting");
       setStatus(retry ? "正在重新连接场景" : "正在连接场景");
       try {
         await client.start({
@@ -1856,6 +1865,7 @@ function CustomSceneConversation({
         if (clientRef.current !== client) return;
         sceneAnalyticsRef.current.fail("REALTIME_ERROR");
         setConnectionFailed(true);
+        setRealtimeState("error");
         setError(realtimeFailureMessage(startError));
         setStatus("连接失败");
       } finally {
@@ -1983,7 +1993,7 @@ function CustomSceneConversation({
           <div className="portrait portrait--small"><img src={teacher.image} alt={teacher.name} /></div>
           <div className="listening-state listening-state--compact">
             <VoiceWaveform active={!ended && !paused && !ending && !error} compact />
-            <CallTimer paused={paused} state={ended ? "ended" : error ? "error" : "active"} stopped={ending} />
+            <CallTimer paused={paused} state={ended ? "ended" : error ? "error" : realtimeState} stopped={ending} />
             <span>{status}</span>
           </div>
         </div>


### PR DESCRIPTION
## 修改说明

本 PR 合并处理 Web Realtime 会话的建联恢复与计时体验：

- 自定义场景“说”阶段首次连接失败后提供“重新连接”按钮
- 复用当前 Realtime 客户端，保留当前场景与训练阶段
- 防止重连操作重复触发
- 建联及重新建联期间显示“连接中”，不累计页面会话时间
- 收到 `local.connected` 后从 `00:00` 开始计时
- 统一自由对话、自定义场景、IELTS 和英文面试的计时起点
- 保留连接失败、结束和报告生成阶段停止计时的原有行为

## 改动范围

- `frontend/web/src/controller/App.jsx`
- `frontend/web/src/component/interview/InterviewModule.jsx`
- `frontend/web/src/component/ielts/IeltsModule.jsx`
- `frontend/web/scripts/check-realtime-events.mjs`
- `frontend/web/scripts/check-call-timer-stop.mjs`

未修改后端、数据库、额度计时、API 协议及移动端。

## 提交记录

- `141b086 fix(web)：增加自定义场景说阶段重新建联`
- `767b411 fix(web)：连接成功后开始会话计时`

## 验证

- [x] `npm run check:realtime-events`
- [x] `npm run check:call-timer`
- [x] `npm run build`
- [x] 本地 Vite 热更新正常
- [x] 页面加载正常且浏览器控制台无错误

## 手动验证建议

1. 登录 Web 并进入自定义场景“说”阶段。
2. 在首次建联时临时中断网络，确认显示连接失败和“重新连接”。
3. 恢复网络并点击“重新连接”，确认仍停留在当前场景。
4. 确认建联期间不累计时间，连接成功后从 `00:00` 开始。
5. 分别检查自由对话、IELTS 和英文面试的计时起点。