### PR TITLE
feat: add randomized daily scene recommendations

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/scene/DailyPickCatalog.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/scene/DailyPickCatalog.java
@@ -1,0 +1,174 @@
+package com.unispeaking.component.scene;
+
+import com.unispeaking.domain.vo.scene.DailyPickTopic;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DailyPickCatalog {
+
+	private static final List<Variation> VARIATIONS = List.of(
+			new Variation("essential", "8–10 分钟", "初级", "完成核心沟通并清楚表达需求", "先完成最常见的基础沟通，确认关键信息"),
+			new Variation("problem", "10–12 分钟", "中级", "说明突发问题并协商解决办法", "过程中遇到一个意外问题，需要解释情况并协商解决"),
+			new Variation("advanced", "12–15 分钟", "高级", "比较不同选择并进行更深入的交流", "进一步询问细节、比较选择，并确认最终安排")
+	);
+
+	private static final List<ScenarioSeed> SEEDS = List.of(
+			seed("coffee-shop", "咖啡店点单", "food", "在咖啡店选择饮品，说明杯型、温度和甜度"),
+			seed("restaurant-order", "餐厅点餐", "food", "在餐厅查看菜单、询问菜品并完成点餐"),
+			seed("food-allergy", "说明食物过敏", "food", "就餐时说明食物过敏和饮食限制"),
+			seed("takeaway-order", "电话订餐", "food", "打电话订餐并确认菜品、地址和送达时间"),
+			seed("bakery-shopping", "面包店选购", "food", "在面包店询问口味、配料和保质期"),
+			seed("buffet-dining", "自助餐咨询", "food", "在自助餐厅询问用餐规则和可选食物"),
+			seed("barbecue-party", "烧烤聚餐", "food", "和朋友准备烧烤，商量食材、分工和时间"),
+			seed("business-dinner", "商务晚餐", "food", "参加商务晚餐并兼顾点餐礼仪和席间交流"),
+			seed("cooking-class", "烹饪课程", "food", "参加烹饪课程，询问步骤、食材和操作方法"),
+			seed("food-delivery", "外卖订单", "food", "联系外卖平台确认订单、配送进度和特殊要求"),
+
+			seed("clothing-store", "服装店选购", "shopping", "在服装店寻找合适的款式、颜色和尺码"),
+			seed("clothing-return", "服装退换", "shopping", "说明服装不合适并询问退换流程"),
+			seed("electronics-store", "选购电子产品", "shopping", "比较电子产品的功能、价格和保修服务"),
+			seed("supermarket", "超市购物", "shopping", "在超市寻找商品并核对规格、成分和促销"),
+			seed("bookstore", "书店选书", "shopping", "说明阅读偏好并请店员推荐合适的书"),
+			seed("market-bargain", "市场询价", "shopping", "在市场询问商品材质、规格和价格"),
+			seed("gift-shopping", "挑选礼物", "shopping", "根据收礼人的喜好和预算挑选礼物"),
+			seed("furniture-store", "家具店咨询", "shopping", "询问家具尺寸、材质、配送和安装服务"),
+			seed("online-refund", "网购退款", "shopping", "联系网店客服说明商品问题并申请退款"),
+			seed("secondhand-trade", "二手交易", "shopping", "和卖家确认二手商品的状况、价格和交付方式"),
+
+			seed("airport-checkin", "机场值机", "transit", "在机场办理值机并确认座位、行李和登机信息"),
+			seed("flight-delay", "航班延误", "transit", "向机场工作人员询问延误和替代安排"),
+			seed("train-ticket", "购买火车票", "transit", "在车站购买车票并确认班次、座位和站台"),
+			seed("train-change", "火车票改签", "transit", "申请改签车票并确认可选班次和费用"),
+			seed("directions", "问路与换乘", "transit", "向路人询问路线和公共交通换乘方式"),
+			seed("taxi-ride", "乘坐出租车", "transit", "向司机说明目的地、路线偏好和下车位置"),
+			seed("car-rental", "租车取车", "transit", "在租车柜台确认车型、保险和还车要求"),
+			seed("bus-pass", "办理公交卡", "transit", "咨询公交卡价格、充值方式和适用范围"),
+			seed("bike-rental", "租用自行车", "transit", "询问自行车租用、计费和归还规则"),
+			seed("missed-connection", "错过交通接驳", "transit", "向工作人员说明错过接驳的情况并寻找替代路线"),
+
+			seed("hotel-checkin", "酒店入住", "accommodation", "在酒店前台办理入住并确认房型和早餐"),
+			seed("hotel-booking", "预订酒店", "accommodation", "咨询酒店房型、价格、设施和取消政策"),
+			seed("room-issue", "酒店房间问题", "accommodation", "向前台反映房间设施或噪音问题"),
+			seed("late-checkout", "延迟退房", "accommodation", "向酒店申请延迟退房并确认时间和费用"),
+			seed("hostel-booking", "青年旅舍预订", "accommodation", "询问床位、储物柜、公共设施和入住规则"),
+			seed("apartment-viewing", "租房看房", "accommodation", "看出租公寓并询问家具、账单、押金和交通"),
+			seed("lease-signing", "签订租约", "accommodation", "与房东核对租期、押金、维修和解约条款"),
+			seed("roommate-rules", "室友生活沟通", "accommodation", "和室友商量清洁、访客、噪音和公共空间规则"),
+			seed("homestay-arrival", "寄宿家庭入住", "accommodation", "与寄宿家庭确认房间、作息和家庭习惯"),
+			seed("home-repair", "预约家中维修", "accommodation", "联系维修人员描述故障并确认上门安排"),
+
+			seed("pharmacy", "药店咨询", "health", "在药店描述轻微症状并询问非处方药"),
+			seed("doctor-booking", "预约医生", "health", "联系诊所说明就诊原因并预约时间"),
+			seed("doctor-visit", "医生问诊", "health", "向医生描述症状、持续时间和既往病史"),
+			seed("dental-visit", "牙科就诊", "health", "描述牙齿不适并确认检查和治疗安排"),
+			seed("health-check", "体检结果咨询", "health", "询问体检指标和后续健康建议"),
+			seed("emergency-clinic", "急诊接待", "health", "在急诊接待处准确描述紧急症状和用药情况"),
+			seed("vaccination", "疫苗接种咨询", "health", "咨询疫苗适用情况、预约和接种后注意事项"),
+			seed("eye-exam", "视力检查", "health", "向验光师说明视力变化并了解检查结果"),
+			seed("fitness-coach", "健身教练沟通", "health", "说明健身目标、身体状况和训练偏好"),
+			seed("mental-wellbeing", "心理咨询预约", "health", "联系咨询机构了解预约、隐私和服务方式"),
+
+			seed("meeting-opinion", "会议表达意见", "workplace", "在团队会议中提出观点并回应同事问题"),
+			seed("project-delay", "沟通项目延期", "workplace", "向同事解释延期原因、影响和新计划"),
+			seed("deadline", "协商工作期限", "workplace", "与负责人讨论工作量、风险和交付期限"),
+			seed("feedback", "绩效反馈沟通", "workplace", "与主管澄清反馈并制定改进计划"),
+			seed("salary", "薪资沟通", "workplace", "用工作成果支持薪资调整诉求"),
+			seed("cross-team", "跨部门协作", "workplace", "与其他部门确认共同目标、职责分工和协作时间表"),
+			seed("client-call", "客户电话", "workplace", "与客户确认需求、时间和下一步安排"),
+			seed("presentation", "工作汇报", "workplace", "向团队汇报进展、成果、风险和计划"),
+			seed("handover", "工作交接", "workplace", "向同事说明任务状态、资料位置和注意事项"),
+			seed("conference-network", "行业会议交流", "workplace", "在行业会议上介绍工作并建立专业联系"),
+
+			seed("new-neighbor", "认识新邻居", "social", "第一次见到邻居并聊聊周边生活"),
+			seed("weekend-plan", "商量周末计划", "social", "和朋友比较活动选择并确定时间地点"),
+			seed("invite-friend", "邀请朋友参加活动", "social", "介绍活动信息并协调彼此时间"),
+			seed("team-lunch", "同事午餐聊天", "social", "和同事聊工作、兴趣和周末安排"),
+			seed("language-meetup", "语言交换见面", "social", "与语言伙伴介绍目标、兴趣和练习安排"),
+			seed("resolve-conflict", "化解朋友误会", "social", "解释自己的感受并倾听朋友的回应"),
+			seed("birthday-party", "参加生日聚会", "social", "在聚会上认识新朋友并参与轻松对话"),
+			seed("community-event", "社区活动", "social", "向组织者了解活动内容并与参与者交流"),
+			seed("volunteering", "志愿活动报名", "social", "询问志愿任务、时间和需要准备的物品"),
+			seed("hobby-club", "兴趣社团交流", "social", "加入兴趣社团并介绍经验和参与期待"),
+
+			seed("teacher-help", "向老师请教", "education", "向老师说明没有理解的知识点并寻求帮助"),
+			seed("course-enroll", "课程报名", "education", "咨询课程内容、时间、费用和报名条件"),
+			seed("campus-arrival", "校园报到", "education", "询问报到地点、流程和所需材料"),
+			seed("library-card", "办理图书证", "education", "了解办证材料、借阅期限和开放时间"),
+			seed("group-project", "小组作业分工", "education", "和同学分配任务、确定时间并协调分歧"),
+			seed("assignment-extension", "申请作业延期", "education", "向老师说明原因、当前进度和提交计划"),
+			seed("office-hours", "参加教授答疑", "education", "在答疑时间讨论课程问题和学习建议"),
+			seed("study-plan", "制定学习计划", "education", "和学习顾问讨论目标、时间和课程安排"),
+			seed("school-presentation", "课堂展示", "education", "介绍研究主题并回答老师和同学的问题"),
+			seed("exam-review", "考试复核", "education", "向老师询问评分标准并讨论答题问题"),
+
+			seed("bank-account", "银行开户", "services", "咨询开户材料、账户费用和办理时间"),
+			seed("phone-plan", "办理手机套餐", "services", "比较手机套餐的流量、月费和合约"),
+			seed("parcel", "快递问题", "services", "联系快递客服查询包裹并协商处理办法"),
+			seed("utility-bill", "水电账单", "services", "联系客服核对账单和计费方式"),
+			seed("haircut", "理发需求", "services", "向理发师说明发型、长度和打理偏好"),
+			seed("gym-membership", "健身房办卡", "services", "咨询设施、课程、试用和会员合同"),
+			seed("insurance", "保险理赔", "services", "说明事故经过并确认保障、材料和流程"),
+			seed("internet-install", "安装家庭网络", "services", "咨询网络套餐、安装时间和设备费用"),
+			seed("printing-service", "打印店服务", "services", "说明文件格式、纸张、装订和取件时间"),
+			seed("lost-and-found", "失物招领", "services", "描述遗失物品、时间和可能遗失的地点"),
+
+			seed("weather-chat", "谈论天气", "other", "围绕近期天气和出行感受展开自然对话"),
+			seed("movie-chat", "聊电影", "other", "分享最近看过的电影和观后感"),
+			seed("music-chat", "聊音乐", "other", "介绍喜欢的歌手、风格和听歌习惯"),
+			seed("travel-memory", "分享旅行经历", "other", "讲述一次旅行经历、难忘细节和感受"),
+			seed("daily-routine", "介绍日常作息", "other", "描述工作日和周末的日常安排"),
+			seed("city-recommend", "推荐所在城市", "other", "向访客介绍城市景点、美食和交通"),
+			seed("technology-life", "讨论科技生活", "other", "交流常用科技产品及其对生活的影响"),
+			seed("environment", "讨论环保习惯", "other", "分享节能、回收和绿色出行习惯"),
+			seed("future-goals", "谈未来目标", "other", "介绍未来一年的学习、工作和生活目标"),
+			seed("cultural-custom", "介绍文化习俗", "other", "介绍一个节日或文化习俗并回答相关问题")
+	);
+
+	private static final List<DailyPickTopic> TOPICS = buildTopics();
+
+	static {
+		if (TOPICS.size() != 300) {
+			throw new IllegalStateException("Daily pick catalog must contain exactly 300 topics");
+		}
+		if (new HashSet<>(TOPICS.stream().map(DailyPickTopic::id).toList()).size() != TOPICS.size()) {
+			throw new IllegalStateException("Daily pick topic ids must be unique");
+		}
+	}
+
+	public List<DailyPickTopic> topics() {
+		return TOPICS;
+	}
+
+	private static List<DailyPickTopic> buildTopics() {
+		List<DailyPickTopic> topics = new ArrayList<>(SEEDS.size() * VARIATIONS.size());
+		for (ScenarioSeed seed : SEEDS) {
+			for (Variation variation : VARIATIONS) {
+				topics.add(new DailyPickTopic(
+						seed.id() + "-" + variation.id(),
+						seed.title(),
+						seed.category(),
+						variation.duration(),
+						variation.level(),
+						variation.goal(),
+						seed.context() + "。" + variation.instruction()));
+			}
+		}
+		return List.copyOf(topics);
+	}
+
+	private static ScenarioSeed seed(String id, String title, String category, String context) {
+		return new ScenarioSeed(id, title, category, context);
+	}
+
+	private record ScenarioSeed(String id, String title, String category, String context) {}
+
+	private record Variation(
+			String id,
+			String duration,
+			String level,
+			String goal,
+			String instruction) {}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/controller/DailyPickController.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/controller/DailyPickController.java
@@ -1,0 +1,29 @@
+package com.unispeaking.controller;
+
+import com.unispeaking.common.response.ApiResponse;
+import com.unispeaking.domain.dto.scene.DailyPicksResponse;
+import com.unispeaking.service.scene.DailyPickService;
+import java.util.HashSet;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/daily-picks")
+public class DailyPickController {
+
+	private final DailyPickService dailyPickService;
+
+	public DailyPickController(DailyPickService dailyPickService) {
+		this.dailyPickService = dailyPickService;
+	}
+
+	@GetMapping
+	public ApiResponse<DailyPicksResponse> getDailyPicks(
+			@RequestParam(name = "exclude", required = false) List<String> excludedIds) {
+		return ApiResponse.success(dailyPickService.getDailyPicks(
+				excludedIds == null ? new HashSet<>() : new HashSet<>(excludedIds)));
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DailyPickResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DailyPickResponse.java
@@ -1,0 +1,12 @@
+package com.unispeaking.domain.dto.scene;
+
+public record DailyPickResponse(
+		String id,
+		int position,
+		String title,
+		String category,
+		String duration,
+		String level,
+		String goal,
+		String sceneInput) {
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DailyPicksResponse.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/dto/scene/DailyPicksResponse.java
@@ -1,0 +1,16 @@
+package com.unispeaking.domain.dto.scene;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+
+public record DailyPicksResponse(
+		LocalDate date,
+		String timezone,
+		Instant nextRefreshAt,
+		List<DailyPickResponse> picks) {
+
+	public DailyPicksResponse {
+		picks = List.copyOf(picks);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/DailyPickTopic.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/vo/scene/DailyPickTopic.java
@@ -1,0 +1,31 @@
+package com.unispeaking.domain.vo.scene;
+
+import java.util.Objects;
+
+public record DailyPickTopic(
+		String id,
+		String title,
+		String category,
+		String duration,
+		String level,
+		String goal,
+		String sceneInput) {
+
+	public DailyPickTopic {
+		id = requireText(id, "id");
+		title = requireText(title, "title");
+		category = requireText(category, "category");
+		duration = requireText(duration, "duration");
+		level = requireText(level, "level");
+		goal = requireText(goal, "goal");
+		sceneInput = requireText(sceneInput, "sceneInput");
+	}
+
+	private static String requireText(String value, String field) {
+		String normalized = Objects.requireNonNull(value, field + " must not be null").trim();
+		if (normalized.isEmpty()) {
+			throw new IllegalArgumentException(field + " must not be blank");
+		}
+		return normalized;
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/DailyPickService.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/service/scene/DailyPickService.java
@@ -1,0 +1,90 @@
+package com.unispeaking.service.scene;
+
+import com.unispeaking.component.scene.DailyPickCatalog;
+import com.unispeaking.domain.dto.scene.DailyPickResponse;
+import com.unispeaking.domain.dto.scene.DailyPicksResponse;
+import com.unispeaking.domain.vo.scene.DailyPickTopic;
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.random.RandomGenerator;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class DailyPickService {
+
+	static final ZoneId RECOMMENDATION_ZONE = ZoneId.of("Asia/Shanghai");
+	private static final int PICKS_PER_DAY = 3;
+
+	private final DailyPickCatalog catalog;
+	private final Clock clock;
+	private final RandomGenerator random;
+
+	@Autowired
+	public DailyPickService(DailyPickCatalog catalog) {
+		this(catalog, Clock.system(RECOMMENDATION_ZONE), RandomGenerator.getDefault());
+	}
+
+	DailyPickService(DailyPickCatalog catalog, Clock clock) {
+		this(catalog, clock, RandomGenerator.getDefault());
+	}
+
+	DailyPickService(DailyPickCatalog catalog, Clock clock, RandomGenerator random) {
+		this.catalog = catalog;
+		this.clock = clock;
+		this.random = random;
+	}
+
+	public DailyPicksResponse getDailyPicks() {
+		return getDailyPicks(Set.of());
+	}
+
+	public DailyPicksResponse getDailyPicks(Set<String> excludedIds) {
+		LocalDate date = LocalDate.now(clock.withZone(RECOMMENDATION_ZONE));
+		Set<String> exclusions = excludedIds == null ? Set.of() : excludedIds;
+		Map<String, List<DailyPickTopic>> topicsByCategory = catalog.topics().stream()
+				.filter(topic -> !exclusions.contains(topic.id()))
+				.collect(Collectors.groupingBy(DailyPickTopic::category));
+		List<String> categories = new ArrayList<>(topicsByCategory.keySet());
+		shuffle(categories);
+		if (categories.size() < PICKS_PER_DAY) {
+			throw new IllegalStateException("Daily pick catalog must provide at least three categories");
+		}
+		List<DailyPickResponse> picks = new ArrayList<>(PICKS_PER_DAY);
+		for (int index = 0; index < PICKS_PER_DAY; index++) {
+			List<DailyPickTopic> categoryTopics = topicsByCategory.get(categories.get(index));
+			DailyPickTopic topic = categoryTopics.get(random.nextInt(categoryTopics.size()));
+			picks.add(toResponse(topic, index + 1));
+		}
+		return new DailyPicksResponse(
+				date,
+				RECOMMENDATION_ZONE.getId(),
+				date.plusDays(1).atStartOfDay(RECOMMENDATION_ZONE).toInstant(),
+				picks);
+	}
+
+	private <T> void shuffle(List<T> values) {
+		for (int index = values.size() - 1; index > 0; index--) {
+			Collections.swap(values, index, random.nextInt(index + 1));
+		}
+	}
+
+	private DailyPickResponse toResponse(DailyPickTopic topic, int position) {
+		return new DailyPickResponse(
+				topic.id(),
+				position,
+				topic.title(),
+				topic.category(),
+				topic.duration(),
+				topic.level(),
+				topic.goal(),
+				topic.sceneInput());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/DailyPickControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/DailyPickControllerTest.java
@@ -1,0 +1,42 @@
+package com.unispeaking.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.unispeaking.component.scene.DailyPickCatalog;
+import com.unispeaking.service.scene.DailyPickService;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+class DailyPickControllerTest {
+
+	@Test
+	void returnsTheDailyPickContract() throws Exception {
+		var mvc = MockMvcBuilders
+				.standaloneSetup(new DailyPickController(new DailyPickService(new DailyPickCatalog())))
+				.build();
+
+		mvc.perform(get("/api/daily-picks"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.timezone").value("Asia/Shanghai"))
+				.andExpect(jsonPath("$.data.picks.length()").value(3))
+				.andExpect(jsonPath("$.data.picks[0].position").value(1))
+				.andExpect(jsonPath("$.data.picks[0].sceneInput").isNotEmpty());
+	}
+
+	@Test
+	void acceptsCurrentTopicIdsAsExclusions() throws Exception {
+		var mvc = MockMvcBuilders
+				.standaloneSetup(new DailyPickController(new DailyPickService(new DailyPickCatalog())))
+				.build();
+
+		mvc.perform(get("/api/daily-picks")
+					.param("exclude", "coffee-shop-essential")
+					.param("exclude", "hotel-checkin-essential"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true))
+				.andExpect(jsonPath("$.data.picks.length()").value(3));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/DailyPickServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/DailyPickServiceTest.java
@@ -1,0 +1,56 @@
+package com.unispeaking.service.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unispeaking.component.scene.DailyPickCatalog;
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class DailyPickServiceTest {
+
+	private final DailyPickCatalog catalog = new DailyPickCatalog();
+
+	@Test
+	void catalogContainsThreeHundredUniqueTopicsAcrossTenCategories() {
+		assertEquals(300, catalog.topics().size());
+		assertEquals(300, new HashSet<>(catalog.topics().stream().map(topic -> topic.id()).toList()).size());
+		assertEquals(10, new HashSet<>(catalog.topics().stream().map(topic -> topic.category()).toList()).size());
+		assertTrue(catalog.topics().stream().noneMatch(topic -> topic.title().contains("·")));
+		assertTrue(catalog.topics().stream().noneMatch(topic ->
+				topic.title().contains("面试") || topic.sceneInput().contains("面试") || topic.sceneInput().contains("求职")));
+	}
+
+	@Test
+	void returnsThreeRandomTopicsWithDifferentCategories() {
+		Clock clock = Clock.fixed(Instant.parse("2026-08-24T09:30:00Z"), ZoneOffset.UTC);
+		DailyPickService service = new DailyPickService(catalog, clock, new Random(7));
+
+		var response = service.getDailyPicks();
+
+		assertEquals("2026-08-24", response.date().toString());
+		assertEquals("Asia/Shanghai", response.timezone());
+		assertEquals(3, response.picks().size());
+		assertEquals(3, new HashSet<>(response.picks().stream().map(pick -> pick.category()).toList()).size());
+		assertEquals(Instant.parse("2026-08-24T16:00:00Z"), response.nextRefreshAt());
+	}
+
+	@Test
+	void excludesTheCurrentBatchWhenRefreshing() {
+		Clock clock = Clock.fixed(Instant.parse("2026-08-24T09:30:00Z"), ZoneOffset.UTC);
+		DailyPickService service = new DailyPickService(catalog, clock, new Random(11));
+		var first = service.getDailyPicks().picks();
+		Set<String> currentIds = new HashSet<>(first.stream().map(pick -> pick.id()).toList());
+
+		var refreshed = service.getDailyPicks(currentIds).picks();
+
+		assertEquals(3, refreshed.size());
+		assertTrue(refreshed.stream().noneMatch(pick -> currentIds.contains(pick.id())));
+		assertEquals(3, new HashSet<>(refreshed.stream().map(pick -> pick.category()).toList()).size());
+	}
+}

--- a/frontend/mobile/src/data/content.ts
+++ b/frontend/mobile/src/data/content.ts
@@ -1,17 +1,20 @@
 import type { SceneCategory } from './sceneCategories';
 
-export const recommendations = [
-  { id: 'coffee', title: '咖啡店点单', category: 'food', duration: '8–10 分钟', level: '初级', goal: '流利点单，清晰表达需求' },
-  { id: 'hotel', title: '酒店入住', category: 'accommodation', duration: '10–12 分钟', level: '中级', goal: '礼貌沟通，确认入住细节' },
-  { id: 'pharmacy', title: '药店咨询', category: 'health', duration: '8–10 分钟', level: '中级', goal: '描述症状，确认用法与注意事项' },
-] as const satisfies readonly {
+export type DailyRecommendation = {
   id: string;
   title: string;
   category: SceneCategory;
   duration: string;
   level: string;
   goal: string;
-}[];
+  sceneInput: string;
+};
+
+export const recommendations = [
+  { id: 'coffee-order', title: '咖啡店点单', category: 'food', duration: '8–10 分钟', level: '初级', goal: '流利点单，清晰表达需求', sceneInput: '在咖啡店点单，选择杯型、温度和甜度，并确认价格' },
+  { id: 'hotel-check-in', title: '酒店入住', category: 'accommodation', duration: '10–12 分钟', level: '中级', goal: '礼貌沟通，确认入住细节', sceneInput: '在酒店前台办理入住，确认房型、早餐和退房时间' },
+  { id: 'pharmacy-advice', title: '药店咨询', category: 'health', duration: '8–10 分钟', level: '中级', goal: '描述症状，确认用法与注意事项', sceneInput: '在药店描述轻微症状，咨询非处方药的用法和注意事项' },
+] as const satisfies readonly DailyRecommendation[];
 
 export type ScenePromptExample = {
   id: string;

--- a/frontend/mobile/src/features/scenes/DailyPicksApi.ts
+++ b/frontend/mobile/src/features/scenes/DailyPicksApi.ts
@@ -1,0 +1,44 @@
+import { sceneCategories, type SceneCategory } from '@/data/sceneCategories';
+import type { DailyRecommendation } from '@/data/content';
+
+type ApiRequester = {
+  request(path: string, options?: RequestInit): Promise<unknown>;
+};
+
+export type DailyPicks = {
+  date: string;
+  timezone: string;
+  nextRefreshAt: string;
+  picks: (DailyRecommendation & { position: number })[];
+};
+
+function isSceneCategory(value: unknown): value is SceneCategory {
+  return typeof value === 'string' && value in sceneCategories;
+}
+
+function isDailyRecommendation(value: unknown): value is DailyRecommendation & { position: number } {
+  if (!value || typeof value !== 'object') return false;
+  const item = value as Partial<DailyRecommendation & { position: number }>;
+  return Boolean(
+    item.id?.trim() &&
+      item.title?.trim() &&
+      isSceneCategory(item.category) &&
+      item.duration?.trim() &&
+      item.level?.trim() &&
+      item.goal?.trim() &&
+      item.sceneInput?.trim() &&
+      Number.isInteger(item.position),
+  );
+}
+
+export class DailyPicksApi {
+  constructor(private readonly client: ApiRequester) {}
+
+  async getDailyPicks() {
+    const response = await this.client.request('/api/daily-picks') as DailyPicks;
+    if (!response || !Array.isArray(response.picks) || response.picks.length !== 3 || !response.picks.every(isDailyRecommendation)) {
+      throw new Error('每日推荐数据不完整');
+    }
+    return response;
+  }
+}

--- a/frontend/mobile/src/features/scenes/__tests__/DailyPicksApi.test.ts
+++ b/frontend/mobile/src/features/scenes/__tests__/DailyPicksApi.test.ts
@@ -1,0 +1,57 @@
+import { DailyPicksApi } from '../DailyPicksApi';
+
+const validResponse = {
+  date: '2026-08-24',
+  timezone: 'Asia/Shanghai',
+  nextRefreshAt: '2026-08-24T16:00:00Z',
+  picks: [
+    {
+      id: 'coffee-order',
+      position: 1,
+      title: '咖啡店点单',
+      category: 'food',
+      duration: '8–10 分钟',
+      level: '初级',
+      goal: '流利点单，清晰表达需求',
+      sceneInput: '在咖啡店点单并确认细节',
+    },
+    {
+      id: 'hotel-check-in',
+      position: 2,
+      title: '酒店入住',
+      category: 'accommodation',
+      duration: '10–12 分钟',
+      level: '中级',
+      goal: '确认入住细节',
+      sceneInput: '在酒店前台办理入住',
+    },
+    {
+      id: 'pharmacy-advice',
+      position: 3,
+      title: '药店咨询',
+      category: 'health',
+      duration: '8–10 分钟',
+      level: '中级',
+      goal: '描述症状并确认用法',
+      sceneInput: '在药店描述症状并咨询用药',
+    },
+  ],
+} as const;
+
+describe('DailyPicksApi', () => {
+  it('loads the shared daily recommendations from the backend', async () => {
+    const request = jest.fn(async () => validResponse);
+    const api = new DailyPicksApi({ request });
+
+    await expect(api.getDailyPicks()).resolves.toEqual(validResponse);
+    expect(request).toHaveBeenCalledWith('/api/daily-picks');
+  });
+
+  it('rejects an incomplete recommendation batch', async () => {
+    const api = new DailyPicksApi({
+      request: jest.fn(async () => ({ ...validResponse, picks: validResponse.picks.slice(0, 2) })),
+    });
+
+    await expect(api.getDailyPicks()).rejects.toThrow('每日推荐数据不完整');
+  });
+});

--- a/frontend/mobile/src/screens/ScenesScreen.tsx
+++ b/frontend/mobile/src/screens/ScenesScreen.tsx
@@ -22,9 +22,11 @@ import {
   getDailyScenePromptExample,
   learningItems,
   recommendations,
+  type DailyRecommendation,
   type ScenePromptExample,
 } from '@/data/content';
 import { SceneService, type GeneratedScene } from '@/features/scenes/SceneService';
+import { DailyPicksApi } from '@/features/scenes/DailyPicksApi';
 import { SceneTrainingController, type SceneTrainingSnapshot } from '@/features/scenes/SceneTrainingController';
 import { WavRecorder } from '@/features/audio/WavRecorder';
 import { createTurnAudioCapture } from '@/features/audio/TurnAudioCapture';
@@ -914,6 +916,16 @@ function createDefaultSceneService(onUnauthorized?: () => void | Promise<void>) 
   );
 }
 
+function createDefaultDailyPicksApi(onUnauthorized?: () => void | Promise<void>) {
+  return new DailyPicksApi(
+    new ApiClient({
+      baseUrl: getRuntimeConfig().backendUrl,
+      tokenStore: new SecureTokenStore(),
+      onUnauthorized,
+    }),
+  );
+}
+
 function createDefaultTtsPlayer() {
   const tokenStore = new SecureTokenStore();
   return new TtsPlayer({
@@ -998,16 +1010,22 @@ export function ScenesHome({
   onStartScene,
   promptExample = getDailyScenePromptExample(),
   sceneService: injectedSceneService,
+  dailyPicksApi: injectedDailyPicksApi,
 }: {
   onOpen: (route: SceneRoute) => void;
   onStartScene?: () => void;
   promptExample?: ScenePromptExample;
   sceneService?: Pick<SceneService, 'generate'>;
+  dailyPicksApi?: Pick<DailyPicksApi, 'getDailyPicks'>;
 }) {
   const { signOut } = useAppModel();
   const [sceneService] = useState(
     () => injectedSceneService ?? createDefaultSceneService(signOut),
   );
+  const [dailyPicksApi] = useState(
+    () => injectedDailyPicksApi ?? createDefaultDailyPicksApi(signOut),
+  );
+  const [dailyRecommendations, setDailyRecommendations] = useState<readonly DailyRecommendation[]>(recommendations);
   const [prompt, setPrompt] = useState('');
   const [preview, setPreview] = useState<GeneratedScene | null>(null);
   const [previewDisplay, setPreviewDisplay] = useState<Partial<GeneratedScene> | null>(null);
@@ -1016,6 +1034,32 @@ export function ScenesHome({
   const [generationError, setGenerationError] = useState<string | null>(null);
   const generating = generatingSource !== null;
   const promptLocked = generating || Boolean(preview);
+  useEffect(() => {
+    let cancelled = false;
+    let refreshTimer: ReturnType<typeof setTimeout> | undefined;
+    const loadDailyPicks = async () => {
+      try {
+        const response = await dailyPicksApi.getDailyPicks();
+        if (cancelled) return;
+        setDailyRecommendations(response.picks);
+        const nextRefreshAt = Date.parse(response.nextRefreshAt);
+        if (Number.isFinite(nextRefreshAt)) {
+          refreshTimer = setTimeout(
+            () => void loadDailyPicks(),
+            Math.max(1_000, nextRefreshAt - Date.now() + 1_000),
+          );
+        }
+      } catch {
+        // Keep the curated local fallback when the backend is unavailable.
+      }
+    };
+    void loadDailyPicks();
+    return () => {
+      cancelled = true;
+      if (refreshTimer) clearTimeout(refreshTimer);
+    };
+  }, [dailyPicksApi]);
+
   useEffect(() => {
     if (Platform.OS !== 'android' || !preview) return;
 
@@ -1165,13 +1209,13 @@ export function ScenesHome({
           </View>
         </View>
         <View style={styles.recommendationList}>
-          {recommendations.map((item) => (
+          {dailyRecommendations.map((item) => (
             <Pressable
               accessibilityRole="button"
               accessibilityLabel={`生成每日推荐：${item.title}`}
               key={item.id}
               disabled={generating}
-              onPress={() => void generatePreview(`${item.title}：${item.goal}`, item.id)}
+              onPress={() => void generatePreview(item.sceneInput, item.id)}
               style={({ pressed }) => [styles.recommendation, pressed && styles.compactPressed]}
             >
               <View style={styles.recommendationCopy}>

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -460,6 +460,14 @@ svg { display: block; }
 .scene-section-heading--primary { align-items: flex-start; margin-bottom: 22px; }
 .scene-section-heading--primary h2 { margin-top: 7px; font-size: 34px; letter-spacing: -.045em; }
 .scene-section-heading--primary div > p:last-child { max-width: 670px; margin-top: 10px; font-size: 15px; line-height: 1.65; }
+.recommendation-heading__actions { display: flex; align-items: center; gap: 14px; }
+.recommendation-refresh { min-height: 36px; padding: 0 14px; display: inline-flex; align-items: center; gap: 7px; border: 1px solid #d9d9d4; border-radius: 999px; background: #fff; color: #4d4d49; font: inherit; font-size: 12px; font-weight: 700; cursor: pointer; transition: border-color .2s, color .2s, background .2s, transform .2s; }
+.recommendation-refresh:hover:not(:disabled) { border-color: #aaa9a4; color: var(--ink); background: #f8f8f5; transform: translateY(-1px); }
+.recommendation-refresh:disabled { opacity: .55; cursor: not-allowed; }
+.recommendation-refresh svg { width: 15px; height: 15px; }
+.recommendation-refresh svg.is-spinning { animation: recommendation-refresh-spin .8s linear infinite; }
+.recommendation-error { margin: -4px 0 10px; color: #bd4037; font-size: 12px; text-align: right; }
+@keyframes recommendation-refresh-spin { to { transform: rotate(360deg); } }
 .scene-builder { padding: 26px 28px 28px; border: 1px solid #dce3ed; border-radius: 24px; background: linear-gradient(110deg, #f4f8ff 0%, #fbf9ff 100%); box-shadow: 0 8px 28px rgba(91,141,239,.07); transition: transform .28s, border-color .28s, box-shadow .28s; }
 .scene-builder:focus-within { transform: translateY(-2px); border-color: #9fc1f5; box-shadow: 0 18px 46px rgba(91,141,239,.11); }
 .scene-builder .scene-section-heading .eyebrow { color: #5b8def; }
@@ -557,6 +565,7 @@ svg { display: block; }
 @media (max-width: 760px) {
   .page--scenes { padding: 28px 22px; }
   .scene-section-heading, .scene-section-heading--primary { align-items: flex-start; flex-direction: column; gap: 10px; }
+  .recommendation-heading__actions { width: 100%; align-items: flex-start; justify-content: space-between; }
   .scene-builder { padding: 22px; border-radius: 20px; }
   .scene-input textarea { height: 140px; font-size: 17px; }
   .scene-input__footer { padding: 14px; }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import {
   ArrowLeft,
   ArrowRight,
+  ArrowsClockwise,
   BookOpenText,
   Briefcase,
   CalendarBlank,
@@ -66,6 +67,7 @@ import {
   deleteLearningAsset,
   evaluateSentenceReading,
   generateCustomScene,
+  getDailyPicks,
   getAchievementOverview,
   getAccessToken,
   getCurrentUser,
@@ -1463,7 +1465,42 @@ function Scenes({ onStartTraining, onIelts, onInterview, teacher }) {
   const [generationSource, setGenerationSource] = useState(null);
   const [startingTraining, setStartingTraining] = useState(false);
   const [generationError, setGenerationError] = useState("");
+  const [dailyRecommendations, setDailyRecommendations] = useState(recommendations);
+  const [refreshingRecommendations, setRefreshingRecommendations] = useState(false);
+  const [recommendationError, setRecommendationError] = useState("");
+  const dailyPicksRequestRef = useRef(0);
   const examples = ["餐厅点餐并说明忌口", "商场退换一件商品", "问路并确认交通方式", "预约理发并说明需求"];
+
+  const loadDailyPicks = async (excludedIds = [], showFeedback = false) => {
+    const requestId = dailyPicksRequestRef.current + 1;
+    dailyPicksRequestRef.current = requestId;
+    if (showFeedback) {
+      setRefreshingRecommendations(true);
+      setRecommendationError("");
+    }
+    try {
+      const response = await getDailyPicks(excludedIds);
+      if (dailyPicksRequestRef.current !== requestId || !Array.isArray(response?.picks) || response.picks.length !== 3) return;
+      setDailyRecommendations(response.picks.map((item, index) => ({
+        ...item,
+        number: String(item.position || index + 1).padStart(2, "0"),
+      })));
+    } catch {
+      if (showFeedback && dailyPicksRequestRef.current === requestId) {
+        setRecommendationError("暂时无法更换，请稍后再试。");
+      }
+      // Keep the current recommendations when the backend is unavailable.
+    } finally {
+      if (showFeedback && dailyPicksRequestRef.current === requestId) setRefreshingRecommendations(false);
+    }
+  };
+
+  useEffect(() => {
+    void loadDailyPicks();
+    return () => {
+      dailyPicksRequestRef.current += 1;
+    };
+  }, []);
   const syncPrompt = (event) => {
     setPrompt(event.currentTarget.value.slice(0, 200));
   };
@@ -1545,22 +1582,36 @@ function Scenes({ onStartTraining, onIelts, onInterview, teacher }) {
         </section>
 
         <section className="recommendations scene-module">
-          <div className="scene-section-heading"><div><p className="eyebrow">DAILY PICKS</p><h2>每日推荐</h2></div><p>选择一个常用场景，直接开始今天的练习。</p></div>
+          <div className="scene-section-heading recommendation-heading">
+            <div><p className="eyebrow">DAILY PICKS</p><h2>每日推荐</h2></div>
+            <div className="recommendation-heading__actions">
+              <button
+                type="button"
+                className="recommendation-refresh"
+                disabled={refreshingRecommendations || generating}
+                onClick={() => void loadDailyPicks(dailyRecommendations.map((item) => item.id), true)}
+              >
+                <ArrowsClockwise className={refreshingRecommendations ? "is-spinning" : ""} />
+                <span>{refreshingRecommendations ? "更换中" : "换一批"}</span>
+              </button>
+            </div>
+          </div>
+          {recommendationError && <p className="recommendation-error" role="alert">{recommendationError}</p>}
           <div className="recommendation-list">
-            {recommendations.map((item) => {
+            {dailyRecommendations.map((item) => {
               const loading = generationSource === `recommendation:${item.id}`;
               const category = sceneCategories[item.category] || sceneCategories.other;
               return (
                 <article key={item.id} style={{ "--scene-category-bg": category.subtleBackgroundColor, "--scene-category-accent": category.subtleTextColor || category.textColor }}>
                   <span className="recommendation__number">{item.number}</span>
                   <span className="recommendation__title"><SceneCategoryTag category={item.category} subtle /><strong>{item.title}</strong></span>
-                  <small>{item.duration}<i>·</i>{item.level}</small>
+                  <small>{item.duration}</small>
                   <p>{item.goal}</p>
                   <button
                     type="button"
                     className={cx("scene-card-cta", loading && "is-generating")}
                     disabled={generating}
-                    onClick={() => void generate(item.title, item.id)}
+                    onClick={() => void generate(item.sceneInput || item.title, item.id)}
                     aria-label={loading ? `正在生成 ${item.title} 场景` : `开始练习 ${item.title} 场景`}
                   >
                     {loading

--- a/frontend/web/src/domain/content/data.js
+++ b/frontend/web/src/domain/content/data.js
@@ -88,9 +88,9 @@ export const sceneCategories = {
 };
 
 export const recommendations = [
-  { id: "coffee", number: "01", title: "咖啡店点单", category: "food", duration: "8–10 分钟", level: "初级", goal: "流利点单，清晰表达需求" },
-  { id: "hotel", number: "02", title: "酒店入住", category: "accommodation", duration: "10–12 分钟", level: "中级", goal: "礼貌沟通，确认入住细节" },
-  { id: "pharmacy", number: "03", title: "药店咨询", category: "health", duration: "8–10 分钟", level: "中级", goal: "描述症状，确认用法与注意事项" },
+  { id: "coffee-order", number: "01", title: "咖啡店点单", category: "food", duration: "8–10 分钟", level: "初级", goal: "流利点单，清晰表达需求", sceneInput: "在咖啡店点单，选择杯型、温度和甜度，并确认价格" },
+  { id: "hotel-check-in", number: "02", title: "酒店入住", category: "accommodation", duration: "10–12 分钟", level: "中级", goal: "礼貌沟通，确认入住细节", sceneInput: "在酒店前台办理入住，确认房型、早餐和退房时间" },
+  { id: "pharmacy-advice", number: "03", title: "药店咨询", category: "health", duration: "8–10 分钟", level: "中级", goal: "描述症状，确认用法与注意事项", sceneInput: "在药店描述轻微症状，咨询非处方药的用法和注意事项" },
 ];
 
 export const learningItems = [

--- a/frontend/web/src/infrastructure/http/apiClient.js
+++ b/frontend/web/src/infrastructure/http/apiClient.js
@@ -283,6 +283,13 @@ export function getUserPreference() {
   return request("/api/user-preferences");
 }
 
+export function getDailyPicks(excludedIds = []) {
+	const params = new URLSearchParams();
+	excludedIds.forEach((id) => params.append("exclude", id));
+	const query = params.toString();
+	return request(`/api/daily-picks${query ? `?${query}` : ""}`);
+}
+
 export function updateUserPreference(preference) {
 	return request("/api/user-preferences", {
 		method: "PUT",


### PR DESCRIPTION
## Summary

- add a backend catalog of 300 curated daily-practice topics across ten scene categories
- return three randomized recommendations from distinct categories and support excluding the current batch
- add a Web “换一批” action with loading and failure states, while hiding difficulty labels from recommendation cards
- connect Web and mobile scene entry points to the shared daily-picks API with local fallbacks
- exclude interview and job-seeking topics from the daily recommendation catalog
- add backend and mobile contract coverage for recommendation loading and refresh behavior

## Verification

- backend DailyPickServiceTest and DailyPickControllerTest: 5 tests passed
- Web production build passed
- mobile DailyPicksApi test suite: 2 tests passed