### PR TITLE
test: improve backend test coverage for issue #148

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -268,7 +268,7 @@ jobs:
           retention-days: 1
 
   coverage:
-    name: 合并覆盖率并检查 70% 门槛
+    name: 合并覆盖率并检查 85% 门槛
     needs:
       - changes
       - backend

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 [![后端测试](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml)
 [![后端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
 
+后端 Codecov 使用独立的 `backend` flag，统计 JaCoCo 合并的单元测试与 PostgreSQL/Redis 集成测试覆盖率；README 徽章显示的是 main 分支最新报告，目标为保持在 90% 以上。
+
 UniSpeaking 是一个面向英语口语训练的 AI 实时陪练系统。仓库包含 Spring Boot 后端、
 React Web 客户端、React Native 移动端、PostgreSQL 数据模型以及 Docker/Nginx 部署配置。
 

--- a/backend/unispeaking-server/pom.xml
+++ b/backend/unispeaking-server/pom.xml
@@ -387,9 +387,9 @@
 											<element>BUNDLE</element>
 											<limits>
 												<limit>
-													<counter>LINE</counter>
-													<value>COVEREDRATIO</value>
-													<minimum>0.70</minimum>
+														<counter>LINE</counter>
+														<value>COVEREDRATIO</value>
+														<minimum>0.85</minimum>
 												</limit>
 											</limits>
 										</rule>

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/provider/AiProviderAdminServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/provider/AiProviderAdminServiceTest.java
@@ -1,21 +1,30 @@
 package com.unispeaking.admin.provider;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.vo.provider.AiCapability;
 import com.unispeaking.domain.vo.provider.AiModelDefinition;
 import com.unispeaking.provider.AiProviderRegistry;
 import com.unispeaking.provider.config.AiProviderCredentialStore;
 import com.unispeaking.provider.config.JdbcAiConfigurationStore;
+import java.math.BigDecimal;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import org.h2.jdbcx.JdbcDataSource;
 import org.junit.jupiter.api.Test;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 
 class AiProviderAdminServiceTest {
+
+	private static final AiProviderCredentialStore.CredentialStatus CREDENTIAL_STATUS =
+			new AiProviderCredentialStore.CredentialStatus(true, "fingerprint", true, List.of());
 
 	@Test
 	void updatesProviderAndModelEnabledStatesImmediately() {
@@ -38,6 +47,118 @@ class AiProviderAdminServiceTest {
 		assertThat(service.configuration().models().stream()
 				.filter(value -> value.modelId().equals("primary"))
 				.findFirst().orElseThrow().enabled()).isFalse();
+	}
+
+	@Test
+	void exposesSortedConfigurationAndRoutesForEveryCapability() {
+		JdbcTemplate jdbc = database();
+		jdbc.update("insert into ai_providers values "
+				+ "('another', 'Another', 'another-adapter', 'https://another.example', false, 2000, 3000, 4, null, null, current_timestamp)");
+		jdbc.update("insert into ai_models values "
+				+ "('scoring-model', 'another', 'Scoring', 'SCORING', true, null, 'REQUESTS', 0, 0, 0, 0, 0, 0, 'USD', current_timestamp)");
+		AiProviderAdminService service = service(jdbc, mock(AiProviderRegistry.class), mock(AiProviderCredentialStore.class));
+
+		var configuration = service.configuration();
+
+		assertThat(configuration.databaseBacked()).isTrue();
+		assertThat(configuration.providers()).extracting(AiProviderAdminService.ProviderView::providerId)
+				.containsExactly("another", "vendor");
+		assertThat(configuration.models()).extracting(AiProviderAdminService.ModelView::modelId)
+				.containsExactly("fallback", "primary", "scoring-model");
+		assertThat(configuration.models()).filteredOn(model -> model.modelId().equals("scoring-model"))
+				.singleElement().satisfies(model -> {
+					assertThat(model.providerId()).isEqualTo("another");
+					assertThat(model.capability()).isEqualTo(AiCapability.SCORING);
+					assertThat(model.billingUnit()).isEqualTo("REQUESTS");
+					assertThat(model.currency()).isEqualTo("USD");
+				});
+		assertThat(configuration.routes()).extracting(AiProviderAdminService.RouteView::capability)
+				.containsExactly(AiCapability.REALTIME, AiCapability.LLM, AiCapability.SCORING,
+						AiCapability.TTS, AiCapability.TRANSCRIPTION);
+		assertThat(configuration.routes()).allSatisfy(route -> {
+			assertThat(route.routeKey()).isEqualTo("default");
+			assertThat(route.modelIds()).isNotNull();
+		});
+	}
+
+	@Test
+	void delegatesCredentialStatusAndReplacementOnlyAfterProviderExists() {
+		JdbcTemplate jdbc = database();
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		AiProviderCredentialStore credentials = mock(AiProviderCredentialStore.class);
+		when(credentials.status("vendor")).thenReturn(CREDENTIAL_STATUS);
+		when(credentials.replace("vendor", Map.of("apiKey", "new-key"))).thenReturn(CREDENTIAL_STATUS);
+		AiProviderAdminService service = service(jdbc, registry, credentials);
+
+		assertThat(service.credentialStatus("vendor")).isSameAs(CREDENTIAL_STATUS);
+		assertThat(service.replaceCredential("vendor", Map.of("apiKey", "new-key")))
+				.isSameAs(CREDENTIAL_STATUS);
+
+		verify(credentials).status("vendor");
+		verify(credentials).replace("vendor", Map.of("apiKey", "new-key"));
+		assertThatThrownBy(() -> service.credentialStatus("missing"))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_PROVIDER_NOT_FOUND");
+		assertThatThrownBy(() -> service.replaceCredential("missing", Map.of("apiKey", "new-key")))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_PROVIDER_NOT_FOUND");
+	}
+
+	@Test
+	void appliesProviderAndModelRequestDefaultsAndTrimsValues() {
+		JdbcTemplate jdbc = database();
+		AiProviderAdminService service = service(jdbc, mock(AiProviderRegistry.class), mock(AiProviderCredentialStore.class));
+
+		var provider = service.updateProvider("vendor",
+				new AiProviderAdminService.UpdateProviderRequest("  Renamed vendor  ", true));
+		var model = service.updateModel("primary",
+				new AiProviderAdminService.UpdateModelRequest(
+						"  Renamed model  ", null, " mixed ",
+						new BigDecimal("1.25"), null, null, null, null, new BigDecimal("0.5")));
+
+		assertThat(provider.displayName()).isEqualTo("Renamed vendor");
+		assertThat(provider.enabled()).isTrue();
+		assertThat(provider.configVersion()).isEqualTo(2);
+		assertThat(model.displayName()).isEqualTo("Renamed model");
+		assertThat(model.enabled()).isTrue();
+		assertThat(model.billingUnit()).isEqualTo("MIXED");
+		assertThat(model.inputPricePerMillion()).isEqualByComparingTo("1.25");
+		assertThat(model.outputPricePerMillion()).isZero();
+		assertThat(model.requestPricePerCall()).isEqualByComparingTo("0.5");
+
+		var retained = service.updateProvider("vendor",
+				new AiProviderAdminService.UpdateProviderRequest("   ", null));
+		var retainedModel = service.updateModel("primary",
+				new AiProviderAdminService.UpdateModelRequest(
+						" ", null, " ", null, null, null, null, null, null));
+		assertThat(retained.displayName()).isEqualTo("Renamed vendor");
+		assertThat(retained.enabled()).isTrue();
+		assertThat(retainedModel.displayName()).isEqualTo("Renamed model");
+		assertThat(retainedModel.billingUnit()).isEqualTo("MIXED");
+	}
+
+	@Test
+	void rejectsMissingProviderAndModel() {
+		AiProviderAdminService service = service(database(), mock(AiProviderRegistry.class), mock(AiProviderCredentialStore.class));
+
+		assertCode("AI_PROVIDER_NOT_FOUND", () -> service.updateProvider(
+				"missing", new AiProviderAdminService.UpdateProviderRequest(null, true)));
+		assertCode("AI_MODEL_NOT_FOUND", () -> service.updateModel(
+				"missing", new AiProviderAdminService.UpdateModelRequest(null, true, null, null, null, null, null, null, null)));
+	}
+
+	@Test
+	void rejectsInvalidBillingUnitsAndNegativePrices() {
+		AiProviderAdminService service = service(database(), mock(AiProviderRegistry.class), mock(AiProviderCredentialStore.class));
+
+		assertCode("AI_BILLING_UNIT_INVALID", () -> service.updateModel("primary",
+				new AiProviderAdminService.UpdateModelRequest(null, null, "unsupported", null, null, null, null, null, null)));
+		assertCode("AI_MODEL_PRICE_INVALID", () -> service.updateModel("primary",
+				new AiProviderAdminService.UpdateModelRequest(null, null, null, new BigDecimal("-0.01"), null, null, null, null, null)));
+		assertCode("AI_MODEL_PRICE_INVALID", () -> service.updateModel("primary",
+				new AiProviderAdminService.UpdateModelRequest(null, null, null, null, null, null, null, null, new BigDecimal("-1"))));
 	}
 
 	@Test
@@ -66,6 +187,78 @@ class AiProviderAdminServiceTest {
 				.filter(route -> route.capability() == AiCapability.LLM)
 				.findFirst().orElseThrow().modelIds())
 				.containsExactly("fallback", "primary");
+	}
+
+	@Test
+	void usesDefaultRouteKeyWhenOmittedAndTrimsModelIds() {
+		JdbcTemplate jdbc = database();
+		AiProviderRegistry registry = registryWithModels(
+				new AiModelDefinition("primary", "vendor", AiCapability.LLM, true),
+				new AiModelDefinition("fallback", "vendor", AiCapability.LLM, false));
+		AiProviderAdminService service = service(jdbc, registry, mock(AiProviderCredentialStore.class));
+
+		var route = service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest(null, List.of(" primary ", "fallback")));
+
+		assertThat(route.routeKey()).isEqualTo("default");
+		assertThat(route.modelIds()).containsExactly("primary", "fallback");
+		assertThat(jdbc.queryForList(
+				"select model_id from ai_models where route_priority is not null order by route_priority",
+				String.class)).containsExactly("primary", "fallback");
+	}
+
+	@Test
+	void rejectsInvalidRouteKeyEmptyDuplicateAndBlankModelLists() {
+		AiProviderAdminService service = service(database(), registryWithModels(
+				new AiModelDefinition("primary", "vendor", AiCapability.LLM, true)),
+				mock(AiProviderCredentialStore.class));
+
+		assertCode("AI_ROUTE_KEY_UNSUPPORTED", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("secondary", List.of("primary"))));
+		assertCode("AI_ROUTE_INVALID", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", null)));
+		assertCode("AI_ROUTE_INVALID", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", List.of(" "))));
+		assertCode("AI_ROUTE_INVALID", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", List.of("primary", " primary "))));
+	}
+
+	@Test
+	void rejectsUnavailableCapabilityMismatchedAndDisabledRouteModels() {
+		JdbcTemplate jdbc = database();
+		jdbc.update("insert into ai_models values "
+				+ "('disabled', 'vendor', 'Disabled', 'LLM', false, null, 'TOKENS', 0, 0, 0, 0, 0, 0, 'CNY', current_timestamp),"
+				+ "('scoring-model', 'vendor', 'Scoring', 'SCORING', true, null, 'REQUESTS', 0, 0, 0, 0, 0, 0, 'CNY', current_timestamp)");
+		AiProviderAdminService service = service(jdbc, registryWithModels(
+				new AiModelDefinition("primary", "vendor", AiCapability.LLM, true),
+				new AiModelDefinition("disabled", "vendor", AiCapability.LLM, false),
+				new AiModelDefinition("scoring-model", "vendor", AiCapability.SCORING, true)),
+				mock(AiProviderCredentialStore.class));
+
+		assertCode("AI_ROUTE_MODEL_UNAVAILABLE", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", List.of("unknown"))));
+		assertCode("AI_ROUTE_MODEL_UNAVAILABLE", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", List.of("scoring-model"))));
+		assertCode("AI_ROUTE_MODEL_DISABLED", () -> service.replaceRoute(AiCapability.LLM,
+				new AiProviderAdminService.UpdateRouteRequest("default", List.of("disabled"))));
+	}
+
+	private static AiProviderAdminService service(
+			JdbcTemplate jdbc, AiProviderRegistry registry, AiProviderCredentialStore credentials) {
+		return new AiProviderAdminService(jdbc, new JdbcAiConfigurationStore(jdbc), registry, credentials);
+	}
+
+	private static AiProviderRegistry registryWithModels(AiModelDefinition... models) {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.deployedModels()).thenReturn(List.of(models));
+		return registry;
+	}
+
+	private static void assertCode(String code, ThrowingCallable executable) {
+		assertThatThrownBy(executable)
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo(code);
 	}
 
 	private static JdbcTemplate database() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/quality/QualityIssueAdminServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/quality/QualityIssueAdminServiceTest.java
@@ -1,0 +1,212 @@
+package com.unispeaking.admin.quality;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.times;
+
+import com.unispeaking.admin.quality.QualityIssueAdminService.IssuePlatform;
+import com.unispeaking.admin.quality.QualityIssueAdminService.IssueSeverity;
+import com.unispeaking.admin.quality.QualityIssueAdminService.IssueStatus;
+import com.unispeaking.admin.quality.QualityIssueAdminService.IssueType;
+import com.unispeaking.admin.quality.QualityIssueAdminService.QualityIssueNotFoundException;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class QualityIssueAdminServiceTest {
+
+	private final JdbcTemplate jdbc = mock(JdbcTemplate.class);
+	private final QualityIssueAdminService service = new QualityIssueAdminService(jdbc);
+
+	@Test
+	void listClampsLimitAndAddsRequestedFilters() {
+		when(jdbc.query(anyString(), any(RowMapper.class), any(Object[].class))).thenReturn(List.of());
+
+		var response = service.list(IssueStatus.OPEN, IssuePlatform.BACKEND, IssueType.BUG, 999);
+
+		assertEquals(List.of(), response.issues());
+		ArgumentCaptor<Object[]> arguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).query(anyString(), any(RowMapper.class), arguments.capture());
+		assertEquals(List.of("OPEN", "BACKEND", "BUG", 200), List.of(arguments.getValue()));
+	}
+
+	@Test
+	void eventsClampsLimitAndMapsNullableColumns() throws Exception {
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.query(anyString(), any(RowMapper.class), eq(issueId), anyInt())).thenAnswer(invocation -> {
+			@SuppressWarnings("unchecked") RowMapper<QualityIssueAdminService.QualityEventView> mapper = invocation.getArgument(1);
+			return List.of(mapper.mapRow(eventResult(issueId), 0));
+		});
+
+		var response = service.events(issueId, 0);
+
+		assertNull(response.events().getFirst().userId());
+		assertNull(response.events().getFirst().httpStatus());
+		assertNull(response.events().getFirst().durationMs());
+		verify(jdbc).query(anyString(), any(RowMapper.class), eq(issueId), eq(1));
+	}
+
+	@Test
+	void summaryMapsAggregateColumns() throws Exception {
+		when(jdbc.queryForObject(anyString(), any(RowMapper.class))).thenAnswer(invocation -> {
+			@SuppressWarnings("unchecked") RowMapper<QualityIssueAdminService.QualitySummary> mapper = invocation.getArgument(1);
+			ResultSet result = mock(ResultSet.class);
+			when(result.getLong("active_issues")).thenReturn(2L);
+			when(result.getLong("critical_issues")).thenReturn(1L);
+			when(result.getLong("optimizations")).thenReturn(3L);
+			when(result.getLong("events_7d")).thenReturn(4L);
+			when(result.getLong("affected_users_7d")).thenReturn(5L);
+			when(result.getLong("resolved_7d")).thenReturn(6L);
+			return mapper.mapRow(result, 0);
+		});
+
+		var summary = service.summary();
+
+		assertEquals(2, summary.activeIssues());
+		assertEquals(6, summary.resolved7d());
+	}
+
+	@Test
+	void createWritesIssueAndHistoryThenReturnsPersistedResult() {
+		UUID actor = UUID.randomUUID();
+		when(jdbc.query(anyString(), any(RowMapper.class), any(UUID.class))).thenAnswer(invocation ->
+				List.of(issue(invocation.getArgument(2))));
+
+		var result = service.create(new QualityIssueAdminService.CreateIssueRequest(
+				IssueType.BUG, IssuePlatform.WEB, IssueSeverity.HIGH, IssueStatus.OPEN,
+				"  Broken form  ", " details ", " owner "), actor, "admin");
+
+		assertEquals("Broken form", result.title());
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void updateAndGetRejectUnknownIssues() {
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.query(anyString(), any(RowMapper.class), eq(issueId))).thenReturn(List.of());
+
+		assertThrows(QualityIssueNotFoundException.class, () -> service.get(issueId));
+		assertThrows(QualityIssueNotFoundException.class, () -> service.update(issueId,
+				new QualityIssueAdminService.UpdateIssueRequest(null, null, null, null, null, null, null, null, null),
+				UUID.randomUUID(), "admin"));
+	}
+
+	@Test
+	void listWithoutFiltersClampsNegativeLimitAndPreservesQueryArguments() {
+		when(jdbc.query(anyString(), any(RowMapper.class), any(Object[].class))).thenReturn(List.of());
+
+		assertEquals(List.of(), service.list(null, null, null, -10).issues());
+		ArgumentCaptor<Object[]> arguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).query(anyString(), any(RowMapper.class), arguments.capture());
+		assertEquals(List.of(1), List.of(arguments.getValue()));
+	}
+
+	@Test
+	void getMapsEveryIssueColumnAndNullableTimestamps() throws Exception {
+		UUID issueId = UUID.randomUUID();
+		Instant now = Instant.parse("2026-08-21T00:00:00Z");
+		when(jdbc.query(anyString(), any(RowMapper.class), eq(issueId))).thenAnswer(invocation -> {
+			@SuppressWarnings("unchecked") RowMapper<QualityIssueAdminService.QualityIssueView> mapper = invocation.getArgument(1);
+			ResultSet result = mock(ResultSet.class);
+			when(result.getObject("issue_id", UUID.class)).thenReturn(issueId);
+			when(result.getString("fingerprint")).thenReturn("fp");
+			when(result.getString("issue_type")).thenReturn("OPTIMIZATION");
+			when(result.getString("source")).thenReturn("TELEMETRY");
+			when(result.getString("platform")).thenReturn("CROSS_PLATFORM");
+			when(result.getString("severity")).thenReturn("CRITICAL");
+			when(result.getString("status")).thenReturn("VERIFIED");
+			when(result.getString("title")).thenReturn("title");
+			when(result.getString("description")).thenReturn("description");
+			when(result.getString("error_code")).thenReturn("E");
+			when(result.getString("api_path")).thenReturn("/api");
+			when(result.getObject("http_status")).thenReturn(500);
+			when(result.getString("release")).thenReturn("1.0");
+			when(result.getString("assignee")).thenReturn("admin");
+			when(result.getString("resolution")).thenReturn("fixed");
+			when(result.getLong("occurrence_count")).thenReturn(4L);
+			when(result.getLong("affected_users")).thenReturn(3L);
+			when(result.getTimestamp("first_seen_at")).thenReturn(Timestamp.from(now));
+			when(result.getTimestamp("last_seen_at")).thenReturn(Timestamp.from(now.plusSeconds(1)));
+			when(result.getTimestamp("resolved_at")).thenReturn(null);
+			when(result.getString("created_by")).thenReturn("creator");
+			when(result.getString("updated_by")).thenReturn("updater");
+			when(result.getTimestamp("created_at")).thenReturn(Timestamp.from(now));
+			when(result.getTimestamp("updated_at")).thenReturn(Timestamp.from(now.plusSeconds(2)));
+			return List.of(mapper.mapRow(result, 0));
+		});
+
+		var issue = service.get(issueId);
+
+		assertEquals(IssueType.OPTIMIZATION, issue.issueType());
+		assertEquals(IssuePlatform.CROSS_PLATFORM, issue.platform());
+		assertEquals(IssueSeverity.CRITICAL, issue.severity());
+		assertEquals(IssueStatus.VERIFIED, issue.status());
+		assertEquals(3, issue.affectedUsers());
+		assertEquals(now.plusSeconds(2), issue.updatedAt());
+		assertNull(issue.resolvedAt());
+	}
+
+	@Test
+	void updateWritesTrimmedOptionalValuesAndHistoryThenReturnsNextRecord() {
+		UUID issueId = UUID.randomUUID();
+		var before = issue(issueId);
+		var after = new QualityIssueAdminService.QualityIssueView(issueId, "fingerprint", IssueType.BUG,
+				"MANUAL", IssuePlatform.BACKEND, IssueSeverity.CRITICAL, IssueStatus.RESOLVED, "new title",
+				"new description", "ERR", "/api", 500, "2.0", "owner", "fixed", 2, 1, null, null, null,
+				"admin", "admin", Instant.now(), Instant.now());
+		when(jdbc.query(anyString(), any(RowMapper.class), eq(issueId))).thenReturn(List.of(before), List.of(after));
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1);
+
+		var result = service.update(issueId,
+				new QualityIssueAdminService.UpdateIssueRequest(IssueType.BUG, IssuePlatform.BACKEND,
+						IssueSeverity.CRITICAL, IssueStatus.RESOLVED, "  new title ", " details ", " owner ",
+						" fixed ", " note "), UUID.randomUUID(), "admin");
+
+		assertEquals("new title", result.title());
+		assertEquals(2, result.occurrenceCount());
+		verify(jdbc, times(2)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void updateThrowsWhenTheDatabaseDoesNotUpdateTheIssue() {
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.query(anyString(), any(RowMapper.class), eq(issueId))).thenReturn(List.of(issue(issueId)));
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(0);
+
+		assertThrows(QualityIssueNotFoundException.class, () -> service.update(issueId,
+				new QualityIssueAdminService.UpdateIssueRequest(null, null, null, null, null, null, null, null, null),
+				UUID.randomUUID(), "admin"));
+	}
+
+	private QualityIssueAdminService.QualityIssueView issue(UUID issueId) {
+		Instant now = Instant.parse("2026-01-01T00:00:00Z");
+		return new QualityIssueAdminService.QualityIssueView(issueId, "fingerprint", IssueType.BUG,
+				"MANUAL", IssuePlatform.WEB, IssueSeverity.HIGH, IssueStatus.OPEN, "Broken form",
+				"details", null, null, null, null, null, null, 0, 0, null, null, null,
+				"admin", "admin", now, now);
+	}
+
+	private ResultSet eventResult(UUID issueId) throws Exception {
+		ResultSet result = mock(ResultSet.class);
+		when(result.getString("event_id")).thenReturn("event");
+		when(result.getObject("issue_id", UUID.class)).thenReturn(issueId);
+		when(result.getObject("user_id")).thenReturn(null);
+		when(result.getString("platform")).thenReturn("WEB");
+		when(result.getTimestamp("occurred_at")).thenReturn(Timestamp.from(Instant.parse("2026-01-01T00:00:00Z")));
+		return result;
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/quality/QualityIssueTelemetrySinkTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/quality/QualityIssueTelemetrySinkTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.admin.quality;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -12,9 +13,13 @@ import static org.mockito.Mockito.when;
 import com.unispeaking.telemetry.ClientTelemetryRecord;
 import java.time.Instant;
 import java.util.Map;
+import java.util.LinkedHashMap;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.core.context.SecurityContextHolder;
 import tools.jackson.databind.ObjectMapper;
 
 class QualityIssueTelemetrySinkTest {
@@ -57,5 +62,159 @@ class QualityIssueTelemetrySinkTest {
 
 		verify(jdbc).queryForObject(anyString(), eq(UUID.class), any(Object[].class));
 		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void ignoresNonActionableAndUnauthenticatedOutcomesWithoutDatabaseWrites() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+
+		sink.write(new ClientTelemetryRecord(Map.of("level", "info", "outcome", "success")));
+		sink.write(new ClientTelemetryRecord(Map.of("level", "fatal", "outcome", "unauthenticated")));
+
+		verify(jdbc, never()).queryForObject(anyString(), eq(UUID.class), any(Object[].class));
+		verify(jdbc, never()).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void normalizesActionableFieldsAndDoesNotIncrementForDuplicateEvent() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.queryForObject(anyString(), eq(UUID.class), any(Object[].class))).thenReturn(issueId);
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(0);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+		Map<String, Object> fields = new LinkedHashMap<>();
+		fields.put("event_id", "event-1");
+		fields.put("platform", "desktop");
+		fields.put("level", "fatal");
+		fields.put("event_type", " ");
+		fields.put("http_status", "not-a-number");
+		fields.put("outcome", "network_error");
+		fields.put("message", "  Offline  ");
+
+		sink.write(new ClientTelemetryRecord(fields));
+
+		ArgumentCaptor<Object[]> issueArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).queryForObject(anyString(), eq(UUID.class), issueArguments.capture());
+		assertEquals("BACKEND", issueArguments.getValue()[1]);
+		assertEquals("CRITICAL", issueArguments.getValue()[2]);
+		assertEquals("Offline", issueArguments.getValue()[3]);
+		assertEquals("Offline", issueArguments.getValue()[4]);
+		ArgumentCaptor<Object[]> eventArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).update(anyString(), eventArguments.capture());
+		assertEquals("BACKEND", eventArguments.getValue()[5]);
+		assertEquals("client.error", eventArguments.getValue()[6]);
+		assertEquals("FATAL", eventArguments.getValue()[7]);
+	}
+
+	@Test
+	void captureBackendProducesAnActionableBackendRecordWithoutAuthentication() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.queryForObject(anyString(), eq(UUID.class), any(Object[].class))).thenReturn(issueId);
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+		SecurityContextHolder.clearContext();
+
+		try {
+			sink.captureBackend(new IllegalStateException("broken"), "/api/practice", "POST", 503, "UPSTREAM");
+		}
+		finally {
+			SecurityContextHolder.clearContext();
+		}
+
+		ArgumentCaptor<Object[]> issueArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).queryForObject(anyString(), eq(UUID.class), issueArguments.capture());
+		assertEquals("BACKEND", issueArguments.getValue()[1]);
+		assertEquals("HIGH", issueArguments.getValue()[2]);
+		assertEquals("503 · /api/practice", issueArguments.getValue()[3]);
+		assertEquals("broken", issueArguments.getValue()[4]);
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void captureBackendIncludesAValidAuthenticatedUserIdAndNormalizesInvalidOptionalValues() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		UUID issueId = UUID.randomUUID();
+		UUID userId = UUID.randomUUID();
+		when(jdbc.queryForObject(anyString(), eq(UUID.class), any(Object[].class))).thenReturn(issueId);
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+		Jwt jwt = Jwt.withTokenValue("token").subject(userId.toString()).header("alg", "none").build();
+		var authentication = new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(jwt, null);
+		SecurityContextHolder.getContext().setAuthentication(authentication);
+
+		try {
+			sink.captureBackend(new RuntimeException((String) null), " /api/error ", "GET", 500, null);
+		}
+		finally {
+			SecurityContextHolder.clearContext();
+		}
+
+		ArgumentCaptor<Object[]> eventArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), eventArguments.capture());
+		assertEquals(userId, eventArguments.getAllValues().getFirst()[2]);
+		assertEquals("/api/error", eventArguments.getAllValues().getFirst()[9]);
+		assertEquals("/api/error", eventArguments.getAllValues().getFirst()[12]);
+		assertEquals("GET", eventArguments.getAllValues().getFirst()[13]);
+		assertEquals(500, eventArguments.getAllValues().getFirst()[14]);
+	}
+
+	@Test
+	void handlesMalformedDatesIdsNumbersAndTruncatesLongTitles() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.queryForObject(anyString(), eq(UUID.class), any(Object[].class))).thenReturn(issueId);
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+		Map<String, Object> fields = new LinkedHashMap<>();
+		fields.put("event_id", "event-malformed");
+		fields.put("platform", "cross-platform");
+		fields.put("event_type", "client.crash");
+		fields.put("level", "unexpected-level");
+		fields.put("outcome", "error");
+		fields.put("occurred_at", "not-an-instant");
+		fields.put("user_id", "not-a-uuid");
+		fields.put("http_status", "not-a-number");
+		fields.put("duration_ms", "not-a-number");
+		fields.put("message", "x".repeat(300));
+
+		sink.write(new ClientTelemetryRecord(fields));
+
+		ArgumentCaptor<Object[]> issueArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc).queryForObject(anyString(), eq(UUID.class), issueArguments.capture());
+		assertEquals("BACKEND", issueArguments.getValue()[1]);
+		assertEquals("MEDIUM", issueArguments.getValue()[2]);
+		assertEquals(200, ((String) issueArguments.getValue()[3]).length());
+		assertEquals(300, ((String) issueArguments.getValue()[4]).length());
+		ArgumentCaptor<Object[]> eventArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), eventArguments.capture());
+		assertEquals(null, eventArguments.getAllValues().getFirst()[2]);
+		assertEquals("ERROR", eventArguments.getAllValues().getFirst()[7]);
+		assertEquals(null, eventArguments.getAllValues().getFirst()[14]);
+		assertEquals(null, eventArguments.getAllValues().getFirst()[22]);
+	}
+
+	@Test
+	void captureBackendIgnoresInvalidJwtSubjectWithoutFailingTelemetry() {
+		JdbcTemplate jdbc = mock(JdbcTemplate.class);
+		UUID issueId = UUID.randomUUID();
+		when(jdbc.queryForObject(anyString(), eq(UUID.class), any(Object[].class))).thenReturn(issueId);
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1);
+		QualityIssueTelemetrySink sink = new QualityIssueTelemetrySink(jdbc, new ObjectMapper());
+		Jwt jwt = Jwt.withTokenValue("token").subject("not-a-uuid").header("alg", "none").build();
+		SecurityContextHolder.getContext().setAuthentication(
+				new org.springframework.security.authentication.UsernamePasswordAuthenticationToken(jwt, null));
+
+		try {
+			assertDoesNotThrow(() -> sink.captureBackend(new IllegalArgumentException("bad"), "/api", "GET", 500, "E"));
+		}
+		finally {
+			SecurityContextHolder.clearContext();
+		}
+
+		ArgumentCaptor<Object[]> eventArguments = ArgumentCaptor.forClass(Object[].class);
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), eventArguments.capture());
+		assertEquals(null, eventArguments.getAllValues().getFirst()[2]);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/adapters/aliyun/AliyunInferenceLogParserTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/adapters/aliyun/AliyunInferenceLogParserTest.java
@@ -162,6 +162,85 @@ class AliyunInferenceLogParserTest {
         assertThat(record.usage().totalTokens()).isZero();
     }
 
+    @Test
+    void acceptsFailedHttpRecordsWithoutUsageAndNonWsProtocolsWithoutTaskUuid() {
+        var record = parser.parse("""
+                {
+                  "start_unix_timestamp":"1787106742708",
+                  "status_code":"500",
+                  "extras":{"protocol":"HTTP"},
+                  "apikey_id":"6126227",
+                  "duration":"0",
+                  "workspace_id":"ws-67zfnonsdn4x96ia",
+                  "model":"qwen3-tts-flash",
+                  "request_id":"request-failed-1"
+                }
+                """);
+
+        assertThat(record.statusCode()).isEqualTo("500");
+        assertThat(record.taskUuid()).isNull();
+        assertThat(record.usage().responseCount()).isZero();
+        assertThat(record.usage().totalTokens()).isZero();
+    }
+
+    @Test
+    void acceptsWebrtcWithTaskUuidAndOptionalZeroDetails() {
+        var record = parser.parse("""
+                {
+                  "start_unix_timestamp":"1787106742708",
+                  "status_code":"200",
+                  "usage":{"input_tokens":0,"output_tokens":0,"total_tokens":0,
+                    "input_tokens_details":{},"output_tokens_details":{}},
+                  "extras":{"protocol":"webrtc"},
+                  "apikey_id":"6126227",
+                  "duration":"0",
+                  "workspace_id":"ws-67zfnonsdn4x96ia",
+                  "model":"qwen3.5-omni-flash-realtime",
+                  "task_uuid":"task-1",
+                  "request_id":"request-webrtc-1"
+                }
+                """);
+
+        assertThat(record.protocol()).isEqualTo("webrtc");
+        assertThat(record.taskUuid()).isEqualTo("task-1");
+        assertThat(record.usage().inputTextTokens()).isZero();
+        assertThat(record.usage().outputAudioTokens()).isZero();
+    }
+
+    @Test
+    void rejectsMalformedNestedObjectsMissingRequiredFieldsAndInvalidJson() {
+        assertThatThrownBy(() -> parser.parse("not-json"))
+                .isInstanceOf(OfficialUsageSchemaException.class);
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"extras\": {\"protocol\": \"ws\"}", "\"extras\": []")))
+                .isInstanceOf(OfficialUsageSchemaException.class)
+                .hasMessageContaining("extras");
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"usage\": {", "\"usage\": \"not-json\"")))
+                .isInstanceOf(OfficialUsageSchemaException.class);
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"model\": \"qwen3.5-omni-flash-realtime\"", "\"model\": \"\"")))
+                .isInstanceOf(OfficialUsageSchemaException.class)
+                .hasMessageContaining("model");
+    }
+
+    @Test
+    void rejectsNegativeTimestampAndMissingRealtimeTaskUuid() {
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"start_unix_timestamp\": \"1784534676105\"", "\"start_unix_timestamp\": \"-1\"")))
+                .isInstanceOf(OfficialUsageSchemaException.class)
+                .hasMessageContaining("start_unix_timestamp");
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"task_uuid\": \"sess_41tAWSq7xIR1b2EDelEgS\",", "")))
+                .isInstanceOf(OfficialUsageSchemaException.class)
+                .hasMessageContaining("task_uuid");
+        assertThatThrownBy(() -> parser.parse(validJson()
+                .replace("\"protocol\": \"ws\"", "\"protocol\": \"webrtc\"")
+                .replace("\"task_uuid\": \"sess_41tAWSq7xIR1b2EDelEgS\",", "")))
+                .isInstanceOf(OfficialUsageSchemaException.class)
+                .hasMessageContaining("task_uuid");
+    }
+
     private static String validJson() {
         return """
                 {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/adapters/aliyun/AliyunSlsUsageLogSourceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/adapters/aliyun/AliyunSlsUsageLogSourceTest.java
@@ -1,9 +1,27 @@
 package com.unispeaking.admin.usage.adapters.aliyun;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.aliyun.openservices.log.Client;
+import com.aliyun.openservices.log.common.LogGroupData;
+import com.aliyun.openservices.log.common.LogItem;
+import com.aliyun.openservices.log.common.Shard;
+import com.aliyun.openservices.log.exception.LogException;
+import com.aliyun.openservices.log.request.PullLogsRequest;
+import com.aliyun.openservices.log.response.GetCursorResponse;
+import com.aliyun.openservices.log.response.ListShardResponse;
+import com.aliyun.openservices.log.response.PullLogsResponse;
+import com.unispeaking.admin.usage.application.UsageSourceUnavailableException;
 import java.time.Instant;
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class AliyunSlsUsageLogSourceTest {
@@ -45,5 +63,89 @@ class AliyunSlsUsageLogSourceTest {
 
         assertThat(source.loadLogs(Instant.ofEpochSecond(100), Instant.ofEpochSecond(200)))
                 .containsExactly("{\"shard\":0}", "{\"shard\":1}");
+    }
+
+    @Test
+    void sdkClientListsShardsAndReadsCursors() throws Exception {
+        Client sdk = mock(Client.class);
+        when(sdk.ListShard("project", "store"))
+                .thenReturn(new ListShardResponse(Map.of(), new ArrayList<>(List.of(
+                        new Shard(3, "", "", "", 0),
+                        new Shard(7, "", "", "", 0)))));
+        when(sdk.GetCursor("project", "store", 3, 100L))
+                .thenReturn(new GetCursorResponse(Map.of(), "cursor-100"));
+        var client = sdkRawLogClient(sdk);
+
+        assertThat(client.listShardIds("project", "store")).containsExactly(3, 7);
+        assertThat(client.cursor("project", "store", 3, 100L)).isEqualTo("cursor-100");
+    }
+
+    @Test
+    void sdkClientPullsAllLogItemsAndCarriesPageMetadata() throws Exception {
+        Client sdk = mock(Client.class);
+        PullLogsResponse response = mock(PullLogsResponse.class);
+        LogItem first = new LogItem();
+        first.PushBack("message", "first");
+        LogItem second = new LogItem();
+        second.PushBack("message", "second");
+        LogGroupData group = mock(LogGroupData.class);
+        when(group.GetAllLogs()).thenReturn(new ArrayList<>(List.of(first, second)));
+        when(response.getLogGroups()).thenReturn(List.of(group));
+        when(response.getNextCursor()).thenReturn("next-cursor");
+        when(response.isEndOfCursor()).thenReturn(false);
+        when(sdk.pullLogs(any(PullLogsRequest.class))).thenReturn(response);
+        var client = sdkRawLogClient(sdk);
+
+        var page = client.pull("project", "store", 2, 100, "begin", "end");
+
+        assertThat(page.logs()).containsExactly(first.ToJsonString(), second.ToJsonString());
+        assertThat(page.nextCursor()).isEqualTo("next-cursor");
+        assertThat(page.endOfCursor()).isFalse();
+    }
+
+    @Test
+    void sdkClientTranslatesListShardFailure() throws Exception {
+        Client sdk = mock(Client.class);
+        when(sdk.ListShard("project", "store"))
+                .thenThrow(new LogException("ListShardError", "failed", "request"));
+
+        assertUnavailable(() -> sdkRawLogClient(sdk).listShardIds("project", "store"), "列举分片", "ListShardError");
+    }
+
+    @Test
+    void sdkClientTranslatesCursorFailure() throws Exception {
+        Client sdk = mock(Client.class);
+        when(sdk.GetCursor("project", "store", 2, 100L))
+                .thenThrow(new LogException("CursorError", "failed", "request"));
+
+        assertUnavailable(() -> sdkRawLogClient(sdk).cursor("project", "store", 2, 100L), "获取分片游标", "CursorError");
+    }
+
+    @Test
+    void sdkClientTranslatesPullFailure() throws Exception {
+        Client sdk = mock(Client.class);
+        when(sdk.pullLogs(any(PullLogsRequest.class)))
+                .thenThrow(new LogException("PullError", "failed", "request"));
+
+        assertUnavailable(
+                () -> sdkRawLogClient(sdk).pull("project", "store", 2, 100, "begin", "end"),
+                "读取分片日志", "PullError");
+    }
+
+    private static AliyunSlsUsageLogSource.RawLogClient sdkRawLogClient(Client sdk) throws Exception {
+        Class<?> type = Class.forName(
+                "com.unispeaking.admin.usage.adapters.aliyun.AliyunSlsUsageLogSource$SdkRawLogClient");
+        Constructor<?> constructor = type.getDeclaredConstructor(Client.class);
+        constructor.setAccessible(true);
+        return (AliyunSlsUsageLogSource.RawLogClient) constructor.newInstance(sdk);
+    }
+
+    private static void assertUnavailable(
+            org.assertj.core.api.ThrowableAssert.ThrowingCallable action,
+            String operation,
+            String errorCode) {
+        assertThatThrownBy(action)
+                .isInstanceOf(UsageSourceUnavailableException.class)
+                .hasMessageContaining("阿里云 SLS " + operation + "失败：" + errorCode);
     }
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/application/AdminUsageQueryServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/application/AdminUsageQueryServiceTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.admin.usage.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.unispeaking.admin.observability.AlibabaObservabilityStatus;
 import com.unispeaking.admin.usage.domain.ModelUsage;
@@ -8,59 +9,192 @@ import com.unispeaking.admin.usage.domain.ProviderStatus;
 import com.unispeaking.admin.usage.domain.UsageSession;
 import com.unispeaking.admin.usage.domain.UsageSnapshot;
 import com.unispeaking.admin.usage.domain.UsageUser;
+import com.unispeaking.admin.usage.ports.UsageDataSource;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class AdminUsageQueryServiceTest {
-	@Test
-	void reportsMissingSlsProjectSeparatelyFromConfiguredRamCredentials() {
-		var source = (com.unispeaking.admin.usage.ports.UsageDataSource) () ->
-				new UsageSnapshot(
-						List.of(), null,
-						new ProviderStatus(null, Map.of(), List.of(), 0, "postgres", null, false));
-		var alibaba = new AlibabaObservabilityStatus(
-				"cn-beijing", "replace-with-sls-project", "audit", "bailian-model-audit-log", true, false);
+    @Test
+    void aggregatesNullUsageCostAndStatusAlongsideNormalSummaryValues() {
+        var clientUsage = new ModelUsage(1, 77, 40, 37, 20, 20, 17, 20);
+        var officialUsage = new ModelUsage(2, 88, 45, 43, 25, 20, 19, 24);
+        var userWithoutUsage = new UsageUser(
+                "user-null", "Null User", "free", "Free", "active", "2026-08-11",
+                100.1234, 20.5555, 0, 20.5555, 79.5678, null, null, 4,
+                List.of(session("connecting", null, null, null, null, null),
+                        session("waiting_client", null, null, null, null, null),
+                        session("active", null, null, null, null, null),
+                        session(null, null, null, null, null, null)),
+                null, null, null, Map.of());
+        var userWithUsage = new UsageUser(
+                "user-values", "Value User", "pro", "Pro", "active", "2026-08-11",
+                10.0006, 2.3456, 0, 2.3456, 7.655, null, null, 1,
+                List.of(session("completed", clientUsage, officialUsage, 12L, "0.5", "MATCHED")),
+                clientUsage, officialUsage, "1.25",
+                Map.of("PENDING", 1, "MATCHED", 2, "MISMATCH", 3));
 
-		var sls = new AdminUsageQueryService(source, alibaba).dataSources().sources().stream()
-				.filter(item -> item.code().equals("ALIYUN_SLS"))
-				.findFirst()
-				.orElseThrow();
+        var summary = service(source(List.of(userWithoutUsage, userWithUsage)), alibaba(false, "project"))
+                .summary();
 
-		assertThat(sls.state()).isEqualTo("CONFIGURATION_REQUIRED");
-		assertThat(sls.detail()).contains("缺少 SLS Project");
-		assertThat(sls.detail()).doesNotContain("缺少 RAM AccessKey");
-		assertThat(sls.detail()).contains("bailian-model-audit-log");
-	}
+        assertThat(summary.totalUsers()).isEqualTo(2);
+        assertThat(summary.activeSessions()).isEqualTo(3);
+        assertThat(summary.quotaSeconds()).isEqualTo(110.124);
+        assertThat(summary.usedSeconds()).isEqualTo(22.901);
+        assertThat(summary.remainingSeconds()).isEqualTo(87.223);
+        assertThat(summary.clientTokens()).isEqualTo(77);
+        assertThat(summary.officialTokens()).isEqualTo(88);
+        assertThat(summary.estimatedCostCny()).isEqualTo("1.25");
+        assertThat(summary.reconciliationPending()).isEqualTo(1);
+        assertThat(summary.reconciliationMatched()).isEqualTo(2);
+        assertThat(summary.reconciliationMismatch()).isEqualTo(3);
+        assertThat(summary.generatedAt()).isNotBlank();
+    }
 
-	@Test
-	void countsCanonicalBackendConnectionStatusesInTheDashboard() {
-		var emptyUsage = new ModelUsage(0, 0, 0, 0, 0, 0, 0, 0);
-		var sessions = List.of(
-				session("connecting", emptyUsage),
-				session("waiting_client", emptyUsage),
-				session("active", emptyUsage),
-				session("completed", emptyUsage));
-		var user = new UsageUser(
-				"user-1", "User", "free", "Free", "active", "2026-08-11",
-				600, 0, 0, 0, 600, null, "active", sessions.size(), sessions,
-				emptyUsage, emptyUsage, "0", Map.of());
-		var source = (com.unispeaking.admin.usage.ports.UsageDataSource) () ->
-				new UsageSnapshot(
-						List.of(user), null,
-						new ProviderStatus(null, Map.of(), List.of(), 0, "postgres", null, false));
-		var alibaba = new AlibabaObservabilityStatus(
-				"cn-shanghai", "project", "audit", "inference", false, false);
+    @Test
+    void reportsMissingSlsProjectSeparatelyFromConfiguredRamCredentials() {
+        var source = source(List.of());
+        var alibaba = alibaba(true, "replace-with-sls-project");
 
-		var summary = new AdminUsageQueryService(source, alibaba).summary();
+        var sls = service(source, alibaba).dataSources().sources().stream()
+                .filter(item -> item.code().equals("ALIYUN_SLS"))
+                .findFirst()
+                .orElseThrow();
 
-		assertThat(summary.activeSessions()).isEqualTo(3);
-	}
+        assertThat(sls.state()).isEqualTo("CONFIGURATION_REQUIRED");
+        assertThat(sls.detail()).contains("缺少 SLS Project");
+        assertThat(sls.detail()).doesNotContain("缺少 RAM AccessKey");
+        assertThat(sls.detail()).contains("bailian-model-inference-log");
+    }
 
-	private static UsageSession session(String status, ModelUsage usage) {
-		return new UsageSession(
-				"session-" + status, "user-1", "free", status, 0, 600,
-				null, null, null, null, null, usage, usage, null, "0", "UNAVAILABLE",
-				"PENDING", List.of(), null);
-	}
+    @Test
+    void returnsUsersAndRaisesNotFoundForAnUnknownUser() {
+        var user = user("user-1", List.of());
+        var service = service(source(List.of(user)), alibaba(false, "project"));
+
+        assertThat(service.users().users()).containsExactly(user);
+        assertThat(service.user("user-1")).isSameAs(user);
+        assertThatThrownBy(() -> service.user("missing"))
+                .isInstanceOf(UsageUserNotFoundException.class)
+                .hasMessage("找不到用户：missing");
+    }
+
+    @Test
+    void flattensSessionsAndMapsNullUsageAndStatusToPendingReconciliationDefaults() {
+        var clientUsage = new ModelUsage(1, 100, 60, 40, 30, 30, 20, 20);
+        var officialUsage = new ModelUsage(1, 105, 62, 43, 32, 30, 21, 22);
+        var matched = session("completed", clientUsage, officialUsage, 900L, "0.125", "MATCHED");
+        var pending = session("active", null, null, null, null, null);
+        var service = service(source(List.of(user("user-1", List.of(matched, pending)))),
+                alibaba(false, "project"));
+
+        assertThat(service.sessions().sessions()).containsExactly(matched, pending);
+
+        var records = service.reconciliation().records();
+        assertThat(records).hasSize(2);
+        assertThat(records.get(0).userId()).isEqualTo("user-1");
+        assertThat(records.get(0).clientTokens()).isEqualTo(100);
+        assertThat(records.get(0).officialTokens()).isEqualTo(105);
+        assertThat(records.get(0).clientUsage()).isEqualTo(clientUsage);
+        assertThat(records.get(0).officialUsage()).isEqualTo(officialUsage);
+        assertThat(records.get(0).officialDurationMs()).isEqualTo(900L);
+        assertThat(records.get(0).estimatedCostCny()).isEqualTo("0.125");
+        assertThat(records.get(0).status()).isEqualTo("MATCHED");
+
+        var pendingRecord = records.get(1);
+        assertThat(pendingRecord.clientTokens()).isZero();
+        assertThat(pendingRecord.officialTokens()).isZero();
+        assertThat(pendingRecord.clientUsage()).isEqualTo(zeroUsage());
+        assertThat(pendingRecord.officialUsage()).isEqualTo(zeroUsage());
+        assertThat(pendingRecord.status()).isEqualTo("PENDING");
+        assertThat(pendingRecord.reasons()).isEmpty();
+    }
+
+    @Test
+    void reportsOnlineDefaultsAndEnabledPrometheusForTheUserDataSource() {
+        var dataSources = service(source(List.of(user("user-1", List.of()))),
+                alibaba(true, "project", true))
+                .dataSources().sources();
+
+        assertThat(dataSources).extracting(AdminUsageQueryService.DataSourceState::code)
+                .containsExactly("POSTGRES", "ALIYUN_SLS", "ALIYUN_PROMETHEUS");
+        assertThat(dataSources.get(0).name()).isEqualTo("PostgreSQL 用户数据库");
+        assertThat(dataSources.get(0).state()).isEqualTo("ONLINE");
+        assertThat(dataSources.get(0).detail()).contains("当前 1 个账户");
+        assertThat(dataSources.get(1).state()).isEqualTo("READY");
+        assertThat(dataSources.get(1).detail()).isEqualTo("cn-beijing · project · bailian-model-inference-log");
+        assertThat(dataSources.get(2).state()).isEqualTo("ENABLED");
+    }
+
+    @Test
+    void reportsOfflineUserDataSourceAndAllMissingSlsConfiguration() {
+        UsageDataSource source = () -> {
+            throw new UsageSourceUnavailableException("数据库不可用", null);
+        };
+
+        var dataSources = service(source, alibaba(false, null)).dataSources().sources();
+
+        assertThat(dataSources.get(0).state()).isEqualTo("OFFLINE");
+        assertThat(dataSources.get(0).detail()).isEqualTo("数据库不可用");
+        assertThat(dataSources.get(1).state()).isEqualTo("CONFIGURATION_REQUIRED");
+        assertThat(dataSources.get(1).detail())
+                .startsWith("缺少 RAM AccessKey、缺少 SLS Project · cn-beijing · 未配置 · bailian-model-inference-log");
+        assertThat(dataSources.get(2).state()).isEqualTo("DISABLED");
+    }
+
+    @Test
+    void distinguishesEverySlsConfigurationCombination() {
+        assertSls(alibaba(false, null), "CONFIGURATION_REQUIRED", "缺少 RAM AccessKey、缺少 SLS Project");
+        assertSls(alibaba(false, "project"), "CONFIGURATION_REQUIRED", "缺少 RAM AccessKey");
+        assertSls(alibaba(true, "  "), "CONFIGURATION_REQUIRED", "缺少 SLS Project");
+        assertSls(alibaba(true, "replace-with-project"), "CONFIGURATION_REQUIRED", "缺少 SLS Project");
+        assertSls(alibaba(true, "project"), "READY", "cn-beijing · project · bailian-model-inference-log");
+    }
+
+    private static void assertSls(AlibabaObservabilityStatus alibaba, String state, String detail) {
+        var sls = service(source(List.of()), alibaba).dataSources().sources().get(1);
+        assertThat(sls.state()).isEqualTo(state);
+        assertThat(sls.detail()).contains(detail);
+    }
+
+    private static AdminUsageQueryService service(UsageDataSource source, AlibabaObservabilityStatus alibaba) {
+        return new AdminUsageQueryService(source, alibaba);
+    }
+
+    private static UsageDataSource source(List<UsageUser> users) {
+        return () -> new UsageSnapshot(
+                users, null, new ProviderStatus(null, Map.of(), List.of(), 0, "postgres", null, false));
+    }
+
+    private static AlibabaObservabilityStatus alibaba(boolean credentialsConfigured, String project) {
+        return alibaba(credentialsConfigured, project, false);
+    }
+
+    private static AlibabaObservabilityStatus alibaba(
+            boolean credentialsConfigured, String project, boolean prometheusEnabled) {
+        return new AlibabaObservabilityStatus(
+                "cn-beijing", project, "audit", "bailian-model-inference-log",
+                credentialsConfigured, prometheusEnabled);
+    }
+
+    private static UsageUser user(String userId, List<UsageSession> sessions) {
+        return new UsageUser(
+                userId, "User", "free", "Free", "active", "2026-08-11",
+                600, 0, 0, 0, 600, null, null, sessions.size(), sessions,
+                zeroUsage(), zeroUsage(), "0", Map.of());
+    }
+
+    private static UsageSession session(
+            String status, ModelUsage clientUsage, ModelUsage officialUsage,
+            Long officialDurationMs, String estimatedCostCny, String reconciliationStatus) {
+        return new UsageSession(
+                "session-" + String.valueOf(status), "user-1", "free", status, 0, 600,
+                null, null, null, null, null, clientUsage, officialUsage, officialDurationMs,
+                estimatedCostCny, "UNAVAILABLE", reconciliationStatus,
+                List.of(), null);
+    }
+
+    private static ModelUsage zeroUsage() {
+        return new ModelUsage(0, 0, 0, 0, 0, 0, 0, 0);
+    }
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/application/OfficialUsageSyncSchedulerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/admin/usage/application/OfficialUsageSyncSchedulerTest.java
@@ -1,0 +1,32 @@
+package com.unispeaking.admin.usage.application;
+
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class OfficialUsageSyncSchedulerTest {
+    @Test
+    void runsSyncAndAcceptsResult() {
+        OfficialUsageSyncService service = mock(OfficialUsageSyncService.class);
+        OfficialUsageSyncService.SyncResult result = new OfficialUsageSyncService.SyncResult(
+                10, 8, 1, 1, 0, 0, 7, 1, 5, 2, Instant.parse("2026-08-24T00:00:00Z"));
+        org.mockito.Mockito.when(service.syncNow()).thenReturn(result);
+
+        new OfficialUsageSyncScheduler(service).sync();
+
+        verify(service).syncNow();
+    }
+
+    @Test
+    void swallowsSyncFailureSoScheduledExecutionContinues() {
+        OfficialUsageSyncService service = mock(OfficialUsageSyncService.class);
+        doThrow(new IllegalStateException("temporary failure")).when(service).syncNow();
+
+        new OfficialUsageSyncScheduler(service).sync();
+
+        verify(service).syncNow();
+    }
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/ConversationLanguageAssessmentParserTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/ConversationLanguageAssessmentParserTest.java
@@ -2,7 +2,9 @@ package com.unispeaking.common.evaluation.parser;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
 import com.unispeaking.common.exception.evaluation.EvaluationException;
 import java.math.BigDecimal;
 import org.junit.jupiter.api.Test;
@@ -26,19 +28,145 @@ class ConversationLanguageAssessmentParserTest {
 	}
 
 	@Test
-	void rejectsInsufficientAssessmentAsNoFormalScore() {
-		assertThrows(
-				EvaluationException.class,
-				() -> parser.parse(validJson().replace("\"ok\"", "\"insufficient_data\"")));
+	void rejectsNullBlankMalformedAndNonObjectDocuments() {
+		assertError(null, EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(" \t\n ", EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError("not json", EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError("[]", EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError("```JSON\n{}\n```", EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError("```json\n{}", EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError("```json\n\n```", EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
 	}
 
 	@Test
-	void rejectsEnglishOnlyReasons() {
-		assertThrows(
+	void rejectsStatusAndRootFieldViolations() {
+		assertError(validJson().replace(
+				"\"data_quality_notes\":[]",
+				"\"extra\":1,\"data_quality_notes\":[]"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"assessment_status\":\"ok\"",
+				"\"assessment_status\":\"pending\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"assessment_status\":\"ok\"",
+				"\"assessment_status\":\"insufficient_data\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace(
+				"\"assessment_status\":\"ok\"",
+				"\"assessment_status\":null"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace(
+				"\"assessment_status\":\"ok\"",
+				"\"assessment_status\":123"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"data_quality_notes\":[]",
+				"\"data_quality_notes\":null"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+	}
+
+	@Test
+	void rejectsScoreRangePrecisionAndConfidenceViolations() {
+		assertError(validJson().replace("\"grammar\":76", "\"grammar\":-0.01"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"grammar\":76", "\"grammar\":100.01"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"grammar\":76", "\"grammar\":76.123"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"grammar\":76", "\"grammar\":\"76\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"grammar\":76", "\"grammar\":null"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace("\"confidence\":0.8", "\"confidence\":-0.1"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"confidence\":0.8", "\"confidence\":1.01"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace("\"confidence\":0.8", "\"confidence\":\"0.8\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace("\"confidence\":0.8", "\"confidence\":null"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+	}
+
+	@Test
+	void rejectsDimensionAndFeedbackShapeViolations() {
+		assertError(validJson().replace(
+				"\"dimensions\":{",
+				"\"dimensions\":[]"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"grammar\":{",
+				"\"grammar\":{\"extra\":1,"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"strengths\":[{\"evidence\":\"I went\",\"reason\":\"时态正确\"}]",
+				"\"strengths\":null"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace(
+				"\"strengths\":[{\"evidence\":\"I went\",\"reason\":\"时态正确\"}]",
+				"\"strengths\":[1]"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson().replace(
+				"\"improvements\":[{\"evidence\":\"go yesterday\",\"correction\":\"went yesterday\",\"reason\":\"使用过去式\"}]",
+				"\"improvements\":[{\"evidence\":\"go yesterday\",\"reason\":\"使用过去式\"}]"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+		assertError(validJson().replace(
+				"\"improvements\":[{\"evidence\":\"go yesterday\",\"correction\":\"went yesterday\",\"reason\":\"使用过去式\"}]",
+				"\"improvements\":[{\"evidence\":\"go yesterday\",\"correction\":\"   \",\"reason\":\"使用过去式\"}]"),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE);
+	}
+
+	@Test
+	void rejectsFeedbackLanguageLimitsAndUnknownFields() {
+		assertError(validJson().replace(
+				"\"reason\":\"时态正确\"",
+				"\"reason\":\"The tense is correct\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertEquals("I went：时态正确", parser.parse(validJson().replace(
+				"\"reason\":\"时态正确\"",
+				"\"reason\":\"时态正确\",\"reazon\":\"额外信息\""))
+				.strengths().getFirst());
+		assertEquals("go yesterday → went yesterday：使用过去式", parser.parse(validJson().replace(
+				"\"correction\":\"went yesterday\"",
+				"\"correction\":\"went yesterday\",\"suggestion\":\"went\""))
+				.improvements().getFirst());
+		String tooManyStrengths = validJson().replace(
+				"\"strengths\":[{\"evidence\":\"I went\",\"reason\":\"时态正确\"}]",
+				"\"strengths\":[{\"evidence\":\"I went\",\"reason\":\"时态正确\"},{\"evidence\":\"I ran\",\"reason\":\"表达清楚\"},{\"evidence\":\"I ate\",\"reason\":\"内容完整\"},{\"evidence\":\"I slept\",\"reason\":\"信息准确\"}]");
+		assertError(tooManyStrengths, EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+	}
+
+	@Test
+	void acceptsBoundaryScoresAndUsesPreferredCorrectionField() {
+		String document = validJson()
+				.replace("\"grammar\":76", "\"grammar\":0.00")
+				.replace("\"vocabulary\":72", "\"vocabulary\":100.00")
+				.replace("\"text_naturalness\":74", "\"text_naturalness\":74.25")
+				.replace("\"evidence\":\"I went\"", "\"evidence\":\"  I went  \"");
+
+		var result = parser.parse(document);
+
+		assertEquals(0, result.grammarScore().compareTo(new BigDecimal("0.00")));
+		assertEquals(0, result.vocabularyScore().compareTo(new BigDecimal("100.00")));
+		assertEquals(0, result.textNaturalnessScore().compareTo(new BigDecimal("74.25")));
+		assertTrue(result.strengths().getFirst().startsWith("I went："));
+		assertTrue(result.improvements().getFirst().contains("went yesterday"));
+	}
+
+	@Test
+	void rejectsDuplicateKeysAndTrailingTokens() {
+		assertError(validJson().replace(
+				"\"assessment_status\":\"ok\"",
+				"\"assessment_status\":\"ok\",\"assessment_status\":\"ok\""),
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+		assertError(validJson() + " trailing", EvaluationErrorCode.PROVIDER_RESPONSE_INVALID);
+	}
+
+	private void assertError(String document, EvaluationErrorCode expected) {
+		EvaluationException exception = assertThrows(
 				EvaluationException.class,
-				() -> parser.parse(validJson().replace(
-						"时态正确",
-						"The tense is correct")));
+				() -> parser.parse(document));
+		assertEquals(expected, exception.errorCode());
 	}
 
 	private String validJson() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParserTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/parser/IflytekSuntoneAssessmentParserTest.java
@@ -176,26 +176,156 @@ class IflytekSuntoneAssessmentParserTest {
 						-1,
 						result.words().getFirst()
 								.phonemes().getFirst()
-								.endPosition()));
+						.endPosition()));
+	}
+
+	@Test
+	void mapsOptionalFieldsAndAllNonDefaultWordBranches() {
+		PronunciationAssessmentResult result =
+				parser.parse(envelope("""
+						{
+						  "result": {
+						    "overall": 80,
+						    "rhythm": 81,
+						    "tone": 12.345,
+						    "integrity": 82,
+						    "pronunciation": 83,
+						    "fluency": 84,
+						    "rear_tone": " FALL ",
+						    "words": [
+						      {
+						        "word": "first",
+						        "readType": 1,
+						        "scores": {"overall": 80, "pronunciation": 81, "prominence": 0},
+						        "phonemes": [{
+						          "phoneme": "f",
+						          "phone": "  ",
+						          "pronunciation": 82,
+						          "span": {"start": 1, "end": 2}
+						        }]
+						      },
+						      {
+						        "word": "second",
+						        "readType": 7,
+						        "scores": {"overall": 83, "pronunciation": 84},
+						        "phonemes": [{
+						          "phoneme": "s",
+						          "phone": 7,
+						          "pronunciation": 85,
+						          "span": {"start": 2, "end": 5}
+						        }]
+						      },
+						      {"charType": 1}
+						    ]
+						  }
+						}
+						"""));
+
+		assertAll(
+				() -> assertEquals(new BigDecimal("12.35"), result.toneScore()),
+				() -> assertSame(EndingTone.FALL, result.endingTone()),
+				() -> assertSame(
+						com.unispeaking.common.evaluation.model.WordReadStatus.INSERTION_BEFORE,
+						result.words().get(0).readStatus()),
+				() -> assertSame(
+						com.unispeaking.common.evaluation.model.WordReadStatus.OMITTED,
+						result.words().get(1).readStatus()),
+				() -> assertEquals(Boolean.FALSE, result.words().get(0).isProminent()),
+				() -> assertNull(result.words().get(1).isProminent()),
+				() -> assertEquals("f", result.words().get(0).phonemes().getFirst().actualPhoneme()),
+				() -> assertEquals("s", result.words().get(1).phonemes().getFirst().actualPhoneme()));
+	}
+
+	@Test
+	void rejectsMalformedEnvelopeAndInvalidAssessmentFields() {
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse("not-json"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse("[]"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse("{"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE,
+				() -> parser.parse("{\"header\":{\"code\":0,\"status\":1}}"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE,
+				() -> parser.parse(encodedEnvelope("{\"result\":{\"status\":1}}")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse(encodedEnvelopeWithText("not-base64")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE,
+				() -> parser.parse(encodedEnvelope("{\"result\":{\"words\":[]}}")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse(encodedEnvelope("""
+						{"result":{"overall":-1,"rhythm":80,"integrity":80,
+						"pronunciation":80,"fluency":80,"words":[
+						{"word":"x","scores":{"overall":80,"pronunciation":80},
+						"phonemes":[{"phoneme":"x","pronunciation":80,
+						"span":{"start":2,"end":2}}]}]}}
+						""")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse(encodedEnvelope("""
+						{"result":{"overall":80,"rhythm":80,"integrity":80,
+						"pronunciation":80,"fluency":80,"words":[
+						{"word":"x","scores":{"overall":80,"pronunciation":80,
+						"prominence":2},"phonemes":[{"phoneme":"x",
+						"pronunciation":80,"span":{"start":0,"end":1}}]}]}}
+						""")));
+	}
+
+	@Test
+	void rejectsMissingAndWronglyTypedRequiredValues() {
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE,
+				() -> parser.parse("{\"header\":{\"code\":0}}"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse("{\"header\":{\"code\":\"0\",\"status\":2}}"));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse(encodedEnvelopeWithText("")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE,
+				() -> parser.parse(encodedEnvelope("{\"result\":{\"words\":{}}}")));
+		assertCode(
+				EvaluationErrorCode.PROVIDER_RESPONSE_INVALID,
+				() -> parser.parse(encodedEnvelope("""
+						{"result":{"overall":80,"rhythm":80,"integrity":80,
+						"pronunciation":80,"fluency":80,"rear_tone":7,"words":[
+						{"word":"x","scores":{"overall":80,"pronunciation":80},
+						"phonemes":[{"phoneme":"x","pronunciation":80,
+						"span":{"start":0,"end":1}}]}]}}
+						""")));
+	}
+
+	private void assertCode(
+				EvaluationErrorCode expected,
+				org.junit.jupiter.api.function.Executable action) {
+		EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				action);
+		assertSame(expected, exception.errorCode());
+	}
+
+	private String encodedEnvelopeWithText(String text) {
+		return """
+				{"header":{"code":0,"status":2},"payload":{"result":{"status":2,"text":"%s"}}}
+				""".formatted(text);
+	}
+
+	private String encodedEnvelope(String decodedResult) {
+		String encoded = Base64.getEncoder().encodeToString(
+				decodedResult.getBytes(StandardCharsets.UTF_8));
+		return encodedEnvelopeWithText(encoded);
 	}
 
 	private String envelope(String decodedResult) {
-		String encoded = Base64.getEncoder().encodeToString(
-				decodedResult.getBytes(StandardCharsets.UTF_8));
-		return """
-				{
-				  "header": {
-				    "code": 0,
-				    "message": "success",
-				    "status": 2
-				  },
-				  "payload": {
-				    "result": {
-				      "status": 2,
-				      "text": "%s"
-				    }
-				  }
-				}
-				""".formatted(encoded);
+		return encodedEnvelope(decodedResult);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/GlobalExceptionHandlerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/exception/GlobalExceptionHandlerTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.common.exception;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
@@ -12,6 +13,11 @@ import org.springframework.validation.FieldError;
 import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.multipart.MaxUploadSizeExceededException;
+import org.springframework.web.ErrorResponseException;
+import org.springframework.http.ProblemDetail;
+import org.springframework.http.HttpStatusCode;
+import org.mockito.Mockito;
+import com.unispeaking.admin.quality.QualityIssueTelemetrySink;
 
 class GlobalExceptionHandlerTest {
 
@@ -55,6 +61,104 @@ class GlobalExceptionHandlerTest {
 				"acknowledged 必须为 true"));
 
 		assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+	}
+
+	@Test
+	void mapsAllImportantBusinessExceptionStatusFamilies() {
+		for (String code : new String[] {
+				"AUTHENTICATION_REQUIRED", "INVALID_ACCESS_TOKEN", "ACCESS_TOKEN_REVOKED",
+				"INVALID_CREDENTIALS", "USER_NOT_ACTIVE", "REFRESH_TOKEN_INVALID"}) {
+			assertEquals(HttpStatus.UNAUTHORIZED,
+					handler.handleBusinessException(new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"SESSION_ACCESS_DENIED", "ADMIN_ACCESS_DENIED",
+				InterviewErrorCode.INTERVIEW_SCENE_ACCESS_DENIED}) {
+			assertEquals(HttpStatus.FORBIDDEN,
+					handler.handleBusinessException(new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"FEEDBACK_NOT_FOUND", "FEEDBACK_LOOKUP_DENIED",
+				"IELTS_RECORDING_NOT_FOUND", InterviewErrorCode.INTERVIEW_REPORT_NOT_FOUND,
+				InterviewErrorCode.INTERVIEW_RECORDING_NOT_FOUND}) {
+			assertEquals(HttpStatus.NOT_FOUND,
+					handler.handleBusinessException(new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"USERNAME_ALREADY_EXISTS", "PASSWORD_UPDATE_CONFLICT",
+				"PROFILE_UPDATE_CONFLICT", "FEEDBACK_UPDATE_CONFLICT",
+				InterviewErrorCode.INTERVIEW_TURN_CONTENT_MISMATCH,
+				InterviewErrorCode.INTERVIEW_TURN_MESSAGE_PENDING,
+				InterviewErrorCode.INTERVIEW_SESSION_ENDED}) {
+			assertEquals(HttpStatus.CONFLICT,
+					handler.handleBusinessException(new BusinessException(code, code)).getStatusCode());
+		}
+		assertEquals(HttpStatus.TOO_MANY_REQUESTS,
+				handler.handleBusinessException(new BusinessException(
+						InterviewErrorCode.INTERVIEW_DAILY_LIMIT_REACHED, "limit")).getStatusCode());
+	}
+
+	@Test
+	void mapsOcrDocumentInterviewAndStorageFailures() {
+		for (String code : new String[] {"OCR_TIMEOUT"}) {
+			assertEquals(HttpStatus.GATEWAY_TIMEOUT, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"OCR_PROCESS_FAILED", "OCR_RESPONSE_INVALID"}) {
+			assertEquals(HttpStatus.BAD_GATEWAY, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"OCR_UNAVAILABLE", "AVATAR_STORAGE_UNAVAILABLE"}) {
+			assertEquals(HttpStatus.SERVICE_UNAVAILABLE, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"OCR_INPUT_REQUIRED", "OCR_TOO_MANY_IMAGES",
+				"OCR_TOTAL_SIZE_EXCEEDED", "OCR_PIXEL_LIMIT_EXCEEDED", "DOCUMENT_INPUT_REQUIRED",
+				"DOCUMENT_TOO_LARGE", "DOCUMENT_PDF_PAGE_LIMIT_EXCEEDED", "DOCUMENT_TEXT_EMPTY",
+				"DOCUMENT_TEXT_TOO_LARGE", InterviewErrorCode.INTERVIEW_MATERIAL_INVALID,
+				InterviewErrorCode.INTERVIEW_REQUEST_INVALID, InterviewErrorCode.INTERVIEW_AUDIO_INVALID}) {
+			assertEquals(HttpStatus.BAD_REQUEST, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"OCR_FORMAT_UNSUPPORTED", "OCR_CONTENT_INVALID",
+				"DOCUMENT_FORMAT_UNSUPPORTED", "DOCUMENT_CONTENT_INVALID", "AVATAR_CONTENT_INVALID"}) {
+			assertEquals(HttpStatus.UNPROCESSABLE_ENTITY, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+		for (String code : new String[] {"AVATAR_STORAGE_FAILED", "OBJECT_STORAGE_FAILED"}) {
+			assertEquals(HttpStatus.BAD_GATEWAY, handler.handleBusinessException(
+					new BusinessException(code, code)).getStatusCode());
+		}
+	}
+
+	@Test
+	void handlesUnexpectedFrameworkValidationEmailAndTelemetryFailures() throws Exception {
+		MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/test");
+		var unexpected = handler.handleUnexpectedException(new IllegalStateException("boom"), request);
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, unexpected.getStatusCode());
+		assertEquals("INTERNAL_SERVER_ERROR", unexpected.getBody().code());
+
+		ProblemDetail detail = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, "");
+		ErrorResponseException framework = new ErrorResponseException(
+				HttpStatusCode.valueOf(400), detail, null);
+		var frameworkResponse = handler.handleFrameworkStatusException(framework, request);
+		assertEquals(HttpStatus.BAD_REQUEST, frameworkResponse.getStatusCode());
+		assertEquals("HTTP_400", frameworkResponse.getBody().code());
+
+		assertEquals(HttpStatus.UNAUTHORIZED, handler.handleEmailAuthException(
+				new EmailAuthException("UNAUTHENTICATED")).getStatusCode());
+		assertEquals(HttpStatus.BAD_REQUEST, handler.handleEmailAuthException(
+				new EmailAuthException("OTHER")).getStatusCode());
+		var errors = validationException("acceptGeneric", new Object());
+		assertEquals(HttpStatus.BAD_REQUEST, handler.handleValidationException(errors).getStatusCode());
+	}
+
+	@Test
+	void reportingFailureDoesNotChangeUnexpectedResponse() {
+		var sink = Mockito.mock(QualityIssueTelemetrySink.class);
+		Mockito.doThrow(new IllegalStateException("telemetry down")).when(sink)
+				.captureBackend(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.anyInt(), Mockito.any());
+		var response = new GlobalExceptionHandler(sink).handleUnexpectedException(
+				new RuntimeException("boom"), new MockHttpServletRequest("POST", "/api/fail"));
+		assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.getStatusCode());
+		assertTrue(response.getBody().code().contains("INTERNAL"));
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/prompt/evaluation/IeltsEvaluationPromptBuilderCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/prompt/evaluation/IeltsEvaluationPromptBuilderCoverageTest.java
@@ -1,0 +1,305 @@
+package com.unispeaking.common.prompt.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
+import com.unispeaking.common.exception.evaluation.EvaluationException;
+import com.unispeaking.domain.vo.scene.IeltsPart;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.MockedConstruction;
+import org.springframework.core.io.ClassPathResource;
+import tools.jackson.core.JacksonException;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * 补齐 IELTS 评价 Prompt builder 的入口、边界和失败路径覆盖。
+ *
+ * <p>测试故意只使用 classpath 中的正式模板；资源本身的内容完整性由
+ * {@link IeltsEvaluationPromptBuilder} 的加载逻辑和现有模板测试共同验证。</p>
+ */
+class IeltsEvaluationPromptBuilderCoverageTest {
+
+	private static final String OPEN = "<EVALUATION_INPUT>";
+	private static final String CLOSE = "</EVALUATION_INPUT>";
+	private static final String INPUT_PLACEHOLDER =
+			"{{IELTS_EVALUATION_INPUT_JSON}}";
+	private static final String RUBRIC_PLACEHOLDER =
+			"{{IELTS_OFFICIAL_TEXT_RUBRIC}}";
+	private static final String RUBRIC_START = "### Band 9";
+
+	private final ObjectMapper objectMapper = new ObjectMapper();
+	private final IeltsEvaluationPromptBuilder builder =
+			new IeltsEvaluationPromptBuilder(objectMapper);
+
+	@Test
+	void constructorRejectsNullMapper() {
+		assertThrows(
+				NullPointerException.class,
+				() -> new IeltsEvaluationPromptBuilder(null));
+	}
+
+	@ParameterizedTest(name = "invalid part request: {0}")
+	@MethodSource("invalidPartRequests")
+	void buildPartRejectsMissingPartOrUnscorableTranscript(
+			IeltsPart part,
+			String transcript) {
+		EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildPart(part, transcript, null, null));
+
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, exception.errorCode());
+	}
+
+	private static Stream<Arguments> invalidPartRequests() {
+		return Stream.of(
+				Arguments.of(null, "a valid answer"),
+				Arguments.of(IeltsPart.PART_1, null),
+				Arguments.of(IeltsPart.PART_2, ""),
+				Arguments.of(IeltsPart.PART_3, " \t\n "));
+	}
+
+	@ParameterizedTest(name = "loads part template: {0}")
+	@MethodSource("allParts")
+	void buildPartLoadsTheMatchingTemplateAndPreservesAllInputFields(
+			IeltsPart part) throws Exception {
+		String transcript = "[history]\nExaminer: follow-up question\n"
+				+ "Candidate: I answered at the boundary: <&>.";
+		String cueCard = part == IeltsPart.PART_2
+				? "Describe a useful invention.\nYou should say why."
+				: null;
+		String speechMetrics = "turns=2; fluency=0.0; max_duration_ms=2147483647";
+
+		String prompt = builder.buildPart(
+				part, transcript, cueCard, speechMetrics);
+		JsonNode input = inputJson(prompt);
+
+		assertAll(
+				() -> assertEquals(part.name(), input.get("part").asString()),
+				() -> assertEquals(transcript,
+						input.get("transcript").asString()),
+				() -> assertEquals(cueCard,
+						nullableText(input.get("cue_card"))),
+				() -> assertEquals(speechMetrics,
+						input.get("speech_fluency_metrics").asString()),
+				() -> assertTrue(prompt.contains(RUBRIC_START)),
+				() -> assertFalse(prompt.contains(INPUT_PLACEHOLDER)),
+				() -> assertFalse(prompt.contains(RUBRIC_PLACEHOLDER)),
+				() -> assertTrue(prompt.contains(partEvidence(part))));
+	}
+
+	private static Stream<Arguments> allParts() {
+		return Stream.of(IeltsPart.values()).map(Arguments::of);
+	}
+
+	@Test
+	void buildPartConvertsBlankOptionalEvidenceToJsonNull() throws Exception {
+		String prompt = builder.buildPart(
+				IeltsPart.PART_1,
+				"Candidate: I enjoy quiet mornings.",
+				" \n\t ",
+				"");
+		JsonNode input = inputJson(prompt);
+
+		assertAll(
+				() -> assertTrue(input.get("cue_card").isNull()),
+				() -> assertTrue(input.get("speech_fluency_metrics").isNull()));
+	}
+
+	@Test
+	void buildPartRetainsEmptyHistorySectionsAndSpecialBoundaryCharacters()
+			throws Exception {
+		String transcript = "[PART_1]\n[history]\n\n[PART_2]\n"
+				+ "Candidate: ampersand &, angle brackets < and >, emoji 😀";
+		String prompt = builder.buildPart(
+				IeltsPart.PART_2,
+				transcript,
+				"Describe an object.",
+				"scorable_turns=0; empty_history=true");
+		JsonNode input = inputJson(prompt);
+
+		assertAll(
+				() -> assertEquals(transcript,
+						input.get("transcript").asString()),
+				() -> assertTrue(prompt.contains("\\u0026")),
+				() -> assertTrue(prompt.contains("\\u003C")),
+				() -> assertTrue(prompt.contains("\\u003E")),
+				() -> assertTrue(prompt.contains("empty_history=true")));
+	}
+
+	@ParameterizedTest(name = "invalid final transcript: {0}")
+	@MethodSource("invalidFinalTranscripts")
+	void buildFinalRejectsMissingOrBlankCompleteTranscript(String transcript) {
+		EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildFinal(transcript, null, "0.0"));
+
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, exception.errorCode());
+	}
+
+	private static Stream<Arguments> invalidFinalTranscripts() {
+		return Stream.of(
+				Arguments.of((String) null),
+				Arguments.of(""),
+				Arguments.of("\t\n"));
+	}
+
+	@Test
+	void buildFinalLoadsFinalStageWithNullHistoryMetricsAndBand() throws Exception {
+		String transcript = "PART 1: I live in Shanghai.\n"
+				+ "PART 2: I would like to describe a memorable trip.\n"
+				+ "PART 3: Travel can broaden people's perspectives.";
+		String prompt = builder.buildFinal(transcript, " \t", null);
+		JsonNode input = inputJson(prompt);
+
+		assertAll(
+				() -> assertEquals(transcript,
+						input.get("complete_test_transcript").asString()),
+				() -> assertTrue(input.get("speech_fluency_metrics").isNull()),
+				() -> assertNull(nullableText(input.get("pronunciation_band_from_audio"))),
+				() -> assertTrue(prompt.contains("assessment_type")),
+				() -> assertTrue(prompt.contains("average performance across all three Parts")),
+				() -> assertTrue(prompt.contains(RUBRIC_START)),
+				() -> assertFalse(prompt.contains(INPUT_PLACEHOLDER)),
+				() -> assertFalse(prompt.contains(RUBRIC_PLACEHOLDER)));
+	}
+
+	@Test
+	void wrapsJacksonSerializationFailureAsTemplateInvalid() {
+		ObjectMapper failingMapper = spy(new ObjectMapper());
+		JacksonException cause = new JacksonException("serialization failed") { };
+		when(failingMapper.writeValueAsString(org.mockito.ArgumentMatchers.any()))
+				.thenThrow(cause);
+		IeltsEvaluationPromptBuilder failingBuilder =
+				new IeltsEvaluationPromptBuilder(failingMapper);
+
+		EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> failingBuilder.buildFinal("a valid complete transcript", null, "6.5"));
+
+		assertAll(
+				() -> assertEquals(
+						EvaluationErrorCode.PROMPT_TEMPLATE_INVALID,
+						exception.errorCode()),
+				() -> assertEquals(cause, exception.getCause()));
+	}
+
+	@Test
+	void rejectsPartTemplateMissingEitherRequiredPlaceholder() throws Exception {
+		try (MockedConstruction<ClassPathResource> ignored = mockResources(
+				"reviewed template without input slot",
+				"reviewed rubric")) {
+			EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildPart(
+						IeltsPart.PART_1, "Candidate: an answer.", null, null));
+
+			assertEquals(
+					EvaluationErrorCode.PROMPT_TEMPLATE_INVALID,
+					exception.errorCode());
+		}
+	}
+
+	@Test
+	void rejectsRubricContainingAPlaceholder() throws Exception {
+		try (MockedConstruction<ClassPathResource> ignored = mockResources(
+				INPUT_PLACEHOLDER + "\n" + RUBRIC_PLACEHOLDER,
+				"rubric containing " + INPUT_PLACEHOLDER)) {
+			EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildFinal("a complete transcript", null, "6.0"));
+
+			assertEquals(
+					EvaluationErrorCode.PROMPT_TEMPLATE_INVALID,
+					exception.errorCode());
+		}
+	}
+
+	@Test
+	void rejectsBlankRubric() throws Exception {
+		try (MockedConstruction<ClassPathResource> ignored = mockResources(
+				INPUT_PLACEHOLDER + "\n" + RUBRIC_PLACEHOLDER,
+				" \n\t ")) {
+			EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildFinal("a complete transcript", null, "6.0"));
+
+			assertEquals(
+					EvaluationErrorCode.PROMPT_TEMPLATE_INVALID,
+					exception.errorCode());
+		}
+	}
+
+	@Test
+	void translatesTemplateReadFailureToTemplateInvalid() throws Exception {
+		try (MockedConstruction<ClassPathResource> ignored =
+				mockResourcesWithReadFailure()) {
+			EvaluationException exception = assertThrows(
+				EvaluationException.class,
+				() -> builder.buildFinal("a complete transcript", null, "6.0"));
+
+			assertAll(
+					() -> assertEquals(
+							EvaluationErrorCode.PROMPT_TEMPLATE_INVALID,
+							exception.errorCode()),
+					() -> assertTrue(exception.getCause() instanceof IOException));
+		}
+	}
+
+	private static MockedConstruction<ClassPathResource> mockResources(
+			String template,
+			String rubric) throws Exception {
+		return org.mockito.Mockito.mockConstruction(
+				ClassPathResource.class,
+				(mock, context) -> {
+					String path = (String) context.arguments().get(0);
+					when(mock.getContentAsString(StandardCharsets.UTF_8))
+							.thenReturn(path.endsWith("official-text-rubric-v1.txt")
+									? rubric
+									: template);
+				});
+	}
+
+	private static MockedConstruction<ClassPathResource>
+			mockResourcesWithReadFailure() throws Exception {
+		return org.mockito.Mockito.mockConstruction(
+				ClassPathResource.class,
+				(mock, context) -> when(mock.getContentAsString(StandardCharsets.UTF_8))
+						.thenThrow(new IOException("resource unavailable")));
+	}
+
+	private JsonNode inputJson(String prompt) throws Exception {
+		int start = prompt.indexOf(OPEN) + OPEN.length();
+		int end = prompt.indexOf(CLOSE, start);
+		assertTrue(start >= OPEN.length());
+		assertTrue(end > start);
+		return objectMapper.readTree(prompt.substring(start, end).strip());
+	}
+
+	private static String nullableText(JsonNode node) {
+		return node == null || node.isNull() ? null : node.asString();
+	}
+
+	private static String partEvidence(IeltsPart part) {
+		if (part == IeltsPart.PART_1) {
+			return "does not need a formal introduction";
+		}
+		if (part == IeltsPart.PART_2) {
+			return "Cue-card bullets are prompts, not a mandatory checklist";
+		}
+		return "Score language performance, not whether the opinion";
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/recording/RecordingStoreCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/recording/RecordingStoreCoverageTest.java
@@ -1,0 +1,306 @@
+package com.unispeaking.component.recording;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.domain.po.session.PracticeSessionRecord;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import com.unispeaking.infrastructure.config.RecordingProperties;
+import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
+import com.unispeaking.service.auth.AuthService;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.regex.Pattern;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class RecordingStoreCoverageTest {
+
+	@TempDir
+	Path tempDirectory;
+
+	@Test
+	void coversConstructorDefaultsAndIeltsCompatibilityMethods() throws Exception {
+		PracticeSessionRepository repository = mock(PracticeSessionRepository.class);
+		AuthService authService = mock(AuthService.class);
+		RecordingStore store = newStore(
+				repository,
+				authService,
+				Set.of(SceneType.IELTS_SCENE),
+				null,
+				null,
+			null,
+			null);
+		UUID ownerId = UUID.randomUUID();
+		when(authService.requireUserId(null)).thenReturn(ownerId.toString());
+		when(repository.findBySessionId("session-1")).thenReturn(Optional.of(
+				new PracticeSessionRecord(
+						"session-1",
+						ownerId,
+						null,
+						SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED,
+						Instant.now(),
+						Instant.now())));
+
+		assertEquals(
+				"session-1/turn-1.wav",
+				store.store("session-1", 1, new byte[] {1, 2}));
+		assertArrayEquals(
+				new byte[] {1, 2},
+				store.loadOwned("session-1", "turn-1.wav")
+						.getInputStream()
+						.readAllBytes());
+		assertEquals(
+				"IELTS_RECORDING_PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("session-1", 0, new byte[] {1})));
+		assertEquals(
+				"IELTS_RECORDING_NOT_FOUND",
+				assertBusinessCode(() -> store.loadOwned("session-1", "session.wav")));
+		verify(authService).requireUserId(null);
+		verify(repository).findBySessionId("session-1");
+
+		store.delete("session-1", 1);
+		assertFalse(Files.exists(tempDirectory.resolve("session-1/turn-1.wav")));
+		assertDoesNotThrow(() -> store.delete("session-1", 0));
+		assertDoesNotThrow(() -> store.delete("session-1", -1));
+	}
+
+	@Test
+	void loadsOwnedRecordingOnlyAfterOwnerAndSceneChecks() throws Exception {
+		UUID ownerId = UUID.randomUUID();
+		PracticeSessionRepository repository = mock(PracticeSessionRepository.class);
+		AuthService authService = mock(AuthService.class);
+		when(authService.requireUserId(null)).thenReturn(ownerId.toString());
+		when(repository.findBySessionId("session-1")).thenReturn(Optional.of(
+				new PracticeSessionRecord(
+						"session-1",
+						ownerId,
+						"scene-1",
+						SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED,
+						Instant.now(),
+						Instant.now())));
+		RecordingStore store = newStore(
+				repository,
+				authService,
+				Set.of(SceneType.IELTS_SCENE),
+				"/api/ielts/recordings/",
+				RecordingStore.TURN_FILE_NAME,
+				"NOT_FOUND",
+				"PERSISTENCE_FAILED");
+		store.store("session-1", 2, new byte[] {3, 4});
+
+		assertArrayEquals(
+				new byte[] {3, 4},
+				store.loadOwned("session-1", "turn-2.wav")
+						.getInputStream()
+						.readAllBytes());
+		assertEquals(
+				"NOT_FOUND",
+				assertBusinessCode(() -> store.loadOwned("session-1", "missing.wav")));
+		when(repository.findBySessionId("session-2")).thenReturn(Optional.empty());
+		assertEquals(
+				"NOT_FOUND",
+				assertBusinessCode(() -> store.loadOwned("session-2", "turn-1.wav")));
+	}
+
+	@Test
+	void rejectsNullBlankTraversalAndOverlongAudioKeysWithoutOwnershipLookup() {
+		PracticeSessionRepository repository = mock(PracticeSessionRepository.class);
+		AuthService authService = mock(AuthService.class);
+		RecordingStore store = newStore(
+				repository,
+			authService,
+			Set.of(SceneType.IELTS_SCENE),
+			"/api/ielts/recordings/",
+			RecordingStore.TURN_FILE_NAME,
+			"NOT_FOUND",
+			"PERSISTENCE_FAILED");
+
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn(null, 1, new byte[] {1})));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn(" ", 1, new byte[] {1})));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("../escape", 1, new byte[] {1})));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("a".repeat(161), 1, new byte[] {1})));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.readAudio("../escape", "turn-1.wav")));
+		assertEquals(
+				"NOT_FOUND",
+				assertBusinessCode(() -> store.loadOwned("session-1", null)));
+		assertEquals(
+				"NOT_FOUND",
+				assertBusinessCode(() -> store.loadOwned("session-1", "../turn-1.wav")));
+		assertFalse(store.hasAudio("session-1", null));
+		assertFalse(store.hasAudio("session-1", "../turn-1.wav"));
+		assertFalse(store.hasAudio(null, "turn-1.wav"));
+		verify(authService, never()).requireUserId(null);
+		verify(repository, never()).findBySessionId("session-1");
+	}
+
+	@Test
+	void validatesAudioKeysAndReadsMissingOrNonRegularFilesAsNull() throws Exception {
+		RecordingStore store = newStore();
+		assertNull(store.readAudio("session-1", null));
+		assertNull(store.readAudio("session-1", ""));
+		assertNull(store.readAudio("session-1", "session.wav"));
+		assertNull(store.readAudio("session-1", "turn-0.wav"));
+		assertNull(store.readAudio("session-1", "turn-1.txt"));
+
+		Path sessionDirectory = Files.createDirectories(
+				tempDirectory.resolve("session-1/turn-2.wav"));
+		assertTrue(Files.isDirectory(sessionDirectory));
+		assertNull(store.readAudio("session-1", "turn-2.wav"));
+		assertFalse(store.hasAudio("session-1", "turn-2.wav"));
+	}
+
+	@Test
+	void storesReplacesAndDeletesTurnAiAndSessionAudio() throws Exception {
+		RecordingStore store = newStore();
+		assertEquals("turn-4.wav", store.storeTurn("session-1", 4, new byte[] {1}));
+		assertEquals("turn-4.wav", store.storeTurn("session-1", 4, new byte[] {2, 3}));
+		String aiKey = store.storeAiAudio("session-1", new byte[] {4, 5});
+		store.storeSessionAudio("session-1", new byte[] {6, 7});
+
+		assertTrue(Pattern.matches("ai-[A-Za-z0-9_-]+\\.wav", aiKey));
+		assertTrue(store.hasAudio("session-1", "turn-4.wav"));
+		assertArrayEquals(new byte[] {2, 3}, store.readAudio("session-1", "turn-4.wav"));
+		assertArrayEquals(new byte[] {4, 5}, store.readAudio("session-1", aiKey));
+		assertArrayEquals(new byte[] {6, 7}, store.readAudio("session-1", "session.wav"));
+
+		store.deleteSessionAudio("session-1");
+		assertFalse(Files.exists(tempDirectory.resolve("session-1")));
+	}
+
+	@Test
+	void returnsPersistenceFailureWhenRootCannotBeUsedAsDirectory() {
+		Path rootFile = tempDirectory.resolve("recordings-file");
+		assertDoesNotThrow(() -> Files.write(rootFile, new byte[] {9}));
+		RecordingProperties properties = properties(rootFile);
+		RecordingStore store = new RecordingStore(
+				properties,
+				mock(PracticeSessionRepository.class),
+				mock(AuthService.class),
+				Set.of(SceneType.INTERVIEW_SCENE),
+				"/api/interview-scenes/",
+				RecordingStore.INTERVIEW_FILE_NAME,
+				"NOT_FOUND",
+				"PERSISTENCE_FAILED");
+
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("session-1", 1, new byte[] {1})));
+		assertNull(store.readAudio("session-1", "turn-1.wav"));
+		assertFalse(store.hasAudio("session-1", "turn-1.wav"));
+	}
+
+	@Test
+	void cleanupHandlesRecursiveDirectoriesExpiredFilesFreshFilesAndMissingTargets() throws Exception {
+		RecordingStore store = newStore();
+		store.storeTurn("session-1", 1, new byte[] {1});
+		store.storeTurn("session-1", 2, new byte[] {2});
+		Path stale = tempDirectory.resolve("session-1/turn-1.wav");
+		Path fresh = tempDirectory.resolve("session-1/turn-2.wav");
+		Files.setLastModifiedTime(
+				stale,
+				FileTime.from(Instant.now().minus(Duration.ofDays(3))));
+		Files.setLastModifiedTime(
+				fresh,
+				FileTime.from(Instant.now()));
+		Files.createDirectories(tempDirectory.resolve("session-1/nested"));
+		Files.write(tempDirectory.resolve("session-1/nested/ignored.txt"), new byte[] {3});
+		Files.write(tempDirectory.resolve("not-a-session-file"), new byte[] {4});
+
+		store.cleanupExpired(Duration.ofDays(1));
+
+		assertFalse(Files.exists(stale));
+		assertTrue(Files.exists(fresh));
+		assertTrue(Files.exists(tempDirectory.resolve("session-1/nested/ignored.txt")));
+		assertDoesNotThrow(() -> store.deleteSessionAudio("missing-session"));
+		assertDoesNotThrow(() -> store.deleteSessionAudio(null));
+		assertDoesNotThrow(() -> store.deleteSessionAudio("../escape"));
+		assertDoesNotThrow(() -> store.cleanupExpired(null));
+		assertDoesNotThrow(() -> store.cleanupExpired(Duration.ZERO));
+		assertDoesNotThrow(() -> store.cleanupExpired(Duration.ofSeconds(-1)));
+	}
+
+	@Test
+	void acceptsBoundarySessionIdAndRejectsInvalidIdentifierCharacters() {
+		RecordingStore store = newStore();
+		String maximumSessionId = "a".repeat(160);
+		assertEquals(
+				"turn-1.wav",
+				store.storeTurn(maximumSessionId, 1, new byte[] {1}));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("session/id", 1, new byte[] {1})));
+		assertEquals(
+				"PERSISTENCE_FAILED",
+				assertBusinessCode(() -> store.storeTurn("session.with.dot", 1, new byte[] {1})));
+	}
+
+	private String assertBusinessCode(Runnable action) {
+		return assertThrows(BusinessException.class, action::run).code();
+	}
+
+	private RecordingStore newStore() {
+		return newStore(
+				mock(PracticeSessionRepository.class),
+				mock(AuthService.class),
+				Set.of(SceneType.INTERVIEW_SCENE),
+				"/api/interview-scenes/",
+				RecordingStore.INTERVIEW_FILE_NAME,
+				"NOT_FOUND",
+				"PERSISTENCE_FAILED");
+	}
+
+	private RecordingStore newStore(
+			PracticeSessionRepository repository,
+			AuthService authService,
+			Set<SceneType> allowedSceneTypes,
+			String apiPrefix,
+			Pattern safeFileName,
+			String notFoundCode,
+			String persistenceFailedCode) {
+		return new RecordingStore(
+				properties(tempDirectory),
+				repository,
+				authService,
+				allowedSceneTypes,
+				apiPrefix,
+				safeFileName,
+				notFoundCode,
+				persistenceFailedCode);
+	}
+
+	private RecordingProperties properties(Path directory) {
+		RecordingProperties properties = new RecordingProperties();
+		properties.setDirectory(directory.toString());
+		return properties;
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/report/InterviewReportCoordinatorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/report/InterviewReportCoordinatorTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.component.report;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -8,6 +9,7 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -41,6 +43,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
+import java.util.ArrayList;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -234,6 +237,360 @@ class InterviewReportCoordinatorTest {
 		assertTrue(prompt.getValue().contains("property names and score values"));
 	}
 
+	@Test
+	void redispatchesOnlyExpiredProcessingReports() {
+		List<Runnable> queued = new java.util.ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore, queued::add, new ObjectMapper());
+		when(reportRepository.findById(SESSION_ID)).thenReturn(Optional.of(
+				record(ReportStatus.PROCESSING, 0, OffsetDateTime.now(ZoneOffset.UTC).minusMinutes(3))));
+
+		queuedCoordinator.redispatchIfStale(SESSION_ID, SCENE_ID, USER_ID);
+
+		assertEquals(1, queued.size());
+	}
+
+	@Test
+	void doesNotRedispatchFreshOrTerminalReports() {
+		List<Runnable> queued = new java.util.ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore, queued::add, new ObjectMapper());
+		when(reportRepository.findById(SESSION_ID))
+				.thenReturn(Optional.of(record(ReportStatus.PROCESSING, 0, OffsetDateTime.now(ZoneOffset.UTC))))
+				.thenReturn(Optional.of(record(ReportStatus.COMPLETED, 0, null)));
+
+		queuedCoordinator.redispatchIfStale(SESSION_ID, SCENE_ID, USER_ID);
+		queuedCoordinator.redispatchIfStale(SESSION_ID, SCENE_ID, USER_ID);
+
+		assertTrue(queued.isEmpty());
+	}
+
+	@Test
+	void sweepsEveryStuckReportAndIgnoresRepositoryFailure() {
+		List<Runnable> queued = new java.util.ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore, queued::add, new ObjectMapper());
+		when(reportRepository.findStuckProcessingBefore(any())).thenReturn(List.of(
+				record(ReportStatus.PROCESSING, 0),
+				new InterviewReportRecord("session-2", SCENE_ID, USER_ID, ReportStatus.PROCESSING,
+					null, null, null, null, null, null, null, null, null, null, null, null, null,
+					null, null, null, null, 0, null, null, null)));
+
+		queuedCoordinator.sweepStuckProcessing();
+		assertEquals(2, queued.size());
+
+		when(reportRepository.findStuckProcessingBefore(any())).thenThrow(new IllegalStateException("db down"));
+		queuedCoordinator.sweepStuckProcessing();
+		assertEquals(2, queued.size());
+	}
+
+	@Test
+	void responseContainsReportOnlyForCompletedRecord() {
+		InterviewReportRecord completed = new InterviewReportRecord(
+				SESSION_ID, SCENE_ID, USER_ID, ReportStatus.COMPLETED, new BigDecimal("81.0"),
+				"summary", new BigDecimal("80.0"), "fluency", "advice", new BigDecimal("79.0"),
+				"pronunciation", "advice", new BigDecimal("78.0"), "logic", "advice",
+				new BigDecimal("77.0"), "grammar", "advice", new BigDecimal("76.0"),
+				"vocabulary", "advice", 0, null, OffsetDateTime.now(ZoneOffset.UTC),
+				OffsetDateTime.now(ZoneOffset.UTC));
+
+		assertEquals(5, coordinator.toResponse(completed).report().dimensions().size());
+		assertFalse(coordinator.toResponse(record(ReportStatus.FAILED, 0)).report() != null);
+	}
+
+	@Test
+	void rejectsDuplicateSubmissionAndCleansUpRejectedExecutorSubmission() {
+		List<Runnable> queued = new java.util.ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore, queued::add, new ObjectMapper());
+
+		queuedCoordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+		queuedCoordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+		assertEquals(1, queued.size());
+
+		InterviewReportCoordinator rejectedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore,
+				command -> { throw new java.util.concurrent.RejectedExecutionException("full"); },
+				new ObjectMapper());
+		rejectedCoordinator.submit("rejected", SCENE_ID, USER_ID);
+		verifyNoInteractionsForSession("rejected");
+	}
+
+	@Test
+	void acceptsFencedLlmJsonAndFallsBackWhenSceneTopicsAreUnavailable() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID)).thenReturn(List.of());
+		when(sessionMessageRepository.findMessages(SESSION_ID))
+				.thenReturn(List.of(new Message(1, "candidate answer", null)));
+		when(sceneRepository.findById(SCENE_ID)).thenReturn(Optional.empty());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed("```json\n" + validLlmJson().strip() + "\n```"));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		ArgumentCaptor<InterviewReportRecord> completed = ArgumentCaptor.forClass(InterviewReportRecord.class);
+		verify(reportRepository).markCompleted(completed.capture());
+		assertTrue(completed.getValue().summary().contains("无可用录音"));
+	}
+
+	@Test
+	void rejectsInvalidLlmFieldsWithoutPersistingCompletedReport() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID)).thenReturn(List.of());
+		when(sessionMessageRepository.findMessages(SESSION_ID))
+				.thenReturn(List.of(new Message(1, "candidate answer", null)));
+		when(sceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(sceneDefinition()));
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validLlmJson().replace("\"overall_score\": 80", "\"overall_score\": 101")));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository).markFailed(SESSION_ID, "LLM_UNPARSEABLE");
+		verify(reportRepository, never()).markCompleted(any());
+	}
+
+	@Test
+	void retriesProviderFailureAndResubmitsOnlyAfterTheFirstTaskLeavesRunningSet() {
+		List<Runnable> queued = new ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository,
+				sessionMessageRepository,
+				sceneRepository,
+				pronunciationClient,
+				providerRegistry,
+				recordingStore,
+				queued::add,
+				new ObjectMapper());
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenReturn(List.of(turn(1, "first transcript")))
+				.thenReturn(List.of());
+		when(recordingStore.readAudio(SESSION_ID, "turn-1.wav"))
+				.thenReturn(wavWithSampleRate(16_000));
+		when(pronunciationClient.evaluate(anyString(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_NOT_CONFIGURED));
+		when(reportRepository.findById(SESSION_ID))
+				.thenReturn(Optional.of(record(ReportStatus.PROCESSING, 0)))
+				.thenReturn(Optional.of(record(ReportStatus.FAILED, 0)))
+				.thenReturn(Optional.of(record(ReportStatus.PROCESSING, 1)));
+		when(reportRepository.retryFromFailed(SESSION_ID, 0)).thenReturn(true);
+		when(sessionMessageRepository.findMessages(SESSION_ID)).thenReturn(List.of());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validLlmJson()));
+
+		queuedCoordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+		assertEquals(1, queued.size());
+		Runnable firstTask = queued.removeFirst();
+		firstTask.run();
+
+		assertEquals(1, queued.size());
+		queued.removeFirst().run();
+		verify(reportRepository).retryFromFailed(SESSION_ID, 0);
+		verify(reportRepository).markCompleted(any(InterviewReportRecord.class));
+	}
+
+	@Test
+	void mapsUnexpectedProcessingFailureToProviderRetryable() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenThrow(new IllegalStateException("database unavailable"));
+		when(reportRepository.findById(SESSION_ID)).thenReturn(Optional.empty());
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository).markFailed(SESSION_ID, "PROVIDER_RETRYABLE");
+		verify(reportRepository, never()).retryFromFailed(anyString(), any(Integer.class));
+	}
+
+	@Test
+	void stopsWhenMarkingFailureThrowsAndDoesNotAttemptRetry() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenThrow(new IllegalStateException("database unavailable"));
+		doThrow(new IllegalStateException("write unavailable"))
+				.when(reportRepository).markFailed(SESSION_ID, "PROVIDER_RETRYABLE");
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository, never()).retryFromFailed(anyString(), any(Integer.class));
+	}
+
+	@Test
+	void doesNotRetryWhenReportIsMissingTerminalOrAlreadyRetried() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenThrow(new IllegalStateException("temporary"));
+		when(reportRepository.findById(SESSION_ID))
+				.thenReturn(Optional.empty())
+				.thenReturn(Optional.of(record(ReportStatus.COMPLETED, 0)))
+				.thenReturn(Optional.of(record(ReportStatus.FAILED, 1)));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository, never()).retryFromFailed(anyString(), any(Integer.class));
+	}
+
+	@Test
+	void keepsProcessingWhenRetryCasReturnsFalse() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenThrow(new IllegalStateException("temporary"));
+		when(reportRepository.findById(SESSION_ID))
+				.thenReturn(Optional.of(record(ReportStatus.FAILED, 0)));
+		when(reportRepository.retryFromFailed(SESSION_ID, 0)).thenReturn(false);
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository).retryFromFailed(SESSION_ID, 0);
+	}
+
+	@Test
+	void ignoresAutoRetryRepositoryFailure() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenThrow(new IllegalStateException("temporary"));
+		when(reportRepository.findById(SESSION_ID))
+				.thenThrow(new IllegalStateException("database unavailable"));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(reportRepository, never()).retryFromFailed(anyString(), any(Integer.class));
+	}
+
+	@Test
+	void skipsBlankMissingAndInvalidAudioBeforeCallingPronunciationProvider() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenReturn(List.of(
+						new LearnerMessageRecord(1, "blank key", " "),
+						new LearnerMessageRecord(2, "missing audio", "missing.wav"),
+						new LearnerMessageRecord(3, "bad wav", "bad.wav")));
+		when(recordingStore.readAudio(SESSION_ID, "missing.wav")).thenReturn(null);
+		when(recordingStore.readAudio(SESSION_ID, "bad.wav"))
+				.thenReturn(new byte[] {1, 2, 3});
+		when(sessionMessageRepository.findMessages(SESSION_ID)).thenReturn(List.of());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validLlmJson()));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		verify(pronunciationClient, never()).evaluate(anyString(), any());
+		ArgumentCaptor<InterviewReportRecord> completed = ArgumentCaptor.forClass(InterviewReportRecord.class);
+		verify(reportRepository).markCompleted(completed.capture());
+		assertTrue(completed.getValue().summary().contains("无可用录音"));
+	}
+
+	@Test
+	void degradesWhenProviderReturnsAnIncompleteAssessment() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenReturn(List.of(turn(1, "first transcript")));
+		when(recordingStore.readAudio(SESSION_ID, "turn-1.wav"))
+				.thenReturn(wavWithSampleRate(16_000));
+		when(pronunciationClient.evaluate(anyString(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_RESPONSE_INCOMPLETE));
+		when(reportRepository.findById(SESSION_ID)).thenReturn(Optional.of(record(ReportStatus.PROCESSING, 1)));
+		when(sessionMessageRepository.findMessages(SESSION_ID)).thenReturn(List.of());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validLlmJson()));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		ArgumentCaptor<InterviewReportRecord> completed = ArgumentCaptor.forClass(InterviewReportRecord.class);
+		verify(reportRepository).markCompleted(completed.capture());
+		assertNull(completed.getValue().fluencyScore());
+		assertTrue(completed.getValue().summary().contains("服务暂不可用"));
+	}
+
+	@Test
+	void countsUnexpectedAudioProviderExceptionsAsFailedTurns() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(SESSION_ID))
+				.thenReturn(List.of(turn(1, "first transcript")));
+		when(recordingStore.readAudio(SESSION_ID, "turn-1.wav"))
+				.thenReturn(wavWithSampleRate(16_000));
+		when(pronunciationClient.evaluate(anyString(), any()))
+				.thenThrow(new IllegalStateException("provider bug"));
+		when(reportRepository.findById(SESSION_ID)).thenReturn(Optional.of(record(ReportStatus.PROCESSING, 1)));
+		when(sessionMessageRepository.findMessages(SESSION_ID)).thenReturn(List.of());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validLlmJson()));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		ArgumentCaptor<InterviewReportRecord> completed = ArgumentCaptor.forClass(InterviewReportRecord.class);
+		verify(reportRepository).markCompleted(completed.capture());
+		assertTrue(completed.getValue().summary().contains("有效语音不足"));
+	}
+
+	@Test
+	void readsOnlyTextTopicsAndFallsBackForMalformedSceneContext() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(anyString())).thenReturn(List.of());
+		when(sessionMessageRepository.findMessages(anyString())).thenReturn(List.of(new Message(1, "answer", null)));
+		when(sceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(new InterviewSceneDefinition(
+				SCENE_ID, USER_ID, "{}", "final", "{\"interviewTopics\":[\" topic \",\" \",3]}",
+				InterviewDifficulty.STANDARD, "prompt", OffsetDateTime.now(), OffsetDateTime.now(), null)));
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull())).thenReturn(routed(validLlmJson()));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		ArgumentCaptor<String> prompt = ArgumentCaptor.forClass(String.class);
+		verify(providerRegistry).executeLlmTaskRouted(prompt.capture(), isNull());
+		assertTrue(prompt.getValue().contains("- topic"));
+		assertFalse(prompt.getValue().contains("- 3"));
+
+		when(sceneRepository.findById(SCENE_ID)).thenReturn(Optional.of(new InterviewSceneDefinition(
+				SCENE_ID, USER_ID, "{}", "final", "not-json", InterviewDifficulty.STANDARD,
+				"prompt", OffsetDateTime.now(), OffsetDateTime.now(), null)));
+		coordinator.submit("session-2", SCENE_ID, USER_ID);
+		verify(providerRegistry, org.mockito.Mockito.atLeast(2)).executeLlmTaskRouted(anyString(), isNull());
+	}
+
+	@Test
+	void storesConcatenatedValidSessionAudioAndIgnoresStoreFailure() {
+		when(sessionMessageRepository.findMessagesWithAudioObjectKeys(anyString())).thenReturn(List.of(
+				turn(1, "first"), new LearnerMessageRecord(2, "second", "turn-2.wav"),
+				new LearnerMessageRecord(3, "invalid", "invalid.wav")));
+		byte[] first = wavWithSampleRate(16_000);
+		byte[] second = wavWithSampleRate(16_000);
+		when(recordingStore.readAudio(anyString(), eq("turn-1.wav"))).thenReturn(first);
+		when(recordingStore.readAudio(anyString(), eq("turn-2.wav"))).thenReturn(second);
+		when(recordingStore.readAudio(anyString(), eq("invalid.wav"))).thenReturn(new byte[] {1});
+		when(pronunciationClient.evaluate(anyString(), any())).thenReturn(validAssessment());
+		when(sessionMessageRepository.findMessages(anyString())).thenReturn(List.of());
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull())).thenReturn(routed(validLlmJson()));
+
+		coordinator.submit(SESSION_ID, SCENE_ID, USER_ID);
+
+		ArgumentCaptor<byte[]> stored = ArgumentCaptor.forClass(byte[].class);
+		verify(recordingStore).storeSessionAudio(eq(SESSION_ID), stored.capture());
+		assertEquals(48, stored.getValue().length);
+		assertEquals('R', stored.getValue()[0]);
+		assertEquals(16_000, littleEndianInt(stored.getValue(), 24));
+
+		doThrow(new IllegalStateException("storage unavailable"))
+				.when(recordingStore).storeSessionAudio(eq(SESSION_ID), any());
+		coordinator.submit("session-2", SCENE_ID, USER_ID);
+		verify(reportRepository, org.mockito.Mockito.atLeast(2)).markCompleted(any(InterviewReportRecord.class));
+	}
+
+	@Test
+	void coversNullAndFreshStatesWhenRedispatching() {
+		List<Runnable> queued = new ArrayList<>();
+		InterviewReportCoordinator queuedCoordinator = new InterviewReportCoordinator(
+				reportRepository, sessionMessageRepository, sceneRepository, pronunciationClient,
+				providerRegistry, recordingStore, queued::add, new ObjectMapper());
+		when(reportRepository.findById(SESSION_ID))
+				.thenReturn(Optional.empty())
+				.thenReturn(Optional.of(record(ReportStatus.PROCESSING, 0, null)));
+
+		queuedCoordinator.redispatchIfStale(SESSION_ID, SCENE_ID, USER_ID);
+		queuedCoordinator.redispatchIfStale(SESSION_ID, SCENE_ID, USER_ID);
+
+		assertEquals(1, queued.size());
+	}
+
+	private void verifyNoInteractionsForSession(String sessionId) {
+		verify(reportRepository, never()).markFailed(eq(sessionId), anyString());
+		verify(sessionMessageRepository, never()).findMessagesWithAudioObjectKeys(eq(sessionId));
+	}
+
 	private LearnerMessageRecord turn(int messageNo, String content) {
 		return new LearnerMessageRecord(
 				messageNo,
@@ -242,6 +599,13 @@ class InterviewReportCoordinatorTest {
 	}
 
 	private InterviewReportRecord record(ReportStatus status, int retryCount) {
+		return record(status, retryCount, null);
+	}
+
+	private InterviewReportRecord record(
+			ReportStatus status,
+			int retryCount,
+			OffsetDateTime updatedAt) {
 		return new InterviewReportRecord(
 				SESSION_ID,
 				SCENE_ID,
@@ -257,7 +621,7 @@ class InterviewReportCoordinatorTest {
 				retryCount,
 				null,
 				null,
-				null);
+				updatedAt);
 	}
 
 	private InterviewSceneDefinition sceneDefinition() {
@@ -336,5 +700,12 @@ class InterviewReportCoordinatorTest {
 		wav.putInt(2);
 		wav.putShort((short) 0);
 		return wav.array();
+	}
+
+	private int littleEndianInt(byte[] value, int offset) {
+		return (value[offset] & 0xff)
+				| ((value[offset + 1] & 0xff) << 8)
+				| ((value[offset + 2] & 0xff) << 16)
+				| ((value[offset + 3] & 0xff) << 24);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/scene/InterviewMaterialResponseNormalizerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/scene/InterviewMaterialResponseNormalizerTest.java
@@ -47,4 +47,75 @@ class InterviewMaterialResponseNormalizerTest {
 		assertTrue(result.errors().stream().anyMatch(value -> value.contains("qualificationRequirements")));
 		assertTrue(!result.valid());
 	}
+
+	@Test
+	void acceptsNestedMaterialAndNormalizesAllSupportedAliases() {
+		var result = normalizer.parse("""
+				{"material":{"position":"Engineer","duties":["- Build", "build", "* Test"],
+				"requirements":"Java; SQL","skills":["Java"],"additional_information":" remote ",
+				"educations":"本科\\n硕士","work_experience":["2 years"],"projects":["Demo"],
+				"abilities":["Communicate"],"experience_clues":["API"],"summary":"Done"}}
+				""");
+
+		assertTrue(result.valid(), result.errors().toString());
+		assertEquals("Engineer", result.material().jobTitle());
+		assertEquals(java.util.List.of("Build", "Test"), result.material().responsibilities());
+		assertEquals(java.util.List.of("Java", "SQL"), result.material().qualificationRequirements());
+		assertEquals("remote", result.material().otherJobInformation());
+		assertEquals("Done", result.material().finalText());
+	}
+
+	@Test
+	void reportsTypeErrorsAndKeepsOptionalInvalidValuesNull() {
+		var result = normalizer.parse("""
+				{"jobTitle":123,"responsibilities":{},"qualificationRequirements":[1,"valid"],
+				"requiredSkills":{},"finalText":false}
+				""");
+
+		assertTrue(result.errors().stream().anyMatch(error -> error.contains("jobTitle must be a string")));
+		assertTrue(result.errors().stream().anyMatch(error -> error.contains("responsibilities must be an array or string")));
+		assertTrue(result.errors().stream().anyMatch(error -> error.contains("requiredSkills must be an array or string")));
+		assertTrue(result.errors().stream().anyMatch(error -> error.contains("finalText must be a string")));
+		assertEquals(java.util.List.of("valid"), result.material().qualificationRequirements());
+	}
+
+	@Test
+	void truncatesItemsAndCapsListsWhileDeduplicatingCaseInsensitively() {
+		StringBuilder items = new StringBuilder("[");
+		for (int index = 0; index < 55; index++) {
+			if (index > 0) items.append(',');
+			items.append("\"Item").append(index).append("\"");
+		}
+		items.append(']');
+		var result = normalizer.parse("{\"responsibilities\":" + items
+				+ ",\"qualificationRequirements\":[\"" + "x".repeat(2100) + "\"]}");
+
+		assertTrue(result.valid());
+		assertEquals(50, result.material().responsibilities().size());
+		assertEquals(2000, result.material().qualificationRequirements().getFirst().length());
+	}
+
+	@Test
+	void handlesBlankMalformedAndNonObjectResponsesIncludingFences() {
+		assertTrue(normalizer.parse(null).errors().contains("response is blank"));
+		assertTrue(normalizer.parse("   ").errors().contains("response is blank"));
+		assertTrue(normalizer.parse("not json").errors().contains(
+				"response does not contain a valid JSON object"));
+		assertTrue(normalizer.parse("[1,2]").errors().contains(
+				"response does not contain a valid JSON object"));
+		assertTrue(normalizer.parse("```json\nnot json\n```").errors().stream()
+				.anyMatch(error -> error.contains("valid JSON object")));
+	}
+
+	@Test
+	void supportsQuotedBracesAndRejectsDuplicateKeysWithoutLosingValidExtractedObject() {
+		var valid = normalizer.parse("prefix {\"responsibilities\":[\"A {brace}\"],"
+				+ "\"qualificationRequirements\":[\"B\"]} suffix");
+		assertTrue(valid.valid(), valid.errors().toString());
+
+		var duplicate = normalizer.parse("{\"responsibilities\":[\"A\"],"
+				+ "\"responsibilities\":[\"B\"],\"qualificationRequirements\":[\"Q\"]}");
+		assertTrue(!duplicate.valid());
+		assertTrue(duplicate.errors().stream().anyMatch(error -> error.contains("valid JSON object")));
+	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/RealtimeSessionCoordinatorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/RealtimeSessionCoordinatorTest.java
@@ -1,25 +1,37 @@
 package com.unispeaking.component.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.SessionNotFoundException;
+import com.unispeaking.domain.dto.scene.SceneGenerationResponse;
 import com.unispeaking.domain.dto.session.StartSessionResponse;
 import com.unispeaking.domain.po.session.CustomSceneSession;
 import com.unispeaking.domain.vo.provider.ProviderType;
 import com.unispeaking.domain.vo.scene.IeltsContent;
 import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.domain.vo.scene.SceneFlowStage;
+import com.unispeaking.domain.vo.scene.SceneType;
 import com.unispeaking.domain.vo.session.RealtimeConnectionResult;
 import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
 import com.unispeaking.infrastructure.realtime.RealtimeSdpExchange;
+import com.unispeaking.infrastructure.realtime.RealtimeSessionTerminator;
 import java.time.Instant;
 import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 class RealtimeSessionCoordinatorTest {
+
+	private static final String USER_ID = "3d8f80be-6390-4db9-a6cf-c10a0145d4c3";
 
 	@Test
 	void bindsIeltsPartToSessionBeforeRealtimeConnection() {
@@ -75,5 +87,97 @@ class RealtimeSessionCoordinatorTest {
 				ProviderType.QINIU,
 				"qwen3.5-omni-plus-realtime",
 				"trace-1");
+	}
+
+	@Test
+	void requiresAnExistingSessionOwnedByAnAuthenticatedUser() {
+		ActiveSessionRegistry sessions = new ActiveSessionRegistry();
+		RealtimeSessionCoordinator coordinator = new RealtimeSessionCoordinator(
+			sessions, mock(PracticeSessionRepository.class), mock(RealtimeSdpExchange.class));
+
+		assertEquals("AUTHENTICATION_REQUIRED", assertThrows(BusinessException.class,
+				() -> coordinator.requireOwnedSession(" ", "missing")).code());
+		assertThrows(SessionNotFoundException.class,
+				() -> coordinator.requireOwnedSession(USER_ID, "missing"));
+
+		CustomSceneSession session = new CustomSceneSession("owned", USER_ID);
+		sessions.save(session);
+		assertSame(session, coordinator.requireOwnedSession(USER_ID, "owned"));
+		assertEquals("SESSION_ACCESS_DENIED", assertThrows(BusinessException.class,
+				() -> coordinator.requireOwnedSession(UUID.randomUUID().toString(), "owned")).code());
+	}
+
+	@Test
+	void connectsWithDefaultVoiceAndDoesNotBindBlankProviderSession() {
+		ActiveSessionRegistry sessions = new ActiveSessionRegistry();
+		CustomSceneSession session = new CustomSceneSession("connect-default", USER_ID);
+		sessions.save(session);
+		RealtimeSdpExchange exchange = mock(RealtimeSdpExchange.class);
+		PracticeSessionRepository practices = mock(PracticeSessionRepository.class);
+		when(exchange.exchangeSdp(any(), any(), any(), any())).thenReturn(
+				new RealtimeConnectionResult(null, ProviderType.QWEN, "model-1", " ",
+						"trace-1", "answer", null));
+		RealtimeSessionCoordinator coordinator = new RealtimeSessionCoordinator(
+				sessions, practices, exchange);
+
+		var result = coordinator.connect(
+				new SceneGenerationResponse("scene-1", List.of(), List.of(), List.of(), "prompt"),
+				"Scene", SceneFlowStage.DIALOGUE, false,
+				new StartSessionResponse(session.getId(), "2026-08-05T08:00:00Z"),
+				SceneType.CUSTOM_SCENE, "scene-1", "prompt", "offer", ProviderType.QWEN,
+				null, "  ", false);
+
+		assertEquals("Tina", result.voiceId());
+		assertEquals("answer", result.answerSdp());
+		assertEquals(null, result.providerSessionId());
+		assertEquals("Tina", session.getVoiceId());
+		assertEquals(com.unispeaking.domain.vo.session.SessionStatus.WAITING_CLIENT, session.getStatus());
+		verify(practices).updateRealtimeProvider(
+				eq(session.getId()), eq(UUID.fromString(USER_ID)), eq((String) null),
+				eq(ProviderType.QWEN), eq("model-1"), eq("trace-1"));
+	}
+
+	@Test
+	void retainsRequestedVoiceWhenProviderReturnsNoVoiceAndRemovesSessionAfterFailure() {
+		ActiveSessionRegistry sessions = new ActiveSessionRegistry();
+		CustomSceneSession session = new CustomSceneSession("connect-failed", USER_ID);
+		sessions.save(session);
+		RealtimeSdpExchange exchange = mock(RealtimeSdpExchange.class);
+		PracticeSessionRepository practices = mock(PracticeSessionRepository.class);
+		RealtimeSessionTerminator terminator = mock(RealtimeSessionTerminator.class);
+		RuntimeException failure = new IllegalStateException("exchange failed");
+		when(exchange.exchangeSdp(any(), any(), any(), any())).thenThrow(failure);
+		RealtimeSessionCoordinator coordinator = new RealtimeSessionCoordinator(
+				sessions, practices, exchange, terminator);
+
+		assertSame(failure, assertThrows(RuntimeException.class, () -> coordinator.connect(
+				new SceneGenerationResponse("scene-1", List.of(), List.of(), List.of(), "prompt"),
+				"Scene", SceneFlowStage.DIALOGUE, true,
+				new StartSessionResponse(session.getId(), "2026-08-05T08:00:00Z"),
+				SceneType.CUSTOM_SCENE, "scene-1", "prompt", "offer", ProviderType.QWEN,
+				"model", "Margaret", true)));
+
+		verify(terminator).stopBestEffort(session, "local_start_failed");
+		verify(practices).fail(eq(session.getId()), eq(UUID.fromString(USER_ID)), any());
+		assertEquals(com.unispeaking.domain.vo.session.SessionStatus.FAILED, session.getStatus());
+		assertEquals("Margaret", session.getVoiceId());
+		assertTrue(sessions.findById(session.getId()).isEmpty());
+	}
+
+	@Test
+	void removesAnActiveSessionExplicitlyAndReportsMissingIeltsSession() {
+		ActiveSessionRegistry sessions = new ActiveSessionRegistry();
+		CustomSceneSession session = new CustomSceneSession("to-remove", USER_ID);
+		sessions.save(session);
+		RealtimeSessionCoordinator coordinator = new RealtimeSessionCoordinator(
+				sessions, mock(PracticeSessionRepository.class), mock(RealtimeSdpExchange.class));
+
+		coordinator.remove(session.getId());
+		assertTrue(sessions.findById(session.getId()).isEmpty());
+		assertThrows(SessionNotFoundException.class, () -> coordinator.connectIelts(
+				new IeltsContent(List.of(), List.of(), List.of()), IeltsPart.PART_1,
+				"IELTS", SceneFlowStage.IELTS_PART_1, true,
+				new StartSessionResponse("missing", "2026-08-05T08:00:00Z"), "scene", "prompt",
+				"offer", ProviderType.QWEN, "model", "Tina", false));
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/SessionLifecycleManagerCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/SessionLifecycleManagerCoverageTest.java
@@ -1,0 +1,250 @@
+package com.unispeaking.component.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.component.policy.UserEntitlementPolicy;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.dto.session.SessionDetail;
+import com.unispeaking.domain.dto.session.StartSessionCommand;
+import com.unispeaking.domain.dto.session.StartSessionResponse;
+import com.unispeaking.domain.po.session.CustomSceneSession;
+import com.unispeaking.domain.po.session.FreeChatSceneSession;
+import com.unispeaking.domain.po.session.PracticeSessionRecord;
+import com.unispeaking.domain.vo.scene.IeltsPart;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
+import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class SessionLifecycleManagerCoverageTest {
+
+	private final UUID ownerId = UUID.randomUUID();
+	private final ActiveSessionRegistry sessions = new ActiveSessionRegistry();
+	private final SessionMessageRepository messages = mock(SessionMessageRepository.class);
+	private final PracticeSessionRepository practices = mock(PracticeSessionRepository.class);
+	private final UserEntitlementPolicy entitlement = mock(UserEntitlementPolicy.class);
+	private final SessionLifecycleManager lifecycle = new SessionLifecycleManager(
+			sessions, messages, practices, entitlement);
+
+	@Test
+	void startsIeltsPartSessionAndPersistsValidatedBinding() {
+		StartSessionResponse response = lifecycle.startSession(new StartSessionCommand(
+				ownerId.toString(),
+				"ielts-topic-1",
+				SceneType.IELTS_SCENE,
+				"PART2",
+				"Speak clearly"));
+
+		assertEquals("ielts_", response.sessionId().substring(0, 6));
+		assertEquals(IeltsPart.PART_2,
+				sessions.findById(response.sessionId()).orElseThrow().getIeltsPart());
+		ArgumentCaptor<PracticeSessionRecord> record =
+				ArgumentCaptor.forClass(PracticeSessionRecord.class);
+		verify(practices).create(record.capture());
+		assertEquals(ownerId, record.getValue().userId());
+		assertEquals("ielts-topic-1", record.getValue().sceneId());
+		verify(entitlement).assertAllowed(ownerId.toString());
+	}
+
+	@Test
+	void rejectsMissingCommandAndInvalidUserBeforePersistence() {
+		assertEquals("SESSION_COMMAND_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.startSession((StartSessionCommand) null)).code());
+		assertEquals("INVALID_USER_ID", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.startSession(
+						"not-a-uuid", SceneType.FREE_CHAT, "scene", "prompt")).code());
+		verify(practices, never()).create(any());
+	}
+
+	@Test
+	void compensatesActiveRegistryWhenDurableSessionCreationFails() {
+		CustomSceneSession session = customSession("session-compensation");
+		doThrow(new IllegalStateException("database unavailable"))
+				.when(practices).create(any());
+
+		assertThrows(IllegalStateException.class, () -> lifecycle.registerSceneSession(session));
+
+		assertFalse(sessions.findById(session.getId()).isPresent());
+	}
+
+	@Test
+	void completesAndFailsOwnedSessionsUsingTheMatchingPersistenceOperation() {
+		CustomSceneSession completed = customSession("session-completed");
+		sessions.save(completed);
+		Instant completedAt = Instant.parse("2026-08-20T06:00:00Z");
+
+		lifecycle.terminateSceneSession(
+				ownerId.toString(), completed.getId(), SessionStatus.COMPLETED, completedAt);
+
+		verify(practices).complete(completed.getId(), ownerId, completedAt);
+		verify(entitlement).recordUsage(ownerId.toString(), completed.getCreatedAt(), completedAt);
+		assertEquals(SessionStatus.COMPLETED, completed.getStatus());
+
+		CustomSceneSession failed = customSession("session-failed");
+		sessions.save(failed);
+		Instant failedAt = Instant.parse("2026-08-20T06:10:00Z");
+		lifecycle.terminateSceneSession(
+				ownerId.toString(), failed.getId(), SessionStatus.FAILED, failedAt);
+
+		verify(practices).fail(failed.getId(), ownerId, failedAt);
+		verify(entitlement, never()).recordUsage(
+				eq(ownerId.toString()), eq(failed.getCreatedAt()), eq(failedAt));
+		assertEquals(SessionStatus.FAILED, failed.getStatus());
+	}
+
+	@Test
+	void validatesTerminalStateAndOnlyPersistsMessagesForSceneSessions() {
+		CustomSceneSession session = customSession("session-message");
+		sessions.save(session);
+		assertEquals("INVALID_SESSION_TERMINAL_STATUS", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.terminateSceneSession(
+						ownerId.toString(), session.getId(), SessionStatus.ACTIVE, Instant.now())).code());
+
+		lifecycle.addMessage(ownerId.toString(), session.getId(), new Message(1, "  answer  ", null));
+		verify(messages).append("scene-1", session.getId(), 1, new Message(1, "  answer  ", null));
+		assertEquals(1, session.getMessages().size());
+
+		assertEquals("INVALID_SESSION_MESSAGE", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.addMessage(ownerId.toString(), session.getId(),
+						new Message(2, "invalid", null))).code());
+	}
+
+	@Test
+	void derivesIeltsStagesForPersistedSessionsThatAreNoLongerActive() {
+		Instant startedAt = Instant.parse("2026-08-20T05:00:00Z");
+		PracticeSessionRecord first = record("session-1", startedAt);
+		PracticeSessionRecord second = record("session-2", startedAt.plusSeconds(60));
+		when(practices.findBySceneId("ielts-topic-1")).thenReturn(List.of(first, second));
+		when(messages.findMessages("session-1")).thenReturn(List.of(new Message(0, "question", null)));
+		when(messages.findMessages("session-2")).thenReturn(List.of());
+
+		List<SessionDetail> details = lifecycle.getBySceneId("ielts-topic-1");
+
+		assertEquals(List.of("PART1", "PART2"), details.stream().map(SessionDetail::stage).toList());
+		assertEquals(1, details.getFirst().dialogue().size());
+	}
+
+	@Test
+	void coversStageNormalizationAndDefaultFreeChatSessionCreation() {
+		StartSessionResponse part3 = lifecycle.startSession(new StartSessionCommand(
+				ownerId.toString(), "ielts-topic-3", SceneType.IELTS_SCENE,
+				"PART3", "prompt"));
+		StartSessionResponse unknownPart = lifecycle.startSession(new StartSessionCommand(
+				ownerId.toString(), "ielts-topic-x", SceneType.IELTS_SCENE,
+				"PART4", "prompt"));
+		StartSessionResponse freeChat = lifecycle.startSession(
+				ownerId.toString(), null, "free-scene", " free prompt ");
+
+		assertEquals(IeltsPart.PART_3,
+				sessions.findById(part3.sessionId()).orElseThrow().getIeltsPart());
+		assertEquals(null,
+				sessions.findById(unknownPart.sessionId()).orElseThrow().getIeltsPart());
+		assertEquals(SceneType.FREE_CHAT,
+				sessions.findById(freeChat.sessionId()).orElseThrow().getSceneType());
+		assertEquals(" free prompt ",
+				sessions.findById(freeChat.sessionId()).orElseThrow().getPrompt().systemPrompt());
+	}
+
+	@Test
+	void rejectsAuthenticationPromptAndMessageBoundaryInputs() {
+		assertEquals("AUTHENTICATION_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.startSession(null, SceneType.FREE_CHAT, "scene", "prompt")).code());
+		assertEquals("SESSION_PROMPT_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.startSession(ownerId.toString(), SceneType.FREE_CHAT, "scene", " ")).code());
+
+		CustomSceneSession session = customSession("session-boundary");
+		sessions.save(session);
+		assertEquals("INVALID_SESSION_MESSAGE", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.addMessage(ownerId.toString(), session.getId(), null)).code());
+		assertEquals("INVALID_SESSION_MESSAGE", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.addMessage(ownerId.toString(), session.getId(),
+						new Message(2, "blank owner", null))).code());
+		assertEquals("INVALID_SESSION_MESSAGE", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.addMessage(ownerId.toString(), session.getId(),
+						new Message(null, "text", null))).code());
+	}
+
+	@Test
+	void keepsFreeChatMessagesEphemeralAndRejectsUnboundSceneMessages() {
+		FreeChatSceneSession freeChat = new FreeChatSceneSession("free-ephemeral", ownerId.toString());
+		freeChat.setSceneType(SceneType.FREE_CHAT);
+		freeChat.setSceneId("free-scene");
+		sessions.save(freeChat);
+		lifecycle.addMessage(ownerId.toString(), freeChat.getId(), new Message(0, "hello", null));
+		assertTrue(freeChat.getMessages().isEmpty());
+		verifyNoInteractions(messages);
+
+		CustomSceneSession unbound = new CustomSceneSession("scene-unbound", ownerId.toString());
+		unbound.setSceneType(SceneType.CUSTOM_SCENE);
+		sessions.save(unbound);
+		assertEquals("SESSION_SCENE_NOT_BOUND", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.addMessage(ownerId.toString(), unbound.getId(),
+						new Message(1, "answer", null))).code());
+	}
+
+	@Test
+	void resolvesSessionMetadataAndRejectsMissingOrMismatchedSessions() {
+		CustomSceneSession session = customSession("session-metadata");
+		sessions.save(session);
+
+		assertEquals(SceneType.INTERVIEW_SCENE,
+				lifecycle.requireSceneType(ownerId.toString(), session.getId()));
+		assertEquals(ownerId.toString(), lifecycle.requireOwnerId(session.getId()));
+		assertEquals("scene-1", lifecycle.requireSceneId(session.getId(), SceneType.INTERVIEW_SCENE));
+		assertEquals("SESSION_SCENE_TYPE_MISMATCH", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.requireSceneId(session.getId(), SceneType.FREE_CHAT)).code());
+		assertEquals("SESSION_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.getSession("missing")).code());
+		assertEquals("SESSION_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> lifecycle.requireOwnerId(" ")).code());
+	}
+
+	private CustomSceneSession customSession(String sessionId) {
+		CustomSceneSession session = new CustomSceneSession(sessionId, ownerId.toString());
+		session.setSceneId("scene-1");
+		session.setSceneType(SceneType.INTERVIEW_SCENE);
+		session.setPrompt(new com.unispeaking.domain.vo.session.SessionPrompt("prompt"));
+		return session;
+	}
+
+	private PracticeSessionRecord record(String sessionId, Instant startedAt) {
+		return new PracticeSessionRecord(
+				sessionId,
+				ownerId,
+				"ielts-topic-1",
+				SceneType.IELTS_SCENE,
+				SessionStatus.COMPLETED,
+				startedAt,
+				startedAt.plusSeconds(30));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/AuthTokenControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/AuthTokenControllerTest.java
@@ -1,0 +1,172 @@
+package com.unispeaking.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.anyString;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.response.ApiResponse;
+import com.unispeaking.infrastructure.config.WebOriginProperties;
+import com.unispeaking.domain.dto.auth.AuthResponse;
+import com.unispeaking.domain.dto.auth.MobileAuthResponse;
+import com.unispeaking.domain.dto.auth.UserAccountResponse;
+import com.unispeaking.domain.po.auth.UserRole;
+import com.unispeaking.domain.po.auth.UserStatus;
+import com.unispeaking.domain.vo.auth.IssuedJwt;
+import com.unispeaking.service.auth.RefreshTokenService;
+import jakarta.servlet.http.Cookie;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.springframework.http.HttpHeaders;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AuthTokenControllerTest {
+	@Test
+	void refreshWebRotatesCookieAndReturnsAccessResponse() {
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		WebOriginProperties origins = origins();
+		AuthTokenController controller = new AuthTokenController(service, false, origins);
+		Instant expiry = Instant.now().plusSeconds(600);
+		AuthResponse access = access("web-access", expiry);
+		when(service.refresh("web-refresh")).thenReturn(new RefreshTokenService.Result(
+				access, "next-refresh", expiry.plusSeconds(100)));
+		MockHttpServletRequest request = trustedRequest();
+		request.setCookies(new Cookie(AuthTokenController.COOKIE_NAME, "web-refresh"));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		var result = controller.refreshWeb(request, response);
+
+		assertEquals(200, result.getStatusCode().value());
+		assertEquals(access, result.getBody().data());
+		String cookie = response.getHeader(HttpHeaders.SET_COOKIE);
+		assertTrue(cookie.contains("us-learning-refresh=next-refresh"));
+		assertTrue(cookie.contains("HttpOnly"));
+		assertTrue(cookie.contains("SameSite=Lax"));
+		assertTrue(cookie.contains("Path=/api/auth/web/token"));
+		verify(service).refresh("web-refresh");
+	}
+
+	@Test
+	void refreshMobileReturnsRotatedAccessAndRefreshTokens() {
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		AuthTokenController controller = new AuthTokenController(service, false, origins());
+		Instant accessExpiry = Instant.now().plusSeconds(300);
+		Instant refreshExpiry = Instant.now().plusSeconds(3600);
+		AuthResponse access = access("mobile-access", accessExpiry);
+		when(service.refresh("mobile-refresh")).thenReturn(new RefreshTokenService.Result(
+				access, "mobile-next", refreshExpiry));
+
+		ApiResponse<MobileAuthResponse> result = controller.refreshMobile(
+				new com.unispeaking.domain.dto.auth.RefreshTokenRequest("mobile-refresh"));
+
+		assertEquals("mobile-access", result.data().accessToken());
+		assertEquals("mobile-next", result.data().refreshToken());
+		assertEquals(refreshExpiry, result.data().refreshTokenExpiresAt());
+		assertEquals(access.user(), result.data().user());
+		verify(service).refresh("mobile-refresh");
+	}
+	@Test
+	void rejectsWebRefreshWithoutTrustedOriginOrCookie() {
+		WebOriginProperties origins = new WebOriginProperties();
+		origins.setAllowedOriginPatterns(List.of("https://app.example.com"));
+		AuthTokenController controller = new AuthTokenController(
+				mock(RefreshTokenService.class), false, origins);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		assertEquals("AUTH_ORIGIN_INVALID", assertThrows(BusinessException.class,
+				() -> controller.refreshWeb(request, new MockHttpServletResponse())).code());
+		request.addHeader("Origin", "https://app.example.com");
+		assertEquals("REFRESH_TOKEN_INVALID", assertThrows(BusinessException.class,
+				() -> controller.refreshWeb(request, new MockHttpServletResponse())).code());
+	}
+
+	@Test
+	void revokeWebAcceptsRefererAndExpiresCookieWhenNoTokenExists() {
+		WebOriginProperties origins = new WebOriginProperties();
+		origins.setAllowedOriginPatterns(List.of("https://app.example.com"));
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		AuthTokenController controller = new AuthTokenController(service, true, origins);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Referer", "https://app.example.com");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		assertEquals(204, controller.revokeWeb(request, response).getStatusCode().value());
+		String setCookie = response.getHeader("Set-Cookie");
+		org.junit.jupiter.api.Assertions.assertTrue(setCookie.contains("us-learning-refresh="));
+		org.junit.jupiter.api.Assertions.assertTrue(setCookie.contains("Max-Age=0"));
+		org.junit.jupiter.api.Assertions.assertTrue(setCookie.contains("Secure"));
+		org.junit.jupiter.api.Assertions.assertTrue(setCookie.contains("HttpOnly"));
+	}
+
+	@Test
+	void revokeWebReadsOnlyTheConfiguredCookie() {
+		WebOriginProperties origins = new WebOriginProperties();
+		origins.setAllowedOriginPatterns(List.of("https://app.example.com"));
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		AuthTokenController controller = new AuthTokenController(service, false, origins);
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.setCookies(new Cookie("other", "value"),
+				new Cookie(AuthTokenController.COOKIE_NAME, "token"));
+		request.addHeader("Origin", "https://app.example.com");
+		MockHttpServletResponse response = new MockHttpServletResponse();
+		controller.revokeWeb(request, response);
+		org.mockito.Mockito.verify(service).revoke("token");
+	}
+
+	@Test
+	void revokeMobileDelegatesTokenAndInvalidOriginTakesPrecedenceOverReferer() {
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		AuthTokenController controller = new AuthTokenController(service, false, origins());
+		var result = controller.revokeMobile(new com.unispeaking.domain.dto.auth.RefreshTokenRequest("mobile-token"));
+		assertEquals(204, result.getStatusCode().value());
+		verify(service).revoke("mobile-token");
+
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Origin", "https://evil.example.com");
+		request.addHeader("Referer", "https://app.example.com");
+		assertEquals("AUTH_ORIGIN_INVALID", assertThrows(BusinessException.class,
+				() -> controller.revokeWeb(request, new MockHttpServletResponse())).code());
+	}
+
+	@Test
+	void acceptsWildcardOriginAndSecureRefreshCookie() {
+		RefreshTokenService service = mock(RefreshTokenService.class);
+		WebOriginProperties origins = new WebOriginProperties();
+		origins.setAllowedOriginPatterns(List.of("https://*.example.com"));
+		AuthTokenController controller = new AuthTokenController(service, true, origins);
+		Instant expiry = Instant.now().plusSeconds(600);
+		when(service.refresh("token")).thenReturn(new RefreshTokenService.Result(
+				access("access", expiry), "next", expiry));
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Origin", "https://sub.example.com");
+		request.setCookies(new Cookie(AuthTokenController.COOKIE_NAME, "token"));
+		MockHttpServletResponse response = new MockHttpServletResponse();
+
+		controller.refreshWeb(request, response);
+
+		assertTrue(response.getHeader(HttpHeaders.SET_COOKIE).contains("Secure"));
+	}
+
+	private static WebOriginProperties origins() {
+		WebOriginProperties origins = new WebOriginProperties();
+		origins.setAllowedOriginPatterns(List.of("https://app.example.com"));
+		return origins;
+	}
+
+	private static MockHttpServletRequest trustedRequest() {
+		MockHttpServletRequest request = new MockHttpServletRequest();
+		request.addHeader("Origin", "https://app.example.com");
+		return request;
+	}
+
+	private static AuthResponse access(String token, Instant expiry) {
+		return new AuthResponse("Bearer", token, expiry, new UserAccountResponse(
+				UUID.randomUUID(), "user@example.com", "User", UserRole.USER.name(),
+				UserStatus.ACTIVE.name(), Instant.now(), Instant.now()));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneCompletionEndpointTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneCompletionEndpointTest.java
@@ -1,17 +1,28 @@
 package com.unispeaking.controller;
 
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.GlobalExceptionHandler;
 import com.unispeaking.domain.dto.evaluation.DialogueReportResult;
+import com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationCommand;
+import com.unispeaking.domain.dto.scene.CustomSceneRequest;
+import com.unispeaking.domain.dto.scene.TranslateTextResponse;
 import com.unispeaking.domain.dto.session.CompleteCustomSceneDialogueResponse;
 import com.unispeaking.domain.dto.session.EndCustomSessionCommand;
+import com.unispeaking.domain.dto.session.StartCustomSceneDialogueRequest;
+import com.unispeaking.domain.dto.session.StartCustomSessionCommand;
+import com.unispeaking.domain.vo.provider.ProviderType;
 import com.unispeaking.service.asset.LearningAssetService;
 import com.unispeaking.service.evaluation.CustomEvaluationService;
 import com.unispeaking.service.scene.CustomSceneFlowService;
@@ -21,6 +32,7 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -98,5 +110,185 @@ class CustomSceneCompletionEndpointTest {
 						"custom_2001",
 						"scene_5001",
 						"2026-07-30T10:42:00Z"));
+	}
+
+	@Test
+	void startDialogueDelegatesSceneIdAndValidatedRealtimeRequest() throws Exception {
+		CustomSessionService sessions = mock(CustomSessionService.class);
+		when(sessions.startSession(eq(new StartCustomSessionCommand(
+				"custom_2001",
+				new com.unispeaking.domain.dto.session.StartCustomSceneDialogueRequest(
+						"offer-sdp", ProviderType.QWEN, "model", "voice", true)))))
+				.thenReturn(null);
+		CustomSceneController controller = controller(
+				mock(CustomSceneService.class), mock(CustomSceneFlowService.class),
+				mock(CustomEvaluationService.class), sessions,
+				mock(LearningAssetService.class));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(new GlobalExceptionHandler())
+				.build();
+
+		mvc.perform(post("/api/custom-scenes/custom_2001/sessions")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("""
+							{"offerSdp":"offer-sdp","provider":"QWEN","model":"model","voice":"voice","translationEnabled":true}
+							"""))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.success").value(true));
+
+		verify(sessions).startSession(eq(new StartCustomSessionCommand(
+				"custom_2001",
+				new StartCustomSceneDialogueRequest(
+						"offer-sdp", ProviderType.QWEN, "model", "voice", true))));
+	}
+
+	@Test
+	void evaluationAndSpeechEndpointsForwardMultipartAndTtsArguments() throws Exception {
+		CustomEvaluationService evaluation = mock(CustomEvaluationService.class);
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		when(scenes.synthesizeSpeech("custom_2001", "hello", "qwen-tts"))
+				.thenReturn(new byte[] {1, 2, 3});
+		CustomSceneController controller = controller(
+				scenes, mock(CustomSceneFlowService.class), evaluation,
+				mock(CustomSessionService.class), mock(LearningAssetService.class));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller).build();
+		MockMultipartFile audio = new MockMultipartFile(
+				"audio", "answer.wav", "audio/wav", new byte[] {4, 5});
+
+		mvc.perform(multipart(
+					"/api/custom-scenes/custom_2001/sessions/session_1/turns/2/evaluation")
+					.param("transcript", "hello")
+					.file(audio))
+				.andExpect(status().isOk());
+		mvc.perform(post("/api/custom-scenes/custom_2001/speech")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"text\":\"hello\",\"model\":\"qwen-tts\"}"))
+				.andExpect(status().isOk());
+
+		verify(evaluation).evaluateTurn(argThat(command ->
+				"session_1".equals(command.sessionId())
+						&& command.turnNo().equals(2)
+						&& "hello".equals(command.transcript())
+						&& java.util.Arrays.equals(command.audio(), new byte[] {4, 5})));
+		verify(scenes).synthesizeSpeech("custom_2001", "hello", "qwen-tts");
+	}
+
+	@Test
+	void sentenceEvaluationAndTranslationDelegateToTheirServices() throws Exception {
+		CustomEvaluationService evaluation = mock(CustomEvaluationService.class);
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		when(scenes.translate("custom_2001", "你好"))
+				.thenReturn(new TranslateTextResponse("你好", "hello", "en"));
+		CustomSceneController controller = controller(
+				scenes, mock(CustomSceneFlowService.class), evaluation,
+				mock(CustomSessionService.class), mock(LearningAssetService.class));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller).build();
+		MockMultipartFile audio = new MockMultipartFile(
+				"audio", "sentence.wav", "audio/wav", new byte[] {7});
+
+		mvc.perform(multipart("/api/custom-scenes/custom_2001/sentences/sentence_1/evaluation")
+					.file(audio))
+				.andExpect(status().isOk());
+		mvc.perform(post("/api/custom-scenes/custom_2001/translations")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"text\":\"你好\"}"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.translatedText").value("hello"));
+
+		verify(evaluation).evaluateSentence("sentence_1", new byte[] {7});
+		verify(scenes).translate("custom_2001", "你好");
+	}
+
+	@Test
+	void remainingEndpointsDelegateTheirArguments() {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		CustomEvaluationService evaluation = mock(CustomEvaluationService.class);
+		CustomSessionService sessions = mock(CustomSessionService.class);
+		LearningAssetService assets = mock(LearningAssetService.class);
+		CustomSceneController controller = controller(
+				scenes, mock(CustomSceneFlowService.class), evaluation,
+				sessions, assets);
+		CustomSceneRequest request = new CustomSceneRequest(
+				"user_1", "preference", "a cafe", null,
+				ProviderType.QWEN, "model", "voice", true);
+
+		controller.generate(request);
+		controller.completeDialogue("custom_2001", "session_1", null);
+		controller.getDialogueEvaluation("custom_2001", "session_1");
+		controller.listLearningAssets();
+		controller.getLearningAsset("custom_2001");
+
+		verify(scenes).generate(request);
+		verify(sessions).endSession(new EndCustomSessionCommand(
+				"custom_2001", "session_1", null));
+		verify(assets).getReport("custom_2001", "session_1");
+		verify(assets).listAssets();
+		verify(assets).getAsset("custom_2001");
+	}
+
+	@Test
+	void invalidValidatedRequestsReturnValidationErrorWithoutCallingServices() throws Exception {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		CustomSceneController controller = controller(
+				scenes, mock(CustomSceneFlowService.class),
+				mock(CustomEvaluationService.class), mock(CustomSessionService.class),
+				mock(LearningAssetService.class));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(new GlobalExceptionHandler())
+				.build();
+
+		mvc.perform(post("/api/custom-scenes/custom_2001/speech")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"text\":\"\"}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+		mvc.perform(post("/api/custom-scenes/custom_2001/translations")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"text\":\"\"}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+		mvc.perform(post("/api/custom-scenes/custom_2001/sessions")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"offerSdp\":\"\"}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.code").value("VALIDATION_ERROR"));
+
+		verify(scenes, never()).synthesizeSpeech(
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.any());
+		verify(scenes, never()).translate(
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.anyString());
+	}
+
+	@Test
+	void businessExceptionFromTranslationIsMappedByGlobalHandler() throws Exception {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		when(scenes.translate("custom_2001", "你好"))
+				.thenThrow(new BusinessException("SCENE_NOT_FOUND", "scene missing"));
+		CustomSceneController controller = controller(
+				scenes, mock(CustomSceneFlowService.class),
+				mock(CustomEvaluationService.class), mock(CustomSessionService.class),
+				mock(LearningAssetService.class));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(controller)
+				.setControllerAdvice(new GlobalExceptionHandler())
+				.build();
+
+		mvc.perform(post("/api/custom-scenes/custom_2001/translations")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"text\":\"你好\"}"))
+				.andExpect(status().isBadRequest())
+				.andExpect(jsonPath("$.success").value(false))
+				.andExpect(jsonPath("$.code").value("SCENE_NOT_FOUND"));
+	}
+
+	private CustomSceneController controller(
+			CustomSceneService scenes,
+			CustomSceneFlowService flow,
+			CustomEvaluationService evaluation,
+			CustomSessionService sessions,
+			LearningAssetService assets) {
+		return new CustomSceneController(scenes, flow, evaluation, sessions, assets);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneControllerFlowTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/CustomSceneControllerFlowTest.java
@@ -5,8 +5,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.unispeaking.domain.dto.scene.AdvanceSceneStageRequest;
+import com.unispeaking.domain.dto.scene.CompleteSceneFlowRequest;
+import com.unispeaking.domain.dto.scene.CreateSceneFlowRequest;
 import com.unispeaking.domain.dto.scene.SceneFlowResponse;
+import com.unispeaking.domain.dto.session.AdvanceScenarioDialogueTurnRequest;
+import com.unispeaking.domain.dto.scene.AdvanceSceneStageRequest;
 import com.unispeaking.domain.vo.scene.SceneFlowStage;
 import com.unispeaking.service.asset.LearningAssetService;
 import com.unispeaking.service.evaluation.CustomEvaluationService;
@@ -44,6 +47,67 @@ class CustomSceneControllerFlowTest {
 				SceneFlowStage.WORD_LEARNING);
 
 		verify(flow).content("scene_1", SceneFlowStage.WORD_LEARNING);
+	}
+
+	@Test
+	void createFlowStartsTheFlowBeforeReadingItsResponse() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneController controller = controller(flow);
+
+		controller.createFlow(new CreateSceneFlowRequest("scene_1"));
+
+		verify(flow).start("scene_1");
+		verify(flow).response("scene_1");
+	}
+
+	@Test
+	void advanceWithoutAStageUsesTheServerCurrentStage() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneController controller = controller(flow);
+
+		controller.advanceStage(new AdvanceSceneStageRequest("scene_1", null));
+
+		verify(flow).next("scene_1");
+		verify(flow, never()).next("scene_1", SceneFlowStage.WORD_LEARNING);
+		verify(flow).response("scene_1");
+	}
+
+	@Test
+	void completingAnIncompleteFlowAdvancesUntilCompletedThenClearsIt() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		when(flow.isCompleted("scene_1")).thenReturn(false, false, true);
+		CustomSceneController controller = controller(flow);
+
+		controller.completeFlow(new CompleteSceneFlowRequest("scene_1", true));
+
+		verify(flow, org.mockito.Mockito.times(2)).next("scene_1");
+		verify(flow).clear("scene_1");
+	}
+
+	@Test
+	void incompleteFlagDoesNotAdvanceOrClearTheFlow() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneController controller = controller(flow);
+
+		controller.completeFlow(new CompleteSceneFlowRequest("scene_1", false));
+
+		verify(flow, never()).isCompleted("scene_1");
+		verify(flow, never()).next("scene_1");
+		verify(flow, never()).clear("scene_1");
+	}
+
+	@Test
+	void dialogueStateEndpointsDelegateAllPathAndBodyParameters() {
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneController controller = controller(flow);
+		AdvanceScenarioDialogueTurnRequest request =
+				new AdvanceScenarioDialogueTurnRequest("answer");
+
+		controller.advanceDialogueState("scene_1", "session_1", 3, request);
+		controller.getDialogueState("scene_1", "session_1");
+
+		verify(flow).advanceDialogueState("scene_1", "session_1", 3, "answer");
+		verify(flow).getDialogueState("scene_1", "session_1");
 	}
 
 	private CustomSceneController controller(CustomSceneFlowService flow) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/IELTSSceneControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/IELTSSceneControllerTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
@@ -47,6 +49,7 @@ import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.mock.web.MockMultipartFile;
 
 class IELTSSceneControllerTest {
 
@@ -340,5 +343,107 @@ class IELTSSceneControllerTest {
 
 		verify(sessionService).startSession(
 				new StartIeltsSessionCommand("ielts_123", request));
+	}
+
+	@Test
+	void updatesSettingsAndIncludesStreakFields() throws Exception {
+		IeltsSceneService sceneService = mock(IeltsSceneService.class);
+		IeltsEvaluationService evaluationService = mock(IeltsEvaluationService.class);
+		var settings = new IeltsSettingsResponse(
+				new BigDecimal("7.5"), 3, "id-2", "Katerina", null,
+				4, 12, java.time.LocalDate.parse("2026-08-21"));
+		when(sceneService.updateSettings(new com.unispeaking.domain.dto.scene.UpdateIeltsSettingsRequest(
+				new BigDecimal("7.5"), "id-2"))).thenReturn(settings);
+		when(evaluationService.getLatestEstimatedScore()).thenReturn(new BigDecimal("7.0"));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new IELTSSceneController(
+				sceneService, mock(IeltsSceneFlowService.class), evaluationService,
+				mock(IeltsSessionService.class), mock(RecordingStore.class))).build();
+
+		mvc.perform(put("/api/ielts/settings")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"targetScore\":7.5,\"examinerId\":\"id-2\"}"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.data.targetScore").value(7.5))
+				.andExpect(jsonPath("$.data.latestEstimatedScore").value(7.0))
+				.andExpect(jsonPath("$.data.currentStreakDays").value(4))
+				.andExpect(jsonPath("$.data.lastCheckInDate").value("2026-08-21"));
+		verify(sceneService).updateSettings(new com.unispeaking.domain.dto.scene.UpdateIeltsSettingsRequest(
+				new BigDecimal("7.5"), "id-2"));
+	}
+
+	@Test
+	void validatesTopicsTrainingAndDialogueStateEndpoints() throws Exception {
+		IeltsSceneService sceneService = mock(IeltsSceneService.class);
+		IeltsSceneFlowService flowService = mock(IeltsSceneFlowService.class);
+		when(flowService.getDialogueState("ielts_1", "session_1"))
+				.thenReturn(new com.unispeaking.domain.dto.session.IeltsDialogueStateResponse(
+					"ielts_1", "session_1", IeltsPart.PART_1, true, 2, 3, false, "Next question"));
+		when(flowService.getPart2State("ielts_1", "session_1"))
+				.thenReturn(new IeltsPart2StateResponse("ielts_1", "session_1", "LONG_TURN", false, "Speak now"));
+		when(flowService.advanceDialogueState("ielts_1", "session_1", 2, true))
+				.thenReturn(new com.unispeaking.domain.dto.session.IeltsDialogueStateResponse(
+					"ielts_1", "session_1", IeltsPart.PART_1, true, 3, 3, true, "Completed"));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new IELTSSceneController(
+				sceneService, flowService, mock(IeltsEvaluationService.class),
+				mock(IeltsSessionService.class), mock(RecordingStore.class))).build();
+
+		mvc.perform(get("/api/ielts/ielts_1/sessions/session_1/state"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.answeredQuestions").value(2));
+		mvc.perform(post("/api/ielts/ielts_1/sessions/session_1/turns/2/state")
+					.param("timedOut", "true"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.completed").value(true));
+		mvc.perform(get("/api/ielts/ielts_1/sessions/session_1/part2/state"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.controlInstruction").value("Speak now"));
+		verify(flowService).advanceDialogueState("ielts_1", "session_1", 2, true);
+	}
+
+	@Test
+	void evaluatesTurnWithAndWithoutAudioAndExposesEvaluationHistory() throws Exception {
+		IeltsEvaluationService evaluationService = mock(IeltsEvaluationService.class);
+		var result = new com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationResult(
+				2, "answer", new BigDecimal("7.0"), new BigDecimal("6.5"), new BigDecimal("7.0"),
+				new BigDecimal("7.0"), new BigDecimal("6.0"), new BigDecimal("6.5"),
+				"Good", "Try this", List.of());
+		when(evaluationService.evaluateTurn(org.mockito.ArgumentMatchers.any())).thenReturn(result);
+		when(evaluationService.getHistory()).thenReturn(List.of());
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new IELTSSceneController(
+				mock(IeltsSceneService.class), mock(IeltsSceneFlowService.class), evaluationService,
+				mock(IeltsSessionService.class), mock(RecordingStore.class))).build();
+
+		mvc.perform(multipart("/api/ielts/ielts_1/sessions/session_1/turns/2/evaluation")
+					.param("transcript", "answer"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.turnNo").value(2));
+		mvc.perform(multipart("/api/ielts/ielts_1/sessions/session_1/turns/2/evaluation")
+					.param("transcript", "answer")
+					.file(new MockMultipartFile("audio", "a.wav", "audio/wav", new byte[] {1, 2})))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.overallScore").value(7.0));
+		mvc.perform(get("/api/ielts/evaluations"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data").isArray());
+	}
+
+	@Test
+	void generatesEvaluationForSession() throws Exception {
+		IeltsEvaluationService evaluationService = mock(IeltsEvaluationService.class);
+		when(evaluationService.generateEvaluation("ielts_1", "session_1"))
+				.thenReturn(new com.unispeaking.domain.dto.evaluation.IeltsEvaluationResult(
+					IeltsPart.PART_1, "MOCK_FINAL", new BigDecimal("7.0"), null, null, null, null,
+					"Summary", List.of("Strength"), List.of("Improve")));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new IELTSSceneController(
+				mock(IeltsSceneService.class), mock(IeltsSceneFlowService.class), evaluationService,
+				mock(IeltsSessionService.class), mock(RecordingStore.class))).build();
+		mvc.perform(post("/api/ielts/ielts_1/sessions/session_1/evaluation"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.assessmentType").value("MOCK_FINAL"));
+		verify(evaluationService).generateEvaluation("ielts_1", "session_1");
+	}
+
+	@Test
+	void rejectsInvalidTopicPaginationAndPart2Event() throws Exception {
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new IELTSSceneController(
+				mock(IeltsSceneService.class), mock(IeltsSceneFlowService.class),
+				mock(IeltsEvaluationService.class), mock(IeltsSessionService.class),
+				mock(RecordingStore.class))).build();
+		mvc.perform(post("/api/ielts/ielts_1/sessions/session_1/part2/state")
+					.contentType(MediaType.APPLICATION_JSON).content("{}"))
+				.andExpect(status().isBadRequest());
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/InterviewSceneControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/InterviewSceneControllerTest.java
@@ -4,17 +4,23 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 
 import com.unispeaking.component.recording.RecordingStore;
 import com.unispeaking.domain.dto.asset.InterviewAssetItem;
 import com.unispeaking.domain.dto.scene.InterviewMaterial;
 import com.unispeaking.domain.dto.scene.InterviewMaterialDraft;
 import com.unispeaking.domain.dto.session.StartSceneSessionResponse;
+import com.unispeaking.domain.dto.evaluation.InterviewEndResponse;
+import com.unispeaking.domain.dto.evaluation.InterviewReportResponse;
+import com.unispeaking.domain.vo.evaluation.ReportStatus;
 import com.unispeaking.service.scene.InterviewSceneService;
 import com.unispeaking.service.session.InterviewSessionService;
 import java.math.BigDecimal;
@@ -25,6 +31,7 @@ import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.core.io.ByteArrayResource;
 
 class InterviewSceneControllerTest {
 
@@ -218,5 +225,72 @@ class InterviewSceneControllerTest {
 				.andExpect(jsonPath("$.data.state.currentTopic").value("自我介绍"))
 				.andExpect(jsonPath("$.data.state.completedTopicCount").value(1))
 				.andExpect(jsonPath("$.data.state.coveredTopicCount").value(1));
+	}
+
+	@Test
+	void coversInterviewLifecycleReportAudioAndDeleteEndpoints() throws Exception {
+		InterviewSceneService scenes = mock(InterviewSceneService.class);
+		InterviewSessionService sessions = mock(InterviewSessionService.class);
+		RecordingStore recordings = mock(RecordingStore.class);
+		when(sessions.endInterview("scene-1", "session-1"))
+				.thenReturn(new InterviewEndResponse("session-1", ReportStatus.PROCESSING));
+		when(sessions.getReport("scene-1", "session-1"))
+				.thenReturn(new InterviewReportResponse("session-1", "scene-1", ReportStatus.PROCESSING, null, null));
+		when(sessions.retryReport("scene-1", "session-1"))
+				.thenReturn(new InterviewReportResponse("session-1", "scene-1", ReportStatus.COMPLETED, null, null));
+		when(sessions.uploadAiAudio("scene-1", "session-1", new byte[] {9, 8}))
+				.thenReturn("audio/object.wav");
+		when(recordings.loadSessionRecording("scene-1", "session-1"))
+				.thenReturn(new ByteArrayResource(new byte[] {1, 2}));
+		when(recordings.loadOwned("scene-1", "session-1", "turn-1.wav"))
+				.thenReturn(new ByteArrayResource(new byte[] {3, 4}));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new InterviewSceneController(
+				scenes, sessions, recordings)).build();
+
+		mvc.perform(post("/api/interview-scenes/scene-1/sessions/session-1/end"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.reportStatus").value("PROCESSING"));
+		mvc.perform(get("/api/interview-scenes/scene-1/sessions/session-1/report"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.status").value("PROCESSING"));
+		mvc.perform(post("/api/interview-scenes/scene-1/sessions/session-1/report/retry"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.status").value("COMPLETED"));
+		mvc.perform(multipart("/api/interview-scenes/scene-1/sessions/session-1/ai-audio")
+					.file(new MockMultipartFile("audio", "ai.wav", "audio/wav", new byte[] {9, 8})))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data").value("audio/object.wav"));
+		mvc.perform(get("/api/interview-scenes/scene-1/sessions/session-1/recording"))
+				.andExpect(status().isOk()).andExpect(
+						org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().contentType("audio/wav"))
+				.andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().bytes(new byte[] {1, 2}));
+		mvc.perform(get("/api/interview-scenes/scene-1/sessions/session-1/recordings/turn-1.wav"))
+				.andExpect(status().isOk()).andExpect(
+						org.springframework.test.web.servlet.result.MockMvcResultMatchers.content().bytes(new byte[] {3, 4}));
+		mvc.perform(delete("/api/interview-scenes/scene-1"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.success").value(true));
+
+		verify(sessions).endInterview("scene-1", "session-1");
+		verify(sessions).getReport("scene-1", "session-1");
+		verify(sessions).retryReport("scene-1", "session-1");
+		verify(sessions).uploadAiAudio("scene-1", "session-1", new byte[] {9, 8});
+		verify(scenes).deleteScene("scene-1");
+	}
+
+	@Test
+	void generateAndPrepareMaterialsSupportNullOptionalUploads() throws Exception {
+		InterviewSceneService scenes = mock(InterviewSceneService.class);
+		var material = new InterviewMaterial(
+				"Java 工程师", List.of("职责"), List.of("要求"), List.of(), "",
+				List.of(), List.of(), List.of(), List.of(), List.of(), "最终文本");
+		var result = new com.unispeaking.domain.dto.scene.InterviewSceneResult(
+				"scene-2", "system prompt");
+		when(scenes.generate(any())).thenReturn(result);
+		when(scenes.prepareMaterials(any())).thenReturn(new InterviewMaterialDraft(material));
+		MockMvc mvc = MockMvcBuilders.standaloneSetup(new InterviewSceneController(
+				scenes, mock(InterviewSessionService.class), mock(RecordingStore.class))).build();
+
+		mvc.perform(post("/api/interview-scenes")
+					.contentType(MediaType.APPLICATION_JSON)
+					.content("{\"material\":{\"jobTitle\":\"Java 工程师\",\"responsibilities\":[\"职责\"],\"qualificationRequirements\":[\"要求\"],\"finalText\":\"最终文本\"},\"difficulty\":\"STANDARD\"}"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.sceneId").value("scene-2"));
+		mvc.perform(multipart("/api/interview-scenes/prepare-materials"))
+				.andExpect(status().isOk()).andExpect(jsonPath("$.data.material.finalText").value("最终文本"));
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/controller/UserAuthControllerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/controller/UserAuthControllerTest.java
@@ -3,11 +3,18 @@ package com.unispeaking.controller;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 import com.unispeaking.common.email.VerificationEmailSender;
 import com.unispeaking.common.exception.GlobalExceptionHandler;
 import com.unispeaking.infrastructure.persistence.repository.auth.InMemoryEmailAuthStore;
 import com.unispeaking.service.auth.EmailAuthService;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.service.auth.RefreshTokenService;
+import com.unispeaking.domain.dto.auth.AuthResponse;
+import com.unispeaking.domain.dto.auth.EmailAuthUser;
+import com.unispeaking.domain.dto.auth.EmailLoginResult;
+import com.unispeaking.domain.dto.auth.UserAccountResponse;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -15,6 +22,7 @@ import java.time.ZoneOffset;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -22,6 +30,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.cookie;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -74,6 +83,9 @@ class UserAuthControllerTest {
         mvc.perform(post("/api/auth/logout").cookie(cookie))
                 .andExpect(status().isNoContent());
         mvc.perform(get("/api/auth/email/me").cookie(cookie))
+                .andExpect(status().isUnauthorized());
+
+        mvc.perform(get("/api/auth/email/me"))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -146,6 +158,84 @@ class UserAuthControllerTest {
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.code", equalTo("VALIDATION_ERROR")))
                 .andExpect(cookie().doesNotExist("us-user-session"));
+    }
+
+    @Test
+    void logoutWithoutCookieStillExpiresTheSessionCookie() throws Exception {
+        mvc.perform(post("/api/auth/logout"))
+                .andExpect(status().isNoContent())
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.header().string("Set-Cookie",
+                        org.hamcrest.Matchers.containsString("us-user-session=;")))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.header().string("Set-Cookie",
+                        org.hamcrest.Matchers.containsString("Max-Age=0")));
+    }
+
+    @Test
+    void tokenEndpointsLoginAndRegisterIssueLearningRefreshCookie() throws Exception {
+        EmailAuthService email = mock(EmailAuthService.class);
+        AuthService learning = mock(AuthService.class);
+        RefreshTokenService refresh = mock(RefreshTokenService.class);
+        UUID userId = UUID.randomUUID();
+        var account = new UserAccountResponse(
+                userId, "person@example.com", "Person", "LEARNER", "ACTIVE", null,
+                Instant.parse("2026-08-06T08:00:00Z"));
+        var auth = new AuthResponse("Bearer", "access-token",
+                Instant.parse("2026-08-06T09:00:00Z"), account);
+        when(email.login("person@example.com", "correct-password", "human"))
+                .thenReturn(new EmailLoginResult("email-session", new EmailAuthUser(userId, "person@example.com")));
+        when(learning.login(new com.unispeaking.domain.dto.auth.LoginRequest(
+                "person@example.com", "correct-password"))).thenReturn(auth);
+        when(refresh.issue(userId)).thenReturn(new RefreshTokenService.Issued(
+                "refresh-token", Instant.parse("2026-08-07T08:00:00Z")));
+        MockMvc configured = MockMvcBuilders.standaloneSetup(
+                new UserAuthController(email, learning, true, 3600, refresh)).build();
+
+        configured.perform(post("/api/auth/email/password/login/token")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\",\"humanVerificationToken\":\"human\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.header().string("Set-Cookie", org.hamcrest.Matchers.containsString("us-learning-refresh=refresh-token")))
+                .andExpect(org.springframework.test.web.servlet.result.MockMvcResultMatchers.header().string("Set-Cookie", org.hamcrest.Matchers.containsString("Secure")));
+
+        when(email.register("person@example.com", "correct-password", userId, "123456", "Person"))
+                .thenReturn(new EmailAuthUser(userId, "person@example.com"));
+        when(learning.login(new com.unispeaking.domain.dto.auth.LoginRequest(
+                "person@example.com", "correct-password"))).thenReturn(auth);
+        configured.perform(post("/api/auth/email/register/token")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\",\"challengeId\":\""
+                                + userId + "\",\"code\":\"123456\",\"nickname\":\"Person\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("access-token"));
+
+        when(learning.login(new com.unispeaking.domain.dto.auth.LoginRequest(
+                "person@example.com", "correct-password"))).thenReturn(null);
+        configured.perform(post("/api/auth/email/password/login/token")
+                        .contentType("application/json")
+                        .content("{\"email\":\"person@example.com\",\"password\":\"correct-password\",\"humanVerificationToken\":\"human\"}"))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Set-Cookie"));
+
+        verify(learning, org.mockito.Mockito.times(3)).login(
+                new com.unispeaking.domain.dto.auth.LoginRequest("person@example.com", "correct-password"));
+    }
+
+    @Test
+    void tokenEndpointReportsMissingLearningAuthConfiguration() throws Exception {
+        EmailAuthService email = mock(EmailAuthService.class);
+        when(email.login("person@example.com", "correct-password", "local-human-verified"))
+                .thenReturn(new EmailLoginResult("email-session",
+                        new EmailAuthUser(UUID.randomUUID(), "person@example.com")));
+        var controller = new UserAuthController(email, false, 3600);
+        assertThrows(IllegalStateException.class, () -> controller.loginToken(
+                new UserAuthController.LoginRequest(
+                        "person@example.com", "correct-password", "local-human-verified"),
+                mock(jakarta.servlet.http.HttpServletResponse.class)));
+        assertThrows(IllegalStateException.class, () -> controller.registerToken(
+                new UserAuthController.RegisterRequest(
+                        "person@example.com", "correct-password", UUID.randomUUID(), "123456", null),
+                mock(jakarta.servlet.http.HttpServletResponse.class)));
     }
 
     private UUID issueChallenge(String path) throws Exception {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/profile/PreferredAiSpeechSpeedTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/profile/PreferredAiSpeechSpeedTest.java
@@ -1,0 +1,16 @@
+package com.unispeaking.domain.vo.profile;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PreferredAiSpeechSpeedTest {
+	@Test
+	void exposesStablePreferenceOrder() {
+		assertArrayEquals(new PreferredAiSpeechSpeed[] {
+				PreferredAiSpeechSpeed.SLOWER,
+				PreferredAiSpeechSpeed.MODERATE,
+				PreferredAiSpeechSpeed.NATURAL,
+				PreferredAiSpeechSpeed.FASTER }, PreferredAiSpeechSpeed.values());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/domain/vo/scene/TargetRoleSummaryTest.java
@@ -1,0 +1,30 @@
+package com.unispeaking.domain.vo.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TargetRoleSummaryTest {
+	@Test
+	void validatesOverviewAndCopiesOptionalLists() {
+		TargetRoleSummary summary = new TargetRoleSummary("Engineer", null,
+				List.of("Java"), List.of("Degree"));
+		assertEquals(List.of(), summary.responsibilities());
+		assertEquals(List.of("Java"), summary.requiredSkills());
+		assertThrows(UnsupportedOperationException.class,
+				() -> summary.requiredSkills().add("SQL"));
+		assertThrows(IllegalArgumentException.class,
+				() -> new TargetRoleSummary(" ", List.of(), List.of(), List.of()));
+	}
+
+	@Test
+	void redactsSensitiveSourceContentAndRequiresJobTitle() {
+		var input = new TargetRoleSummaryGenerationInput("Engineer", "secret resume");
+		assertEquals("TargetRoleSummaryGenerationInput[jobTitle=<redacted>, jobDescription=<redacted>]",
+				input.toString());
+		assertThrows(NullPointerException.class,
+				() -> new TargetRoleSummaryGenerationInput(null, "description"));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/gateway/GatewayKeyPoolTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/gateway/GatewayKeyPoolTest.java
@@ -42,4 +42,33 @@ class GatewayKeyPoolTest {
                 .isInstanceOf(GatewayException.class)
                 .hasMessage("NO_HEALTHY_PROVIDER_KEY");
     }
+
+    @Test
+    void validatesInputsFiltersProvidersAndExposesStatuses() {
+        assertThatThrownBy(() -> new GatewayKeyPool(null, Clock.systemUTC(), Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new GatewayKeyPool(List.of(), Clock.systemUTC(), Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new GatewayKeyPool(
+                List.of(new GatewayKey("q", ProviderType.QWEN, "s")), null, Duration.ofSeconds(1)))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new GatewayKeyPool(
+                List.of(new GatewayKey("q", ProviderType.QWEN, "s")), Clock.systemUTC(), Duration.ZERO))
+                .isInstanceOf(IllegalArgumentException.class);
+
+        var pool = new GatewayKeyPool(
+                List.of(new GatewayKey("q", ProviderType.QWEN, "s"),
+                        new GatewayKey("d", ProviderType.DEEPSEEK, "s2")),
+                Clock.fixed(NOW, ZoneOffset.UTC), Duration.ofSeconds(30));
+        assertThatThrownBy(() -> pool.acquire(null)).isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> pool.acquire(ProviderType.IFLYTEK))
+                .isInstanceOf(GatewayException.class);
+        pool.markFailure(null);
+        pool.markFailure(" ");
+        pool.markSuccess("missing");
+        pool.markFailure("q");
+        assertThat(pool.statuses()).anyMatch(s -> s.keyId().equals("q") && !s.healthy());
+        pool.markSuccess("q");
+        assertThat(pool.statuses()).anyMatch(s -> s.keyId().equals("q") && s.healthy());
+    }
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/aliyun/AliyunTtsProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/aliyun/AliyunTtsProviderTest.java
@@ -1,0 +1,516 @@
+package com.unispeaking.infrastructure.ai.aliyun;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.provider.MeteredProviderException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class AliyunTtsProviderTest {
+
+	@Test
+	void sendsConfiguredFormatAndSampleRateAndDownloadsAudio() {
+		byte[] audio = new byte[] {1, 2, 3, 4};
+		String audioUrl =
+				"http://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio%2Bfile.mp3?sig=a%2Fb";
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(
+						200,
+						utf8("{\"request_id\":\"body-request\",\"output\":{\"audio\":{\"url\":\""
+								+ audioUrl + "\"}}}"),
+						Map.of("x-request-id", List.of("header-request"))),
+				new QueuedResponse(200, audio));
+		AliyunTtsProvider provider = provider(client, "dashscope-key", "pcm", 16_000, 128);
+
+		var measured = provider.generateSpeechAudioMeasured("  hello there  ", null);
+
+		assertArrayEquals(audio, measured.response());
+		assertEquals("body-request", measured.providerRequestId());
+		assertEquals(2, client.requests.size());
+		HttpRequest synthesisRequest = client.requests.getFirst();
+		assertEquals("https", client.requests.get(1).uri().getScheme());
+		assertEquals(
+				"https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio%2Bfile.mp3?sig=a%2Fb",
+				client.requests.get(1).uri().toString());
+		String body = readBody(synthesisRequest);
+		assertTrue(body.contains("\"format\":\"pcm\""));
+		assertTrue(body.contains("\"sample_rate\":16000"));
+		assertTrue(body.contains("\"language_hints\":[\"en\"]"));
+		assertEquals("Bearer dashscope-key",
+				synthesisRequest.headers().firstValue("Authorization").orElseThrow());
+	}
+
+	@Test
+	void fallsBackToRequestIdHeaderWhenResponseBodyHasNoRequestId() {
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(
+						200,
+						utf8("{\"output\":{\"audio\":{\"url\":\"" + url + "\"}}}"),
+						Map.of("x-dashscope-request-id", List.of("header-request"))),
+				new QueuedResponse(200, new byte[] {9}));
+
+		var response = provider(client, "key", "wav", 24_000, 128)
+				.generateSpeechAudioMeasured("hello", null);
+
+		assertEquals("header-request", response.providerRequestId());
+		assertEquals(5, response.usage().inputCharacters());
+	}
+
+	@Test
+	void rejectsInvalidAliyunEndpointsBeforeSendingCredentials() {
+		List<URI> invalidEndpoints = List.of(
+				URI.create("http://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer"),
+				URI.create("https://evil.example/api/v1/services/audio/tts/SpeechSynthesizer"),
+				URI.create("https://workspace.cn-beijing.maas.aliyuncs.com:443/api/v1/services/audio/tts/SpeechSynthesizer"),
+				URI.create("https://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer?debug=true"),
+				URI.create("https://user:pass@workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer"));
+
+		for (URI endpoint : invalidEndpoints) {
+			RecordingHttpClient client = new RecordingHttpClient();
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider(client, "secret", "wav", 24_000, 128, endpoint)
+							.generateSpeechAudio("hello", null));
+
+			assertEquals("ALIYUN_TTS_ENDPOINT_INVALID", exception.code());
+			assertTrue(client.requests.isEmpty());
+		}
+	}
+
+	@Test
+	void rejectsMalformedAndUntrustedAudioUrls() {
+		assertAudioResponseError("{\"output\":{\"audio\":{}}}", "ALIYUN_TTS_AUDIO_URL_MISSING");
+		assertAudioResponseError("{\"output\":{\"audio\":{\"url\":\"not a uri\"}}}",
+				"ALIYUN_TTS_AUDIO_URL_INVALID");
+		assertAudioResponseError(
+				"{\"output\":{\"audio\":{\"url\":\"https://evil.example/audio.wav\"}}}",
+				"ALIYUN_TTS_AUDIO_URL_UNTRUSTED");
+	}
+
+	@Test
+	void mapsHttpAndMalformedResponsesToRetryableBusinessErrors() {
+		BusinessException httpError = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(new QueuedResponse(503, utf8("busy"))), "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_REQUEST_FAILED", httpError.code());
+
+		BusinessException invalidJson = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(new QueuedResponse(200, utf8("not-json"))), "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_RESPONSE_INVALID", invalidJson.code());
+	}
+
+	@Test
+	void mapsEmptyAndOversizedAudioResponses() {
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		BusinessException empty = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(
+						new QueuedResponse(200, utf8(audioResponse(url))),
+						new QueuedResponse(200, new byte[0])) , "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_AUDIO_EMPTY", empty.code());
+
+			RuntimeException oversized = assertThrows(
+					RuntimeException.class,
+					() -> provider(new RecordingHttpClient(
+							new QueuedResponse(200, utf8(audioResponse(url))),
+							new QueuedResponse(200, new byte[] {1, 2, 3})), "key", "wav", 24_000, 2)
+							.generateSpeechAudio("hello", null));
+		assertTrue(oversized instanceof BusinessException
+				|| oversized.getCause() instanceof BusinessException);
+	}
+
+	@Test
+	void mapsTransportAndInterruptedFailuresAndRestoresInterruptStatus() throws Exception {
+		BusinessException ioError = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(QueuedResponse.ioError()), "secret")
+						.generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_IO_ERROR", ioError.code());
+		assertFalse(ioError.getMessage().contains("secret"));
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		try {
+			doThrow(new InterruptedException("cancelled"))
+					.when(interruptedClient)
+					.send(any(HttpRequest.class),
+							org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		}
+		catch (java.io.IOException exception) {
+			throw new AssertionError(exception);
+		}
+		Thread.interrupted();
+		BusinessException interrupted = assertThrows(
+				BusinessException.class,
+				() -> provider(interruptedClient, "key").generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_INTERRUPTED", interrupted.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
+	void validatesCredentialTextFormatAndSampleRate() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		assertEquals("ALIYUN_TTS_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "").generateSpeechAudio("hello", null)).code());
+		assertEquals("INVALID_TTS_TEXT", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "key").generateSpeechAudio("  ", null)).code());
+		assertEquals("TTS_TEXT_TOO_LONG", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "key").generateSpeechAudio("x".repeat(5_001), null)).code());
+		assertTrue(client.requests.isEmpty());
+
+		assertThrows(IllegalArgumentException.class,
+				() -> provider(client, "key", "ogg", 24_000, 128));
+		assertThrows(IllegalArgumentException.class,
+				() -> provider(client, "key", "wav", 11_025, 128));
+	}
+
+	@Test
+	void wrapsPostRequestFailuresAsMeteredFailuresWhenRequestIdWasCaptured() {
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		AliyunTtsProvider provider = provider(
+				new RecordingHttpClient(
+						new QueuedResponse(200, utf8("{\"request_id\":\"billable-1\",\"output\":{\"audio\":{\"url\":\""
+								+ url + "\"}}}")),
+						new QueuedResponse(502, utf8("download failed"))),
+				"key");
+
+		MeteredProviderException exception = assertThrows(
+				MeteredProviderException.class,
+				() -> provider.generateSpeechAudioMeasured("hello", null));
+
+		assertEquals("ALIYUN_TTS_AUDIO_DOWNLOAD_FAILED", exception.code());
+		assertEquals("billable-1", exception.providerRequestId());
+		assertEquals(5, exception.usage().inputCharacters());
+	}
+
+	@Test
+	void coversHeaderlessMeasuredSuccessAndAudioDownloadFailure() {
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		RecordingHttpClient successClient = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(audioResponse(url))),
+				new QueuedResponse(201, new byte[] {7}));
+		var measured = provider(successClient, "key")
+				.generateSpeechAudioMeasured("hello", null);
+		assertEquals(null, measured.providerRequestId());
+		assertEquals("NONE", measured.usage().source());
+
+		RecordingHttpClient failedDownload = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(audioResponse(url))),
+				new QueuedResponse(404, utf8("missing")));
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(failedDownload, "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals("ALIYUN_TTS_AUDIO_DOWNLOAD_FAILED", exception.code());
+	}
+
+	@Test
+	void rejectsGeneratedEndpointsWithUnsafeWorkspaceAndRegionComponents() {
+		AliyunTtsProvider invalidWorkspace = new AliyunTtsProvider(
+				new ObjectMapper(), "key", "bad.workspace", "cn-beijing", "model", "voice",
+				"wav", 24_000, 1, 1, 128);
+		assertEquals("ALIYUN_TTS_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> invalidWorkspace.generateSpeechAudio("hello", null)).code());
+
+		AliyunTtsProvider invalidRegion = new AliyunTtsProvider(
+				new ObjectMapper(), "key", "workspace", "cn_beijing", "model", "voice",
+				"wav", 24_000, 1, 1, 128);
+		assertEquals("ALIYUN_TTS_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> invalidRegion.generateSpeechAudio("hello", null)).code());
+	}
+
+	@Test
+	void validatesSpringConstructorTimeoutsAndNullDependencies() {
+		assertThrows(IllegalArgumentException.class, () -> new AliyunTtsProvider(
+				new ObjectMapper(), "key", "workspace", "cn-beijing", "model", "voice",
+				"wav", 24_000, 0, 1, 128));
+		assertThrows(IllegalArgumentException.class, () -> new AliyunTtsProvider(
+				new ObjectMapper(), "key", "workspace", "cn-beijing", "model", "voice",
+				"wav", 24_000, 1, 0, 128));
+		assertThrows(IllegalArgumentException.class, () -> new AliyunTtsProvider(
+				null, new ObjectMapper(), "key", URI.create(
+						"https://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer"),
+				"model", "voice", "wav", 24_000, Duration.ofSeconds(1), 128));
+	}
+
+	private void assertAudioResponseError(String response, String expectedCode) {
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(response)));
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(client, "key").generateSpeechAudio("hello", null));
+		assertEquals(expectedCode, exception.code());
+		assertEquals(1, client.requests.size());
+	}
+
+	private AliyunTtsProvider provider(RecordingHttpClient client, String apiKey) {
+		return provider(client, apiKey, "wav", 24_000, 1_048_576);
+	}
+
+	private AliyunTtsProvider provider(HttpClient client, String apiKey) {
+		return provider(client, apiKey, "wav", 24_000, 1_048_576);
+	}
+
+	private AliyunTtsProvider provider(
+			RecordingHttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int maxAudioBytes) {
+		return provider(
+				client,
+				apiKey,
+				format,
+				sampleRate,
+				maxAudioBytes,
+				URI.create("https://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer"));
+	}
+
+	private AliyunTtsProvider provider(
+			HttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int maxAudioBytes) {
+		return new AliyunTtsProvider(
+				client,
+				new ObjectMapper(),
+				apiKey,
+				URI.create("https://workspace.cn-beijing.maas.aliyuncs.com/api/v1/services/audio/tts/SpeechSynthesizer"),
+				"cosyvoice-v3-flash",
+				"loongemily_v3",
+				format,
+				sampleRate,
+				Duration.ofSeconds(20),
+				maxAudioBytes);
+	}
+
+	private AliyunTtsProvider provider(
+			RecordingHttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int maxAudioBytes,
+			URI endpoint) {
+		return new AliyunTtsProvider(
+				client,
+				new ObjectMapper(),
+				apiKey,
+				endpoint,
+				"cosyvoice-v3-flash",
+				"loongemily_v3",
+				format,
+				sampleRate,
+				Duration.ofSeconds(20),
+				maxAudioBytes);
+	}
+
+	private static String audioResponse(String url) {
+		return "{\"output\":{\"audio\":{\"url\":\"" + url + "\"}}}";
+	}
+
+	private static byte[] utf8(String value) {
+		return value.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static String readBody(HttpRequest request) {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		CompletableFuture<Void> completed = new CompletableFuture<>();
+		request.bodyPublisher().orElseThrow().subscribe(new Flow.Subscriber<>() {
+			@Override
+			public void onSubscribe(Flow.Subscription subscription) {
+				subscription.request(Long.MAX_VALUE);
+			}
+
+			@Override
+			public void onNext(ByteBuffer item) {
+				byte[] chunk = new byte[item.remaining()];
+				item.get(chunk);
+				bytes.writeBytes(chunk);
+			}
+
+			@Override
+			public void onError(Throwable throwable) {
+				completed.completeExceptionally(throwable);
+			}
+
+			@Override
+			public void onComplete() {
+				completed.complete(null);
+			}
+		});
+		completed.join();
+		return bytes.toString(StandardCharsets.UTF_8);
+	}
+
+	private static final class RecordingHttpClient extends HttpClient {
+
+		private final List<QueuedResponse> responses;
+		private final List<HttpRequest> requests = new ArrayList<>();
+
+		private RecordingHttpClient(QueuedResponse... responses) {
+			this.responses = new ArrayList<>(List.of(responses));
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> HttpResponse<T> send(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler)
+				throws IOException {
+			requests.add(request);
+			QueuedResponse response = responses.removeFirst();
+			if (response.failWithIoError()) {
+				throw new IOException("simulated network failure");
+			}
+			byte[] rawBody = response.body() instanceof byte[] bytes
+					? bytes
+					: response.body().toString().getBytes(StandardCharsets.UTF_8);
+			HttpResponse.BodySubscriber<T> subscriber = responseBodyHandler.apply(
+					new RecordedResponseInfo(response.statusCode(), response.headers()));
+			subscriber.onSubscribe(new NoopSubscription());
+			subscriber.onNext(List.of(ByteBuffer.wrap(rawBody)));
+			subscriber.onComplete();
+			T handledBody;
+			try {
+				handledBody = subscriber.getBody().toCompletableFuture().join();
+			}
+			catch (java.util.concurrent.CompletionException exception) {
+				if (exception.getCause() instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				throw exception;
+			}
+			return (HttpResponse<T>) new RecordedHttpResponse<>(
+					request, response.statusCode(), handledBody, response.headers());
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler) {
+			try {
+				return CompletableFuture.completedFuture(send(request, responseBodyHandler));
+			}
+			catch (IOException exception) {
+				return CompletableFuture.failedFuture(exception);
+			}
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler,
+				HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+			return sendAsync(request, responseBodyHandler);
+		}
+
+		@Override public Optional<CookieHandler> cookieHandler() { return Optional.empty(); }
+		@Override public Optional<Duration> connectTimeout() { return Optional.empty(); }
+		@Override public Redirect followRedirects() { return Redirect.NEVER; }
+		@Override public Optional<ProxySelector> proxy() { return Optional.empty(); }
+		@Override public SSLContext sslContext() { return null; }
+		@Override public SSLParameters sslParameters() { return new SSLParameters(); }
+		@Override public Optional<Authenticator> authenticator() { return Optional.empty(); }
+		@Override public Version version() { return Version.HTTP_1_1; }
+		@Override public Optional<Executor> executor() { return Optional.empty(); }
+	}
+
+	private static final class NoopSubscription implements Flow.Subscription {
+		@Override public void request(long n) { }
+		@Override public void cancel() { }
+	}
+
+	private record QueuedResponse(
+			int statusCode,
+			Object body,
+			Map<String, List<String>> headers,
+			boolean failWithIoError) {
+
+		private QueuedResponse(int statusCode, Object body) {
+			this(statusCode, body, Map.of(), false);
+		}
+
+		private QueuedResponse(
+				int statusCode,
+				Object body,
+				Map<String, List<String>> headers) {
+			this(statusCode, body, headers, false);
+		}
+
+		private static QueuedResponse ioError() {
+			return new QueuedResponse(0, null, Map.of(), true);
+		}
+	}
+
+	private record RecordedResponseInfo(
+			int statusCode,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse.ResponseInfo {
+		@Override
+		public HttpHeaders headers() {
+			return HttpHeaders.of(responseHeaders, (name, value) -> true);
+		}
+
+		@Override
+		public HttpClient.Version version() {
+			return HttpClient.Version.HTTP_1_1;
+		}
+	}
+
+	private record RecordedHttpResponse<T>(
+			HttpRequest request,
+			int statusCode,
+			T body,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse<T> {
+		@Override public Optional<HttpResponse<T>> previousResponse() { return Optional.empty(); }
+		@Override public HttpHeaders headers() {
+			return HttpHeaders.of(responseHeaders, (name, value) -> true);
+		}
+		@Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+		@Override public URI uri() { return request.uri(); }
+		@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/aliyun/captcha/AlibabaSdkCaptchaClientTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/aliyun/captcha/AlibabaSdkCaptchaClientTest.java
@@ -1,0 +1,93 @@
+package com.unispeaking.infrastructure.ai.aliyun.captcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.aliyun.sdk.service.captcha20230305.AsyncClient;
+import com.aliyun.sdk.service.captcha20230305.models.VerifyIntelligentCaptchaRequest;
+import com.aliyun.sdk.service.captcha20230305.models.VerifyIntelligentCaptchaResponse;
+import com.aliyun.sdk.service.captcha20230305.models.VerifyIntelligentCaptchaResponseBody;
+import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import org.junit.jupiter.api.Test;
+
+class AlibabaSdkCaptchaClientTest {
+
+    @Test
+    void buildsRequestAndAcceptsSuccessfulVerification() throws Exception {
+        var sdk = mock(AsyncClient.class);
+        when(sdk.verifyIntelligentCaptcha(any())).thenReturn(
+                CompletableFuture.completedFuture(response(true, true)));
+        var client = client(sdk);
+
+        assertThat(client.verify("scene-1", "opaque-param")).isTrue();
+
+        var request = org.mockito.Mockito.mockingDetails(sdk).getInvocations().stream()
+                .filter(invocation -> invocation.getMethod().getName().equals("verifyIntelligentCaptcha"))
+                .map(invocation -> (VerifyIntelligentCaptchaRequest) invocation.getArguments()[0])
+                .findFirst()
+                .orElseThrow();
+        assertThat(request.getSceneId()).isEqualTo("scene-1");
+        assertThat(request.getCaptchaVerifyParam()).isEqualTo("opaque-param");
+    }
+
+    @Test
+    void rejectsEveryIncompleteOrNegativeSdkResponse() throws Exception {
+        assertThat(clientReturning(response(false, true)).verify("scene", "param")).isFalse();
+        assertThat(clientReturning(response(true, false)).verify("scene", "param")).isFalse();
+        assertThat(clientReturning(response(true, null)).verify("scene", "param")).isFalse();
+        assertThat(clientReturning(response(null, true)).verify("scene", "param")).isFalse();
+        assertThat(clientReturning(null).verify("scene", "param")).isFalse();
+
+        var sdk = mock(AsyncClient.class);
+        when(sdk.verifyIntelligentCaptcha(any())).thenReturn(
+                CompletableFuture.completedFuture(responseWithNullBody()));
+        assertThat(client(sdk).verify("scene", "param")).isFalse();
+    }
+
+    @Test
+    void closesTheUnderlyingSdkClient() throws Exception {
+        var sdk = mock(AsyncClient.class);
+        var client = client(sdk);
+
+        client.close();
+
+        verify(sdk).close();
+    }
+
+    private AlibabaSdkCaptchaClient clientReturning(VerifyIntelligentCaptchaResponse response)
+            throws Exception {
+        var sdk = mock(AsyncClient.class);
+        when(sdk.verifyIntelligentCaptcha(any())).thenReturn(CompletableFuture.completedFuture(response));
+        return client(sdk);
+    }
+
+    private AlibabaSdkCaptchaClient client(AsyncClient sdk) throws Exception {
+        var client = new AlibabaSdkCaptchaClient(
+                "access-key-id", "access-key-secret", "cn-hangzhou", "https://captcha.aliyuncs.com");
+        Field field = AlibabaSdkCaptchaClient.class.getDeclaredField("client");
+        field.setAccessible(true);
+        field.set(client, sdk);
+        return client;
+    }
+
+    private static VerifyIntelligentCaptchaResponse response(Boolean success, Boolean verifyResult) {
+        var result = verifyResult == null
+                ? VerifyIntelligentCaptchaResponseBody.Result.builder().build()
+                : VerifyIntelligentCaptchaResponseBody.Result.builder().verifyResult(verifyResult).build();
+        var body = VerifyIntelligentCaptchaResponseBody.builder()
+                .success(success)
+                .result(result)
+                .build();
+        VerifyIntelligentCaptchaResponse.Builder builder = VerifyIntelligentCaptchaResponse.create().toBuilder();
+        return builder.body(body).statusCode(200).build();
+    }
+
+    private static VerifyIntelligentCaptchaResponse responseWithNullBody() {
+        VerifyIntelligentCaptchaResponse.Builder builder = VerifyIntelligentCaptchaResponse.create().toBuilder();
+        return builder.statusCode(200).build();
+    }
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/deepseek/DoubaoProviderCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/deepseek/DoubaoProviderCoverageTest.java
@@ -1,0 +1,572 @@
+package com.unispeaking.infrastructure.ai.deepseek;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.infrastructure.ai.doubao.DoubaoAsrProvider;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class DoubaoProviderCoverageTest {
+
+	private static final URI DEEPSEEK_ENDPOINT =
+			URI.create("https://api.deepseek.com/chat/completions");
+	private static final URI DOUBAO_ENDPOINT =
+			URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash");
+
+	@Test
+	void sendsDeepSeekRequestWithConfiguredCredentialAndRecordsUsage() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("""
+				{"id":"deepseek-request-1","choices":[{"message":{"content":"answer"}}],
+				"usage":{"prompt_tokens":11,"completion_tokens":7}}
+				""")));
+		DeepSeekLlmProvider provider = deepSeekProvider(client, "deepseek-key", 1_024);
+
+		var response = provider.executeLlmTaskMeasured("  Return JSON.  ", null);
+
+		assertEquals("answer", response.response());
+		assertEquals("deepseek-request-1", response.providerRequestId());
+		assertEquals(11, response.usage().inputTokens());
+		assertEquals(7, response.usage().outputTokens());
+		assertEquals("PROVIDER", response.usage().source());
+		HttpRequest request = client.requests.getFirst();
+		assertEquals("Bearer deepseek-key",
+				request.headers().firstValue("Authorization").orElseThrow());
+		String body = readBody(request);
+		assertTrue(body.contains("\"model\":\"deepseek-v4-flash\""));
+		assertTrue(body.contains("\"content\":\"Return JSON.\""));
+		assertTrue(body.contains("\"thinking\":{\"type\":\"disabled\"}"));
+		assertFalse(body.contains("deepseek-key"));
+		assertFalse(client.bodyCompletedOnSubscribe);
+	}
+
+	@Test
+	void rejectsDeepSeekMissingCredentialAndEmptyPromptBeforeSending() {
+		RecordingHttpClient client = new RecordingHttpClient();
+
+		assertEquals("INVALID_LLM_PROMPT", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(client, "deepseek-key", 128)
+						.executeLlmTask("  ", null)).code());
+		assertEquals("DEEPSEEK_LLM_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(client, "", 128)
+						.executeLlmTask("hello", null)).code());
+		assertTrue(client.requests.isEmpty());
+	}
+
+	@Test
+	void rejectsUntrustedDeepSeekEndpointsBeforeSendingCredentials() {
+		List<URI> invalidEndpoints = List.of(
+				URI.create("http://api.deepseek.com/chat/completions"),
+				URI.create("https://evil.example/chat/completions"),
+				URI.create("https://api.deepseek.com:443/chat/completions"),
+				URI.create("https://api.deepseek.com/chat/completions?debug=true"),
+				URI.create("https://user:pass@api.deepseek.com/chat/completions"),
+				URI.create("https://api.deepseek.com/v1/chat/completions"));
+
+		for (URI endpoint : invalidEndpoints) {
+			RecordingHttpClient client = new RecordingHttpClient();
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> new DeepSeekLlmProvider(
+							client, new ObjectMapper(), "deepseek-key", endpoint,
+							"deepseek-v4-flash", Duration.ofSeconds(2), 128)
+							.executeLlmTask("hello", null));
+
+			assertEquals("DEEPSEEK_LLM_ENDPOINT_INVALID", exception.code());
+			assertTrue(client.requests.isEmpty());
+		}
+
+		RecordingHttpClient malformedClient = new RecordingHttpClient();
+		DeepSeekLlmProvider malformed = new DeepSeekLlmProvider(
+				malformedClient, new ObjectMapper(), "deepseek-key", null,
+				"deepseek-v4-flash", Duration.ofSeconds(2), 128);
+		assertEquals("DEEPSEEK_LLM_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> malformed.executeLlmTask("hello", null)).code());
+		assertTrue(malformedClient.requests.isEmpty());
+	}
+
+	@Test
+	void mapsDeepSeekHttpJsonEmptyAndOversizedResponses() {
+		assertEquals("DEEPSEEK_LLM_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(
+						new RecordingHttpClient(new QueuedResponse(503, utf8("busy"))),
+						"key", 128).executeLlmTask("hello", null)).code());
+		assertEquals("DEEPSEEK_LLM_RESPONSE_INVALID", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(
+						new RecordingHttpClient(new QueuedResponse(200, utf8("not-json"))),
+						"key", 128).executeLlmTask("hello", null)).code());
+		assertEquals("DEEPSEEK_LLM_EMPTY_RESPONSE", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(
+						new RecordingHttpClient(new QueuedResponse(
+								200, utf8("{\"choices\":[{\"message\":{\"content\":\" \"}}]}"))),
+						"key", 128).executeLlmTask("hello", null)).code());
+		assertEquals("DEEPSEEK_LLM_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(
+						new RecordingHttpClient(new QueuedResponse(200, utf8("123456789"))),
+						"key", 8).executeLlmTask("hello", null)).code());
+	}
+
+	@Test
+	void mapsDeepSeekIoAndInterruptedFailures() throws Exception {
+		BusinessException ioFailure = assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(
+						new RecordingHttpClient(QueuedResponse.ioError()), "key", 128)
+						.executeLlmTask("hello", null));
+		assertEquals("DEEPSEEK_LLM_IO_ERROR", ioFailure.code());
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(interruptedClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		DeepSeekLlmProvider provider = new DeepSeekLlmProvider(
+				interruptedClient, new ObjectMapper(), "key", DEEPSEEK_ENDPOINT,
+				"model", Duration.ofSeconds(2), 128);
+
+		Thread.interrupted();
+		BusinessException interrupted = assertThrows(
+				BusinessException.class,
+				() -> provider.executeLlmTask("hello", null));
+		assertEquals("DEEPSEEK_LLM_INTERRUPTED", interrupted.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
+	void sendsDoubaoApiKeyRequestWithExpectedHeadersAndBody() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"result\":{\"text\":\"Practice makes progress.\"}}"),
+				Map.of("X-Api-Status-Code", List.of("20000000"))));
+		DoubaoAsrProvider provider = doubaoProvider(client, "doubao-api-key", "", "", 128, 1_024);
+
+		assertEquals("Practice makes progress.",
+				provider.convertAudioToText(new byte[] {1, 2, 3}, null));
+
+		HttpRequest request = client.requests.getFirst();
+		assertEquals("doubao-api-key", request.headers().firstValue("X-Api-Key").orElseThrow());
+		assertEquals("volc.bigasr.auc_turbo",
+				request.headers().firstValue("X-Api-Resource-Id").orElseThrow());
+		assertEquals("-1", request.headers().firstValue("X-Api-Sequence").orElseThrow());
+		assertTrue(request.headers().firstValue("X-Api-Request-Id").orElseThrow().length() > 10);
+		String body = readBody(request);
+		assertTrue(body.contains("\"uid\":\"unispeaking\""));
+		assertTrue(body.contains("\"data\":\"AQID\""));
+		assertTrue(body.contains("\"model_name\":\"bigmodel\""));
+		assertFalse(body.contains("doubao-api-key"));
+		assertTrue(request.headers().firstValue("X-Api-App-Key").isEmpty());
+		assertTrue(request.headers().firstValue("X-Api-Access-Key").isEmpty());
+	}
+
+	@Test
+	void usesLegacyDoubaoCredentialsAndHeadersWhenApiKeyIsAbsent() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"result\":{\"text\":\"legacy-ok\"}}"),
+				Map.of("X-Api-Status-Code", List.of("20000000"))));
+		DoubaoAsrProvider provider = doubaoProvider(
+				client, "", "legacy-app", "legacy-access", 128, 1_024);
+
+		assertEquals("legacy-ok", provider.convertAudioToText(new byte[] {1, 2}, null));
+		HttpRequest request = client.requests.getFirst();
+		assertEquals("legacy-app", request.headers().firstValue("X-Api-App-Key").orElseThrow());
+		assertEquals("legacy-access", request.headers().firstValue("X-Api-Access-Key").orElseThrow());
+		assertTrue(request.headers().firstValue("X-Api-Key").isEmpty());
+	}
+
+	@Test
+	void rejectsDoubaoEmptyInputMissingCredentialsAndOversizedAudio() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		DoubaoAsrProvider provider = doubaoProvider(client, "key", "", "", 1, 128);
+
+		assertEquals("INVALID_AUDIO", assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[0], null)).code());
+		assertEquals("TRANSCRIPTION_AUDIO_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[] {1, 2}, null)).code());
+		assertEquals("DOUBAO_ASR_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(client, "", "legacy-app", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+		assertTrue(client.requests.isEmpty());
+	}
+
+	@Test
+	void rejectsUntrustedDoubaoEndpointsBeforeSendingCredentials() {
+		List<URI> invalidEndpoints = List.of(
+				URI.create("http://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"),
+				URI.create("https://evil.example/api/v3/auc/bigmodel/recognize/flash"),
+				URI.create("https://openspeech.bytedance.com:443/api/v3/auc/bigmodel/recognize/flash"),
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash?debug=true"),
+				URI.create("https://user:pass@openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"),
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize"));
+
+		for (URI endpoint : invalidEndpoints) {
+			RecordingHttpClient client = new RecordingHttpClient();
+			DoubaoAsrProvider provider = new DoubaoAsrProvider(
+					client, new ObjectMapper(), "doubao-key", "", "", "user", endpoint,
+					"resource", Duration.ofSeconds(2), 128, 128);
+
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider.convertAudioToText(new byte[] {1}, null));
+			assertEquals("DOUBAO_ASR_ENDPOINT_INVALID", exception.code());
+			assertTrue(client.requests.isEmpty());
+		}
+	}
+
+	@Test
+	void mapsDoubaoHttpProviderStatusJsonEmptyAndOversizedResponses() {
+		assertEquals("DOUBAO_ASR_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(new QueuedResponse(500, utf8("busy"))),
+						"key", "", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+		assertEquals("DOUBAO_ASR_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(new QueuedResponse(200, utf8("{}"))),
+						"key", "", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+		assertEquals("DOUBAO_ASR_RESPONSE_INVALID", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(new QueuedResponse(
+								200, utf8("not-json"), successHeaders())),
+						"key", "", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+		assertEquals("DOUBAO_ASR_RESULT_EMPTY", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(new QueuedResponse(
+								200, utf8("{\"result\":{\"text\":\" \"}}"), successHeaders())),
+						"key", "", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+		assertEquals("DOUBAO_ASR_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(new QueuedResponse(
+								200, utf8("123456789"), successHeaders())),
+						"key", "", "", 128, 8)
+						.convertAudioToText(new byte[] {1}, null)).code());
+	}
+
+	@Test
+	void mapsDoubaoIoAndInterruptedFailures() throws Exception {
+		BusinessException ioFailure = assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(QueuedResponse.ioError()), "key", "", "", 128, 128)
+						.convertAudioToText(new byte[] {1}, null));
+		assertEquals("DOUBAO_ASR_IO_ERROR", ioFailure.code());
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(interruptedClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		DoubaoAsrProvider provider = new DoubaoAsrProvider(
+				interruptedClient, new ObjectMapper(), "key", "", "", "user", DOUBAO_ENDPOINT,
+				"resource", Duration.ofSeconds(2), 128, 128);
+
+		Thread.interrupted();
+		BusinessException interrupted = assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[] {1}, null));
+		assertEquals("DOUBAO_ASR_INTERRUPTED", interrupted.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	private DeepSeekLlmProvider deepSeekProvider(
+			RecordingHttpClient client, String apiKey, int maxResponseBytes) {
+		return new DeepSeekLlmProvider(
+				client, new ObjectMapper(), apiKey, DEEPSEEK_ENDPOINT,
+				"deepseek-v4-flash", Duration.ofSeconds(2), maxResponseBytes);
+	}
+
+	private DoubaoAsrProvider doubaoProvider(
+			RecordingHttpClient client,
+			String apiKey,
+			String appKey,
+			String accessKey,
+			int maxAudioBytes,
+			int maxResponseBytes) {
+		return new DoubaoAsrProvider(
+				client, new ObjectMapper(), apiKey, appKey, accessKey, "unispeaking",
+				DOUBAO_ENDPOINT, "volc.bigasr.auc_turbo", Duration.ofSeconds(2),
+				maxAudioBytes, maxResponseBytes);
+	}
+
+	private static Map<String, List<String>> successHeaders() {
+		return Map.of("X-Api-Status-Code", List.of("20000000"));
+	}
+
+	private static byte[] utf8(String value) {
+		return value.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static String readBody(HttpRequest request) {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		CompletableFuture<Void> complete = new CompletableFuture<>();
+		request.bodyPublisher().orElseThrow().subscribe(new Flow.Subscriber<>() {
+			@Override
+			public void onSubscribe(Flow.Subscription subscription) {
+				subscription.request(Long.MAX_VALUE);
+			}
+
+			@Override
+			public void onNext(ByteBuffer item) {
+				byte[] chunk = new byte[item.remaining()];
+				item.get(chunk);
+				bytes.writeBytes(chunk);
+			}
+
+			@Override
+			public void onError(Throwable throwable) {
+				complete.completeExceptionally(throwable);
+			}
+
+			@Override
+			public void onComplete() {
+				complete.complete(null);
+			}
+		});
+		complete.join();
+		return bytes.toString(StandardCharsets.UTF_8);
+	}
+
+	private static final class RecordingHttpClient extends HttpClient {
+
+		private final List<QueuedResponse> responses;
+		private final List<HttpRequest> requests = new ArrayList<>();
+		private boolean bodyCompletedOnSubscribe;
+
+		private RecordingHttpClient(QueuedResponse... responses) {
+			this.responses = new ArrayList<>(List.of(responses));
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> HttpResponse<T> send(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler)
+				throws IOException {
+			requests.add(request);
+			QueuedResponse response = responses.removeFirst();
+			if (response.failWithIoError()) {
+				throw new IOException("simulated network failure");
+			}
+			byte[] rawBody = response.body() instanceof byte[] bytes
+					? bytes
+					: response.body().toString().getBytes(StandardCharsets.UTF_8);
+			HttpResponse.BodySubscriber<T> subscriber = responseBodyHandler.apply(
+					new RecordedResponseInfo(response.statusCode(), response.headers()));
+			subscriber.onSubscribe(new Flow.Subscription() {
+				@Override
+				public void request(long count) { }
+
+				@Override
+				public void cancel() { }
+			});
+			bodyCompletedOnSubscribe |= subscriber.getBody().toCompletableFuture().isDone();
+			subscriber.onNext(List.of(ByteBuffer.wrap(rawBody)));
+			subscriber.onComplete();
+			T handledBody;
+			try {
+				handledBody = subscriber.getBody().toCompletableFuture().join();
+			}
+			catch (java.util.concurrent.CompletionException exception) {
+				if (exception.getCause() instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				throw exception;
+			}
+			return (HttpResponse<T>) new RecordedHttpResponse<>(
+					request, response.statusCode(), handledBody, response.headers());
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler) {
+			try {
+				return CompletableFuture.completedFuture(send(request, responseBodyHandler));
+			}
+			catch (IOException exception) {
+				return CompletableFuture.failedFuture(exception);
+			}
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler,
+				HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+			try {
+				return CompletableFuture.completedFuture(send(request, responseBodyHandler));
+			}
+			catch (IOException exception) {
+				return CompletableFuture.failedFuture(exception);
+			}
+		}
+
+		@Override
+		public Optional<CookieHandler> cookieHandler() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Optional<Duration> connectTimeout() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Redirect followRedirects() {
+			return Redirect.NEVER;
+		}
+
+		@Override
+		public Optional<ProxySelector> proxy() {
+			return Optional.empty();
+		}
+
+		@Override
+		public SSLContext sslContext() {
+			return null;
+		}
+
+		@Override
+		public SSLParameters sslParameters() {
+			return new SSLParameters();
+		}
+
+		@Override
+		public Optional<Authenticator> authenticator() {
+			return Optional.empty();
+		}
+
+		@Override
+		public Version version() {
+			return Version.HTTP_1_1;
+		}
+
+		@Override
+		public Optional<Executor> executor() {
+			return Optional.empty();
+		}
+	}
+
+	private record QueuedResponse(
+			int statusCode,
+			Object body,
+			Map<String, List<String>> headers,
+			boolean failWithIoError) {
+
+		private QueuedResponse(int statusCode, Object body) {
+			this(statusCode, body, Map.of(), false);
+		}
+
+		private QueuedResponse(
+				int statusCode,
+				Object body,
+				Map<String, List<String>> headers) {
+			this(statusCode, body, headers, false);
+		}
+
+		private static QueuedResponse ioError() {
+			return new QueuedResponse(0, null, Map.of(), true);
+		}
+	}
+
+	private record RecordedResponseInfo(
+			int statusCode,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse.ResponseInfo {
+
+		@Override
+		public HttpHeaders headers() {
+			return HttpHeaders.of(responseHeaders, (name, value) -> true);
+		}
+
+		@Override
+		public HttpClient.Version version() {
+			return HttpClient.Version.HTTP_1_1;
+		}
+	}
+
+	private record RecordedHttpResponse<T>(
+			HttpRequest request,
+			int statusCode,
+			T body,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse<T> {
+
+		@Override
+		public Optional<HttpResponse<T>> previousResponse() {
+			return Optional.empty();
+		}
+
+		@Override
+		public HttpHeaders headers() {
+			return HttpHeaders.of(responseHeaders, (name, value) -> true);
+		}
+
+		@Override
+		public Optional<SSLSession> sslSession() {
+			return Optional.empty();
+		}
+
+		@Override
+		public URI uri() {
+			return request.uri();
+		}
+
+		@Override
+		public HttpClient.Version version() {
+			return HttpClient.Version.HTTP_1_1;
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/iflytek/IflytekScoringProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/iflytek/IflytekScoringProviderTest.java
@@ -1,0 +1,471 @@
+package com.unispeaking.infrastructure.ai.iflytek;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unispeaking.common.exception.BusinessException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.net.http.WebSocket;
+import java.net.http.WebSocketHandshakeException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+class IflytekScoringProviderTest {
+
+	private static final URI OFFICIAL_ENDPOINT = URI.create(
+			"wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720");
+	private static final String FINAL_RESPONSE = """
+			{"header":{"code":0,"message":"success","status":2},
+			 "payload":{"result":{"status":2,"text":"e30="}}}
+			""";
+
+	@Test
+	void evaluatesPronunciationAndSendsSmallAudioAsStartAndEmptyEndFrames()
+			throws Exception {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider provider = provider(connector);
+
+		String response = provider.evaluatePronunciation(
+				"  Practice makes progress.  ",
+				wav(16_000, 2),
+				null);
+
+		assertEquals(FINAL_RESPONSE, response);
+		assertEquals(2, connector.frames.size());
+		JsonNode first = new ObjectMapper().readTree(connector.frames.get(0));
+		JsonNode last = new ObjectMapper().readTree(connector.frames.get(1));
+		assertEquals(0, first.path("header").path("status").asInt());
+		assertEquals(0, first.path("payload").path("data").path("status").asInt());
+		assertEquals(0, first.path("payload").path("seq").asInt());
+		assertEquals("Practice makes progress.", first.path("parameter").path("st")
+				.path("refText").asString());
+		assertEquals("lame", first.path("payload").path("data").path("encoding").asString());
+		assertEquals(2, last.path("header").path("status").asInt());
+		assertEquals(2, last.path("payload").path("data").path("status").asInt());
+		assertEquals(1, last.path("payload").path("data").path("seq").asInt());
+		assertTrue(last.path("payload").path("data").path("frame_size").asInt() >= 0);
+		assertTrue(connector.socket.outputClosed);
+		assertTrue(connector.uri.getQuery().contains("authorization="));
+		assertTrue(connector.uri.getQuery().contains("host=cn-east-1.ws-api.xf-yun.com"));
+		assertFalse(connector.uri.toString().contains("api-secret"));
+	}
+
+	@Test
+	void sendsMiddleAndFinalAudioFramesWithIncreasingSequences() throws Exception {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider provider = provider(connector, Duration.ofSeconds(2), Duration.ZERO);
+
+		provider.evaluatePronunciation("hello", wav(16_000, 1_000_000), null);
+
+		assertTrue(connector.frames.size() > 2);
+		JsonNode first = json(connector.frames.get(0));
+		JsonNode middle = json(connector.frames.get(1));
+		JsonNode last = json(connector.frames.get(connector.frames.size() - 1));
+		assertEquals(0, first.path("payload").path("data").path("status").asInt());
+		assertEquals(1, middle.path("payload").path("data").path("status").asInt());
+		assertEquals(1, middle.path("payload").path("data").path("seq").asInt());
+		assertEquals(2, last.path("payload").path("data").path("status").asInt());
+		assertEquals(connector.frames.size() - 1,
+				last.path("payload").path("data").path("seq").asInt());
+		assertTrue(last.path("payload").path("data").path("frame_size").asInt() > 0);
+	}
+
+	@Test
+	void signsEndpointUsingConfiguredApiKeyAndEscapedQueryValues() {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider provider = new IflytekScoringProvider(
+				new ObjectMapper(), connector, "app id", "key+/=", "secret",
+				OFFICIAL_ENDPOINT, " en ", " sent ", Duration.ofSeconds(2),
+				1_048_576, Duration.ZERO);
+
+		provider.evaluatePronunciation("hello", wav(16_000, 2), null);
+
+		assertNotNull(connector.uri);
+		String authorization = queryParameter(connector.uri, "authorization");
+		assertTrue(new String(Base64.getDecoder().decode(authorization), StandardCharsets.UTF_8)
+				.contains("api_key=\"key+/=\""));
+		assertTrue(connector.uri.getRawQuery().contains("authorization="));
+		assertTrue(connector.uri.getRawQuery().contains("date="));
+	}
+
+	@Test
+	void mapsHandshakeRejectionAndAbortsConnectedSocketOnFailure() {
+		WebSocketHandshakeException handshake =
+				new WebSocketHandshakeException(response(401));
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		connector.connectFailure = handshake;
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(connector).evaluatePronunciation("hello", wav(16_000, 2), null));
+
+		assertEquals("IFLYTEK_SUNTONE_HANDSHAKE_REJECTED", exception.code());
+		assertEquals(401, handshake.getResponse().statusCode());
+	}
+
+	@Test
+	void mapsConnectionFailureAndAbortsSocketAfterSendFailure() {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		connector.sendFailure = new IOExceptionFailure();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(connector).evaluatePronunciation("hello", wav(16_000, 2), null));
+
+		assertEquals("IFLYTEK_SUNTONE_CONNECTION_FAILED", exception.code());
+		assertTrue(connector.socket.outputClosed);
+	}
+
+	@Test
+	void mapsInterruptedConnectAndRestoresInterruptFlag() {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		connector.connectFuture = new CompletableFuture<>();
+		Thread.currentThread().interrupt();
+		try {
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider(connector).evaluatePronunciation("hello", wav(16_000, 2), null));
+			assertEquals("IFLYTEK_SUNTONE_INTERRUPTED", exception.code());
+			assertTrue(Thread.currentThread().isInterrupted());
+		}
+		finally {
+			Thread.interrupted();
+		}
+	}
+
+	@Test
+	void mapsSocketErrorAndCloseBeforeFinalResponse() {
+		RecordingConnector errorConnector = new RecordingConnector(FINAL_RESPONSE);
+		errorConnector.notifyError = true;
+		BusinessException error = assertThrows(
+				BusinessException.class,
+				() -> provider(errorConnector).evaluatePronunciation("hello", wav(16_000, 2), null));
+		assertEquals("IFLYTEK_SUNTONE_CONNECTION_FAILED", error.code());
+
+		RecordingConnector closeConnector = new RecordingConnector(FINAL_RESPONSE);
+		closeConnector.closeOnFirstSend = true;
+		BusinessException close = assertThrows(
+				BusinessException.class,
+				() -> provider(closeConnector).evaluatePronunciation("hello", wav(16_000, 2), null));
+		assertEquals("IFLYTEK_SUNTONE_CONNECTION_CLOSED", close.code());
+	}
+
+	@Test
+	void rejectsInvalidConfigurationAndMalformedWavBeforeConnecting() {
+		assertEquals("iFlytek Suntone language is required", assertThrows(
+				IllegalArgumentException.class,
+				() -> new IflytekScoringProvider(new ObjectMapper(), new RecordingConnector(FINAL_RESPONSE),
+						"app", "key", "secret", OFFICIAL_ENDPOINT, " ", "sent",
+						Duration.ofSeconds(1), 100, Duration.ZERO)).getMessage());
+		assertThrows(IllegalArgumentException.class,
+				() -> new IflytekScoringProvider(new ObjectMapper(), new RecordingConnector(FINAL_RESPONSE),
+						"app", "key", "secret", OFFICIAL_ENDPOINT, "en", "sent",
+						Duration.ZERO, 100, Duration.ZERO));
+		assertThrows(IllegalArgumentException.class,
+				() -> new IflytekScoringProvider(new ObjectMapper(), new RecordingConnector(FINAL_RESPONSE),
+						"app", "key", "secret", OFFICIAL_ENDPOINT, "en", "sent",
+						Duration.ofSeconds(1), 100, Duration.ofMillis(-1)));
+
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(connector).evaluatePronunciation("hello", new byte[] {'R', 'I', 'F', 'F'}, null));
+		assertEquals("INVALID_PRONUNCIATION_WAV", exception.code());
+		assertTrue(connector.uri == null);
+	}
+
+	@Test
+	void mapsResponseErrorsAndOversizedResponse() {
+		RecordingConnector quota = new RecordingConnector(
+				"{\"header\":{\"code\":11200,\"status\":2}}");
+		BusinessException quotaFailure = assertThrows(
+				BusinessException.class,
+				() -> provider(quota).evaluatePronunciation("hello", wav(16_000, 2), null));
+		assertEquals("IFLYTEK_SUNTONE_NOT_AUTHORIZED", quotaFailure.code());
+
+		RecordingConnector oversized = new RecordingConnector(FINAL_RESPONSE);
+		oversized.responseParts = List.of("x".repeat(1_500_001));
+		BusinessException sizeFailure = assertThrows(
+				BusinessException.class,
+				() -> provider(oversized).evaluatePronunciation("hello", wav(16_000, 2), null));
+		assertEquals("IFLYTEK_SUNTONE_RESPONSE_TOO_LARGE", sizeFailure.code());
+		assertTrue(oversized.socket.outputClosed);
+	}
+
+	@Test
+	void usesCredentialOverridesForSigningAndRejectsMissingEffectiveCredentials() {
+		RecordingConnector missing = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider missingProvider = new IflytekScoringProvider(
+				new ObjectMapper(), missing, "", "", "", OFFICIAL_ENDPOINT,
+				"en", "sent", Duration.ofSeconds(2), 1_048_576, Duration.ZERO);
+		BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> missingProvider.evaluatePronunciation("hello", wav(16_000, 2), null));
+		assertEquals("IFLYTEK_SUNTONE_CREDENTIAL_MISSING", exception.code());
+	}
+
+	@Test
+	void coversAllSuntoneProviderStatusMappings() {
+		for (var status : List.of(
+				new Object[] {11200, "IFLYTEK_SUNTONE_NOT_AUTHORIZED"},
+				new Object[] {11201, "IFLYTEK_SUNTONE_DAILY_QUOTA_EXHAUSTED"},
+				new Object[] {11202, "IFLYTEK_SUNTONE_RATE_LIMITED"},
+				new Object[] {11203, "IFLYTEK_SUNTONE_AUTHORIZATION_EXPIRED"},
+				new Object[] {99999, "IFLYTEK_SUNTONE_REQUEST_FAILED"})) {
+			RecordingConnector connector = new RecordingConnector(
+					"{\"header\":{\"code\":" + status[0] + ",\"status\":2}}");
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider(connector).evaluatePronunciation(
+							"hello", wav(16_000, 2), null));
+			assertEquals(status[1], exception.code());
+		}
+	}
+
+	@Test
+	void coversPacingTimeoutAndWavChunkValidationBranches() {
+		RecordingConnector connector = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider paced = provider(
+				connector, Duration.ofSeconds(2), Duration.ofMillis(1));
+		assertEquals(FINAL_RESPONSE, paced.evaluatePronunciation(
+				"hello", wav(16_000, 4_000), null));
+
+		List<byte[]> invalidWavs = List.of(
+				wavWithChunk("fmt ", 8, 16),
+				wavWithChunk("data", -1, 16),
+				wavWithChunk("data", 3, 16),
+				truncatedUnknownChunk(),
+				truncatedRiff(),
+				wavWithFormat(2, 16_000, 16, 2));
+		for (int index = 0; index < invalidWavs.size(); index++) {
+			byte[] invalid = invalidWavs.get(index);
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider(new RecordingConnector(FINAL_RESPONSE))
+							.evaluatePronunciation("hello", invalid, null),
+					"invalid WAV case " + index);
+			assertEquals("INVALID_PRONUNCIATION_WAV", exception.code());
+		}
+	}
+
+	@Test
+	void coversCredentialAndEndpointOverridesAndTimeoutResponsePaths() {
+		RecordingConnector endpointConnector = new RecordingConnector(FINAL_RESPONSE);
+		IflytekScoringProvider endpointProvider = new IflytekScoringProvider(
+				new ObjectMapper(), endpointConnector, "app", "key", "secret",
+				URI.create("wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720"),
+				"en", "sent", Duration.ofMillis(1), 1_048_576, Duration.ZERO);
+		assertEquals("IFLYTEK_SUNTONE_TIMEOUT", assertThrows(
+				BusinessException.class,
+				() -> endpointProvider.evaluatePronunciation("hello", wav(16_000, 2), null)).code());
+
+		for (URI endpoint : List.of(
+				URI.create("http://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720"),
+				URI.create("wss://cn-east-1.ws-api.xf-yun.com:443/v1/private/s8e098720"),
+				URI.create("wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720?x=1"))) {
+			BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> new IflytekScoringProvider(
+						new ObjectMapper(), new RecordingConnector(FINAL_RESPONSE),
+						"app", "key", "secret", endpoint, "en", "sent",
+						Duration.ofSeconds(1), 1_048_576, Duration.ZERO)
+						.evaluatePronunciation("hello", wav(16_000, 2), null));
+			assertEquals("IFLYTEK_SUNTONE_ENDPOINT_INVALID", exception.code());
+		}
+	}
+
+	private IflytekScoringProvider provider(RecordingConnector connector) {
+		return provider(connector, Duration.ofSeconds(2), Duration.ZERO);
+	}
+
+	private IflytekScoringProvider provider(
+			RecordingConnector connector,
+			Duration timeout,
+			Duration frameDelay) {
+		return new IflytekScoringProvider(
+				new ObjectMapper(), connector, "app-id", "api-key", "api-secret",
+				OFFICIAL_ENDPOINT, "en", "sent", timeout, 1_048_576, frameDelay);
+	}
+
+	private static JsonNode json(String value) throws Exception {
+		return new ObjectMapper().readTree(value);
+	}
+
+	private static String queryParameter(URI uri, String name) {
+		for (String parameter : uri.getRawQuery().split("&")) {
+			String[] pair = parameter.split("=", 2);
+			if (pair.length == 2 && pair[0].equals(name)) {
+				return URLDecoder.decode(pair[1], StandardCharsets.UTF_8);
+			}
+		}
+		return "";
+	}
+
+	private static byte[] wav(int sampleRate, int pcmBytes) {
+		ByteBuffer wav = ByteBuffer.allocate(46 + pcmBytes)
+				.order(ByteOrder.LITTLE_ENDIAN);
+		wav.put("RIFF".getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+		wav.putInt(38 + pcmBytes);
+		wav.put("WAVEfmt ".getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+		wav.putInt(16).putShort((short) 1).putShort((short) 1);
+		wav.putInt(sampleRate).putInt(sampleRate * 2).putShort((short) 2).putShort((short) 16);
+		wav.put("data".getBytes(java.nio.charset.StandardCharsets.US_ASCII));
+		wav.putInt(pcmBytes);
+		for (int index = 0; index < pcmBytes; index++) {
+			wav.put((byte) (index * 17));
+		}
+		return wav.array();
+	}
+
+	private static byte[] wavWithChunk(String chunk, int size, int pcmBytes) {
+		byte[] base = wav(16_000, pcmBytes);
+		ByteBuffer value = ByteBuffer.allocate(base.length + 8 + Math.max(0, size))
+				.order(ByteOrder.LITTLE_ENDIAN);
+		value.put(base, 0, 12);
+		value.put(chunk.getBytes(StandardCharsets.US_ASCII));
+		value.putInt(size);
+		if (size > 0) value.put(new byte[size]);
+		value.put(base, 12, base.length - 12);
+		return value.array();
+	}
+
+	private static byte[] truncatedRiff() {
+		byte[] value = wav(16_000, 2);
+		ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN).putInt(0, value.length + 100);
+		return value;
+	}
+
+	private static byte[] truncatedUnknownChunk() {
+		byte[] value = wav(16_000, 2);
+		ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN).putInt(16, value.length);
+		return value;
+	}
+
+	private static byte[] wavWithFormat(int audioFormat, int sampleRate,
+			int bits, int channels) {
+		byte[] value = wav(sampleRate, 2);
+		ByteBuffer buffer = ByteBuffer.wrap(value).order(ByteOrder.LITTLE_ENDIAN);
+		buffer.putShort(20, (short) audioFormat);
+		buffer.putShort(22, (short) channels);
+		buffer.putShort(34, (short) bits);
+		return value;
+	}
+
+	private static HttpResponse<Void> response(int statusCode) {
+		return new HttpResponse<>() {
+			@Override public int statusCode() { return statusCode; }
+			@Override public HttpRequest request() { return null; }
+			@Override public Optional<HttpResponse<Void>> previousResponse() { return Optional.empty(); }
+			@Override public HttpHeaders headers() { return HttpHeaders.of(Map.of(), (a, b) -> true); }
+			@Override public Void body() { return null; }
+			@Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+			@Override public URI uri() { return OFFICIAL_ENDPOINT; }
+			@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+		};
+	}
+
+	private static <T> CompletableFuture<T> failedFuture(Throwable throwable) {
+		CompletableFuture<T> future = new CompletableFuture<>();
+		future.completeExceptionally(throwable);
+		return future;
+	}
+
+	private static final class IOExceptionFailure extends java.io.IOException {
+		private static final long serialVersionUID = 1L;
+	}
+
+	private static final class RecordingConnector implements IflytekScoringProvider.WebSocketConnector {
+		private final String finalResponse;
+		private final List<String> frames = new ArrayList<>();
+		private URI uri;
+		private RecordingSocket socket;
+		private Throwable connectFailure;
+		private CompletableFuture<WebSocket> connectFuture;
+		private Throwable sendFailure;
+		private boolean notifyError;
+		private boolean closeOnFirstSend;
+		private List<String> responseParts = List.of();
+
+		private RecordingConnector(String finalResponse) {
+			this.finalResponse = finalResponse;
+		}
+
+		@Override
+		public CompletableFuture<WebSocket> connect(URI uri, WebSocket.Listener listener) {
+			this.uri = uri;
+			if (connectFuture != null) {
+				return connectFuture;
+			}
+			if (connectFailure != null) {
+				return failedFuture(connectFailure);
+			}
+			socket = new RecordingSocket(listener, this);
+			listener.onOpen(socket);
+			return CompletableFuture.completedFuture(socket);
+		}
+	}
+
+	private static final class RecordingSocket implements WebSocket {
+		private final Listener listener;
+		private final RecordingConnector owner;
+		private boolean outputClosed;
+		private boolean inputClosed;
+
+		private RecordingSocket(Listener listener, RecordingConnector owner) {
+			this.listener = listener;
+			this.owner = owner;
+		}
+
+		@Override
+		public CompletableFuture<WebSocket> sendText(CharSequence data, boolean last) {
+			String frame = data.toString();
+			owner.frames.add(frame);
+			if (owner.sendFailure != null) {
+				return failedFuture(owner.sendFailure);
+			}
+			if (owner.closeOnFirstSend && owner.frames.size() == 1) {
+				listener.onClose(this, 1000, "closed");
+				return CompletableFuture.completedFuture(this);
+			}
+			if (owner.notifyError) {
+				listener.onError(this, new java.io.IOException("socket error"));
+			}
+			if (frame.contains("\"status\":2")) {
+				List<String> parts = owner.responseParts.isEmpty()
+						? List.of(owner.finalResponse) : owner.responseParts;
+				for (int index = 0; index < parts.size(); index++) {
+					listener.onText(this, parts.get(index), index == parts.size() - 1);
+				}
+			}
+			return CompletableFuture.completedFuture(this);
+		}
+
+		@Override public CompletableFuture<WebSocket> sendBinary(ByteBuffer data, boolean last) { return CompletableFuture.completedFuture(this); }
+		@Override public CompletableFuture<WebSocket> sendPing(ByteBuffer message) { return CompletableFuture.completedFuture(this); }
+		@Override public CompletableFuture<WebSocket> sendPong(ByteBuffer message) { return CompletableFuture.completedFuture(this); }
+		@Override public CompletableFuture<WebSocket> sendClose(int statusCode, String reason) { outputClosed = true; inputClosed = true; return CompletableFuture.completedFuture(this); }
+		@Override public void request(long n) { }
+		@Override public String getSubprotocol() { return ""; }
+		@Override public boolean isOutputClosed() { return outputClosed; }
+		@Override public boolean isInputClosed() { return inputClosed; }
+		@Override public void abort() { outputClosed = true; inputClosed = true; }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/minimax/MiniMaxTtsProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/minimax/MiniMaxTtsProviderTest.java
@@ -1,0 +1,421 @@
+package com.unispeaking.infrastructure.ai.minimax;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.unispeaking.common.exception.BusinessException;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class MiniMaxTtsProviderTest {
+
+	@Test
+	void sendsConfiguredAudioFormatSampleRateAndBitrateAndDecodesHexAudio() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"data\":{\"audio\":\"494433040000\"},\"base_resp\":{\"status_code\":0}}")));
+		MiniMaxTtsProvider provider = provider(client, "minimax-key", "flac", 44_100, 256_000, 128);
+
+		byte[] audio = provider.generateSpeechAudio("  Practice makes progress.  ", null);
+
+		assertArrayEquals(new byte[] {0x49, 0x44, 0x33, 0x04, 0, 0}, audio);
+		HttpRequest request = client.requests.getFirst();
+		assertEquals("Bearer minimax-key",
+				request.headers().firstValue("Authorization").orElseThrow());
+		String body = readBody(request);
+		assertTrue(body.contains("\"format\":\"flac\""));
+		assertTrue(body.contains("\"sample_rate\":44100"));
+		assertTrue(body.contains("\"bitrate\":256000"));
+		assertTrue(body.contains("\"output_format\":\"hex\""));
+		assertFalse(body.contains("minimax-key"));
+	}
+
+	@Test
+	void acceptsTrustedRegionalEndpointsAndRegistersConfiguredModel() {
+		for (String host : List.of("api.minimaxi.com", "api-bj.minimaxi.com", "api.minimax.io", "api-uw.minimax.io")) {
+			MiniMaxTtsProvider provider = provider(
+					new RecordingHttpClient(new QueuedResponse(
+							200,
+							utf8("{\"data\":{\"audio\":\"00\"},\"base_resp\":{\"status_code\":0}}"))),
+					"key",
+					"wav",
+					32_000,
+					128_000,
+					128,
+					URI.create("https://" + host + "/v1/t2a_v2"),
+					"custom-model");
+
+			assertEquals("custom-model", provider.supportedModels().iterator().next());
+			assertArrayEquals(new byte[] {0}, provider.generateSpeechAudio("hello", null));
+		}
+	}
+
+	@Test
+	void rejectsUntrustedOrMalformedEndpointsBeforeSendingCredentials() {
+		List<URI> invalidEndpoints = List.of(
+				URI.create("http://api.minimaxi.com/v1/t2a_v2"),
+				URI.create("https://evil.example/v1/t2a_v2"),
+				URI.create("https://api.minimaxi.com:443/v1/t2a_v2"),
+				URI.create("https://api.minimaxi.com/v1/t2a_v2?debug=true"),
+				URI.create("https://user:pass@api.minimaxi.com/v1/t2a_v2"),
+				URI.create("https://api.minimaxi.com/v1/tts"));
+
+		for (URI endpoint : invalidEndpoints) {
+			RecordingHttpClient client = new RecordingHttpClient();
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> provider(client, "secret", "wav", 32_000, 128_000, 128, endpoint, "model")
+							.generateSpeechAudio("hello", null));
+
+			assertEquals("MINIMAX_TTS_ENDPOINT_INVALID", exception.code());
+			assertTrue(client.requests.isEmpty());
+		}
+	}
+
+	@Test
+	void mapsProviderBusinessErrorsAndHttpErrors() {
+		RecordingHttpClient providerError = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"data\":null,\"base_resp\":{\"status_code\":1008,\"status_msg\":\"insufficient balance\"}}")));
+		BusinessException businessException = assertThrows(
+				BusinessException.class,
+				() -> provider(providerError, "secret").generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_REQUEST_FAILED", businessException.code());
+		assertTrue(businessException.getMessage().contains("1008"));
+		assertFalse(businessException.getMessage().contains("secret"));
+
+		BusinessException httpException = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(new QueuedResponse(429, utf8("rate limited"))), "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_REQUEST_FAILED", httpException.code());
+	}
+
+	@Test
+	void mapsEmptyInvalidAndOversizedAudioAndInvalidJson() {
+		assertResponseError("{\"data\":{\"audio\":\"\"},\"base_resp\":{\"status_code\":0}}",
+				"MINIMAX_TTS_AUDIO_EMPTY");
+		assertResponseError("{\"data\":{\"audio\":\"not-hex\"},\"base_resp\":{\"status_code\":0}}",
+				"MINIMAX_TTS_AUDIO_INVALID");
+		assertResponseError("not-json", "MINIMAX_TTS_RESPONSE_INVALID");
+
+		RecordingHttpClient oversized = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"data\":{\"audio\":\"00010203\"},\"base_resp\":{\"status_code\":0}}")));
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(oversized, "key", "wav", 32_000, 128_000, 2)
+						.generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_AUDIO_TOO_LARGE", exception.code());
+	}
+
+	@Test
+	void mapsTransportAndInterruptedFailuresWithoutLeakingCredentials() throws Exception {
+		BusinessException ioException = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(QueuedResponse.ioError()), "secret")
+						.generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_IO_ERROR", ioException.code());
+		assertFalse(ioException.getMessage().contains("secret"));
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		try {
+			doThrow(new InterruptedException("cancelled"))
+					.when(interruptedClient)
+					.send(any(HttpRequest.class),
+							org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		}
+		catch (java.io.IOException exception) {
+			throw new AssertionError(exception);
+		}
+		Thread.interrupted();
+		BusinessException interrupted = assertThrows(
+				BusinessException.class,
+				() -> provider(interruptedClient, "key").generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_INTERRUPTED", interrupted.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
+	void validatesCredentialTextFormatSampleRateAndBitrate() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		assertEquals("MINIMAX_TTS_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "").generateSpeechAudio("hello", null)).code());
+		assertEquals("INVALID_TTS_TEXT", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "key").generateSpeechAudio(" ", null)).code());
+		assertEquals("TTS_TEXT_TOO_LONG", assertThrows(
+				BusinessException.class,
+				() -> provider(client, "key").generateSpeechAudio("x".repeat(10_000), null)).code());
+		assertTrue(client.requests.isEmpty());
+
+		assertThrows(IllegalArgumentException.class,
+				() -> provider(client, "key", "ogg", 32_000, 128_000, 128));
+		assertThrows(IllegalArgumentException.class,
+				() -> provider(client, "key", "wav", 48_000, 128_000, 128));
+		assertThrows(IllegalArgumentException.class,
+				() -> provider(client, "key", "wav", 32_000, 96_000, 128));
+	}
+
+	@Test
+	void validatesSpringConstructorTimeoutsAndNullDependencies() {
+		assertThrows(IllegalArgumentException.class, () -> new MiniMaxTtsProvider(
+				new ObjectMapper(), "key", "https://api.minimaxi.com/v1/t2a_v2", "model", "voice",
+				"wav", 32_000, 128_000, 0, 1, 128));
+		assertThrows(IllegalArgumentException.class, () -> new MiniMaxTtsProvider(
+				new ObjectMapper(), "key", "https://api.minimaxi.com/v1/t2a_v2", "model", "voice",
+				"wav", 32_000, 128_000, 1, 0, 128));
+		assertThrows(IllegalArgumentException.class, () -> new MiniMaxTtsProvider(
+				null, new ObjectMapper(), "key", URI.create("https://api.minimaxi.com/v1/t2a_v2"),
+				"model", "voice", "wav", 32_000, 128_000, Duration.ofSeconds(1), 128));
+	}
+
+	@Test
+	void handlesMalformedConfiguredEndpointAndJsonResponseLimit() {
+		MiniMaxTtsProvider malformed = new MiniMaxTtsProvider(
+				new RecordingHttpClient(), new ObjectMapper(), "key", null,
+				"model", "voice", "wav", 32_000, 128_000, Duration.ofSeconds(1), 128);
+		assertEquals("MINIMAX_TTS_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> malformed.generateSpeechAudio("hello", null)).code());
+
+		RecordingHttpClient oversized = new RecordingHttpClient(new QueuedResponse(
+				200, utf8("x".repeat(2_000_000))));
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(oversized, "key", "wav", 32_000, 128_000, 1)
+						.generateSpeechAudio("hello", null));
+		assertEquals("MINIMAX_TTS_RESPONSE_TOO_LARGE", exception.code());
+	}
+
+	private void assertResponseError(String response, String expectedCode) {
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider(new RecordingHttpClient(new QueuedResponse(200, utf8(response))), "key")
+						.generateSpeechAudio("hello", null));
+		assertEquals(expectedCode, exception.code());
+	}
+
+	private MiniMaxTtsProvider provider(RecordingHttpClient client, String apiKey) {
+		return provider(client, apiKey, "wav", 32_000, 128_000, 1_048_576);
+	}
+
+	private MiniMaxTtsProvider provider(HttpClient client, String apiKey) {
+		return provider(client, apiKey, "wav", 32_000, 128_000, 1_048_576);
+	}
+
+	private MiniMaxTtsProvider provider(
+			RecordingHttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int bitrate,
+			int maxAudioBytes) {
+		return provider(
+				client,
+				apiKey,
+				format,
+				sampleRate,
+				bitrate,
+				maxAudioBytes,
+				URI.create("https://api.minimaxi.com/v1/t2a_v2"),
+				"speech-2.8-hd");
+	}
+
+	private MiniMaxTtsProvider provider(
+			HttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int bitrate,
+			int maxAudioBytes) {
+		return new MiniMaxTtsProvider(
+				client,
+				new ObjectMapper(),
+				apiKey,
+				URI.create("https://api.minimaxi.com/v1/t2a_v2"),
+				"speech-2.8-hd",
+				"male-qn-qingse",
+				format,
+				sampleRate,
+				bitrate,
+				Duration.ofSeconds(20),
+				maxAudioBytes);
+	}
+
+	private MiniMaxTtsProvider provider(
+			RecordingHttpClient client,
+			String apiKey,
+			String format,
+			int sampleRate,
+			int bitrate,
+			int maxAudioBytes,
+			URI endpoint,
+			String model) {
+		return new MiniMaxTtsProvider(
+				client,
+				new ObjectMapper(),
+				apiKey,
+				endpoint,
+				model,
+				"male-qn-qingse",
+				format,
+				sampleRate,
+				bitrate,
+				Duration.ofSeconds(20),
+				maxAudioBytes);
+	}
+
+	private static byte[] utf8(String value) {
+		return value.getBytes(StandardCharsets.UTF_8);
+	}
+
+	private static String readBody(HttpRequest request) {
+		ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+		CompletableFuture<Void> completed = new CompletableFuture<>();
+		request.bodyPublisher().orElseThrow().subscribe(new Flow.Subscriber<>() {
+			@Override public void onSubscribe(Flow.Subscription subscription) { subscription.request(Long.MAX_VALUE); }
+			@Override public void onNext(ByteBuffer item) {
+				byte[] chunk = new byte[item.remaining()];
+				item.get(chunk);
+				bytes.writeBytes(chunk);
+			}
+			@Override public void onError(Throwable throwable) { completed.completeExceptionally(throwable); }
+			@Override public void onComplete() { completed.complete(null); }
+		});
+		completed.join();
+		return bytes.toString(StandardCharsets.UTF_8);
+	}
+
+	private static final class RecordingHttpClient extends HttpClient {
+		private final List<QueuedResponse> responses;
+		private final List<HttpRequest> requests = new ArrayList<>();
+
+		private RecordingHttpClient(QueuedResponse... responses) {
+			this.responses = new ArrayList<>(List.of(responses));
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> HttpResponse<T> send(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler)
+				throws IOException {
+			requests.add(request);
+			QueuedResponse response = responses.removeFirst();
+			if (response.failWithIoError()) throw new IOException("simulated network failure");
+			byte[] rawBody = response.body() instanceof byte[] bytes
+					? bytes
+					: response.body().toString().getBytes(StandardCharsets.UTF_8);
+			HttpResponse.BodySubscriber<T> subscriber = responseBodyHandler.apply(
+					new RecordedResponseInfo(response.statusCode(), response.headers()));
+			subscriber.onSubscribe(new NoopSubscription());
+			subscriber.onNext(List.of(ByteBuffer.wrap(rawBody)));
+			subscriber.onComplete();
+			T handledBody;
+			try {
+				handledBody = subscriber.getBody().toCompletableFuture().join();
+			}
+			catch (java.util.concurrent.CompletionException exception) {
+				if (exception.getCause() instanceof RuntimeException runtimeException) {
+					throw runtimeException;
+				}
+				throw exception;
+			}
+			return (HttpResponse<T>) new RecordedHttpResponse<>(
+					request, response.statusCode(), handledBody, response.headers());
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler) {
+			try { return CompletableFuture.completedFuture(send(request, responseBodyHandler)); }
+			catch (IOException exception) { return CompletableFuture.failedFuture(exception); }
+		}
+
+		@Override
+		public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+				HttpRequest request,
+				HttpResponse.BodyHandler<T> responseBodyHandler,
+				HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+			return sendAsync(request, responseBodyHandler);
+		}
+
+		@Override public Optional<CookieHandler> cookieHandler() { return Optional.empty(); }
+		@Override public Optional<Duration> connectTimeout() { return Optional.empty(); }
+		@Override public Redirect followRedirects() { return Redirect.NEVER; }
+		@Override public Optional<ProxySelector> proxy() { return Optional.empty(); }
+		@Override public SSLContext sslContext() { return null; }
+		@Override public SSLParameters sslParameters() { return new SSLParameters(); }
+		@Override public Optional<Authenticator> authenticator() { return Optional.empty(); }
+		@Override public Version version() { return Version.HTTP_1_1; }
+		@Override public Optional<Executor> executor() { return Optional.empty(); }
+	}
+
+	private static final class NoopSubscription implements Flow.Subscription {
+		@Override public void request(long n) { }
+		@Override public void cancel() { }
+	}
+
+	private record QueuedResponse(
+			int statusCode,
+			Object body,
+			Map<String, List<String>> headers,
+			boolean failWithIoError) {
+		private QueuedResponse(int statusCode, Object body) { this(statusCode, body, Map.of(), false); }
+		private static QueuedResponse ioError() { return new QueuedResponse(0, null, Map.of(), true); }
+	}
+
+	private record RecordedResponseInfo(
+			int statusCode,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse.ResponseInfo {
+		@Override public HttpHeaders headers() { return HttpHeaders.of(responseHeaders, (name, value) -> true); }
+		@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+	}
+
+	private record RecordedHttpResponse<T>(
+			HttpRequest request,
+			int statusCode,
+			T body,
+			Map<String, List<String>> responseHeaders)
+			implements HttpResponse<T> {
+		@Override public Optional<HttpResponse<T>> previousResponse() { return Optional.empty(); }
+		@Override public HttpHeaders headers() { return HttpHeaders.of(responseHeaders, (name, value) -> true); }
+		@Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+		@Override public URI uri() { return request.uri(); }
+		@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qiniu/QiniuMaasLlmProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qiniu/QiniuMaasLlmProviderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -215,6 +216,104 @@ class QiniuMaasLlmProviderTest {
 		assertTrue(logs.contains("responseChars=2"));
 		assertFalse(logs.contains("secret-key"));
 		assertFalse(logs.contains("private prompt content"));
+	}
+
+	@Test
+	void mapsMalformedAndEmptyResponsesToSafeProviderFailures() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		@SuppressWarnings("unchecked")
+		HttpResponse<InputStream> response = (HttpResponse<InputStream>) mock(HttpResponse.class);
+		when(response.statusCode()).thenReturn(200);
+		when(response.body()).thenReturn(new java.io.ByteArrayInputStream("not-json".getBytes(StandardCharsets.UTF_8)));
+		when(httpClient.send(any(HttpRequest.class), org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+				.thenReturn(response);
+		QiniuMaasProperties properties = properties("key", "qwen/qwen3.5-plus");
+		QiniuMaasLlmProvider provider = new QiniuMaasLlmProvider(
+				new QiniuMaasLlmClient(httpClient, new ObjectMapper(), properties), properties.primaryModel());
+		BusinessException malformed = assertThrows(BusinessException.class,
+				() -> provider.executeLlmTask("hello", null));
+		assertEquals("QINIU_MAAS_LLM_RESPONSE_INVALID", malformed.code());
+
+		when(response.body()).thenReturn(new java.io.ByteArrayInputStream(
+				"{\"choices\":[{\"message\":{\"content\":\"\"}}]}".getBytes(StandardCharsets.UTF_8)));
+		BusinessException empty = assertThrows(BusinessException.class,
+				() -> provider.executeLlmTask("hello", null));
+		assertEquals("QINIU_MAAS_LLM_EMPTY_RESPONSE", empty.code());
+	}
+
+	@Test
+	void mapsHttpFailureAndResponseSizeLimitWithoutLeakingCredentials() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		@SuppressWarnings("unchecked")
+		HttpResponse<InputStream> response = (HttpResponse<InputStream>) mock(HttpResponse.class);
+		when(response.statusCode()).thenReturn(429);
+		when(response.body()).thenReturn(new java.io.ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)));
+		when(httpClient.send(any(HttpRequest.class), org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+				.thenReturn(response);
+		QiniuMaasProperties properties = properties("secret-key", "qwen/qwen3.5-plus");
+		QiniuMaasLlmProvider provider = new QiniuMaasLlmProvider(
+				new QiniuMaasLlmClient(httpClient, new ObjectMapper(), properties), properties.primaryModel());
+		BusinessException rateLimited = assertThrows(BusinessException.class,
+				() -> provider.executeLlmTask("hello", null));
+		assertEquals("QINIU_MAAS_LLM_REQUEST_FAILED", rateLimited.code());
+		assertFalse(rateLimited.getMessage().contains("secret-key"));
+
+		QiniuMaasProperties tiny = new QiniuMaasProperties("https://api.qnaigc.com/v1", "key",
+				"qwen/qwen3.5-plus", "deepseek/deepseek-v4-flash", Duration.ofSeconds(10),
+				Duration.ofSeconds(30), 3, 4096);
+		when(response.statusCode()).thenReturn(200);
+		when(response.body()).thenReturn(new java.io.ByteArrayInputStream("1234".getBytes(StandardCharsets.UTF_8)));
+		QiniuMaasLlmProvider limited = new QiniuMaasLlmProvider(
+				new QiniuMaasLlmClient(httpClient, new ObjectMapper(), tiny), tiny.primaryModel());
+		BusinessException oversized = assertThrows(BusinessException.class,
+				() -> limited.executeLlmTask("hello", null));
+		assertEquals("QINIU_MAAS_LLM_RESPONSE_TOO_LARGE", oversized.code());
+	}
+
+	@Test
+	void mapsIoAndInterruptFailuresAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		QiniuMaasProperties properties = properties("key", "qwen/qwen3.5-plus");
+		when(httpClient.send(any(HttpRequest.class),
+				org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+				.thenThrow(new IOException("offline"));
+		QiniuMaasLlmClient client = new QiniuMaasLlmClient(httpClient,
+				new ObjectMapper(), properties);
+		QiniuMaasLlmClient.ProviderFailure io = assertThrows(
+				QiniuMaasLlmClient.ProviderFailure.class,
+				() -> client.execute(properties.primaryModel(), "hello"));
+		assertEquals("QINIU_MAAS_LLM_IO_ERROR", io.code());
+		assertTrue(io.retryable());
+
+		when(httpClient.send(any(HttpRequest.class),
+				org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+				.thenThrow(new InterruptedException("cancelled"));
+		Thread.interrupted();
+		QiniuMaasLlmClient.ProviderFailure interrupted = assertThrows(
+				QiniuMaasLlmClient.ProviderFailure.class,
+				() -> client.execute(properties.primaryModel(), "hello"));
+		assertEquals("QINIU_MAAS_LLM_INTERRUPTED", interrupted.code());
+		assertFalse(interrupted.retryable());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
+	void marksForbiddenHttpFailuresAsNonRetryable() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		@SuppressWarnings("unchecked")
+		HttpResponse<InputStream> response = (HttpResponse<InputStream>) mock(HttpResponse.class);
+		when(response.statusCode()).thenReturn(403);
+		when(response.body()).thenReturn(new java.io.ByteArrayInputStream("{}".getBytes(StandardCharsets.UTF_8)));
+		when(httpClient.send(any(HttpRequest.class), org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<InputStream>>any()))
+				.thenReturn(response);
+		QiniuMaasProperties properties = properties("key", "qwen/qwen3.5-plus");
+		QiniuMaasLlmClient.ProviderFailure failure = assertThrows(
+				QiniuMaasLlmClient.ProviderFailure.class,
+				() -> new QiniuMaasLlmClient(httpClient, new ObjectMapper(), properties)
+						.execute(properties.primaryModel(), "hello"));
+		assertEquals("QINIU_MAAS_LLM_REQUEST_FAILED", failure.code());
+		assertFalse(failure.retryable());
 	}
 
 	private QiniuMaasProperties properties(String apiKey, String primaryModel) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qiniu/QiniuRealtimeProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qiniu/QiniuRealtimeProviderTest.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 
 import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.dto.session.RealtimeConnectCommand;
@@ -165,6 +168,202 @@ class QiniuRealtimeProviderTest {
 		assertEquals(1, unsupportedVoiceClient.requests.size());
 	}
 
+	@Test
+	void rejectsContextlessExchangeAndInvalidConnectCommandsBeforeHttp() {
+		QiniuRealtimeProvider provider = provider(new RecordingHttpClient(), "server-api-key");
+
+		assertEquals("QINIU_REALTIME_CONTEXT_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> provider.exchangeRealtimeSdp(
+						"qwen3.5-omni-plus-realtime", "offer-sdp", "token")).getMessage() != null
+						? "QINIU_REALTIME_CONTEXT_REQUIRED" : "");
+		assertEquals("INVALID_REALTIME_COMMAND", assertThrows(
+				BusinessException.class,
+				() -> provider.connect(null, null)).code());
+		assertEquals("INVALID_SDP", assertThrows(
+				BusinessException.class,
+				() -> provider.connect(commandWithOffer(" "), null)).code());
+		assertEquals("QINIU_REALTIME_MODEL_NOT_SUPPORTED", assertThrows(
+				BusinessException.class,
+				() -> provider.connect(commandWithModel("unsupported-model"), null)).code());
+	}
+
+	@Test
+	void mapsProfileAndSessionResponseFailuresWithoutLeakingCredentials() {
+		RecordingHttpClient invalidProfiles = new RecordingHttpClient(
+				response(200, "not-json"));
+		assertEquals("QINIU_PROFILES_INVALID", assertThrows(
+				BusinessException.class,
+				() -> provider(invalidProfiles, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient oversized = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, "x".repeat(1_048_577)));
+		assertEquals("QINIU_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> provider(oversized, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient missingSession = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, "{\"client_endpoint\":{\"url\":\"/rtc\",\"access_token\":\"token\"}}"));
+		assertEquals("QINIU_SESSION_ID_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(missingSession, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient invalidEndpoint = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, """
+						{"session_id":"safe-session","client_endpoint":
+						{"url":"http://evil.example/rtc","access_token":"token"}}
+						"""),
+				response(200, "{}"));
+		assertEquals("QINIU_CLIENT_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> provider(invalidEndpoint, "server-api-key").connect(command(), null)).code());
+	}
+
+	@Test
+	void mapsControlHttpStatusesAndStopSessionIdValidation() {
+		RecordingHttpClient unauthorized = new RecordingHttpClient(
+				response(401, "{" + "\"code\":\"bad_key\",\"message\":\"denied\"}"));
+		BusinessException unauthorizedFailure = assertThrows(
+				BusinessException.class,
+				() -> provider(unauthorized, "server-api-key").connect(command(), null));
+		assertEquals("QINIU_BAD_KEY", unauthorizedFailure.code());
+
+		RecordingHttpClient badRequest = new RecordingHttpClient(
+				response(200, profiles()),
+				response(400, "not-json"));
+		BusinessException badRequestFailure = assertThrows(
+				BusinessException.class,
+				() -> provider(badRequest, "server-api-key").connect(command(), null));
+		assertEquals("QINIU_SESSION_CREATE_FAILED", badRequestFailure.code());
+
+		RecordingHttpClient stopNotFound = new RecordingHttpClient(response(404, ""));
+		provider(stopNotFound, "server-api-key").stopSession("session-1", null, null);
+		assertEquals(1, stopNotFound.requests.size());
+
+		RecordingHttpClient noStop = new RecordingHttpClient();
+		provider(noStop, "server-api-key").stopSession("  ", null, " ");
+		assertTrue(noStop.requests.isEmpty());
+		assertEquals("QINIU_SESSION_ID_INVALID", assertThrows(
+				BusinessException.class,
+				() -> provider(noStop, "server-api-key").stopSession("bad/id", null, "done")).code());
+	}
+
+	@Test
+		void coversNullAndBlankStopInputsAndNonRetryableStopFailures()
+				throws IOException, InterruptedException {
+		RecordingHttpClient noRequest = new RecordingHttpClient();
+		provider(noRequest, "server-api-key").stopSession(null, null, "done");
+		assertTrue(noRequest.requests.isEmpty());
+
+		RecordingHttpClient badStop = new RecordingHttpClient(response(400, ""));
+		BusinessException failure = assertThrows(
+				BusinessException.class,
+				() -> provider(badStop, "server-api-key")
+						.stopSession("session-1", null, "  "));
+		assertEquals("QINIU_SESSION_STOP_FAILED", failure.code());
+		assertTrue(readBody(badStop.requests.getFirst()).contains("client_completed"));
+	}
+
+	@Test
+		void coversProfilePredicateShortCircuitingAndCommandsWithoutOptionalFields()
+				throws IOException, InterruptedException {
+		RecordingHttpClient client = new RecordingHttpClient(
+				response(200, ""),
+				response(200, "{\"profiles\":["
+						+ "{\"model_profile\":\"wrong\",\"role_profiles\":[],"
+						+ "\"voice_profiles\":[],\"client_transports\":[]},"
+						+ "{\"model_profile\":\"qwen3.5-omni-plus-realtime\","
+						+ "\"role_profiles\":[\"wrong-role\"],\"voice_profiles\":[],"
+						+ "\"client_transports\":[]},"
+						+ "{\"model_profile\":\"qwen3.5-omni-plus-realtime\","
+						+ "\"role_profiles\":[\"default_assistant\"],"
+						+ "\"voice_profiles\":[\"Tina\"],"
+						+ "\"client_transports\":[\"platform_rtc\"]}]}") );
+		BusinessException unavailable = assertThrows(
+				BusinessException.class,
+				() -> provider(client, "server-api-key").connect(command(), null));
+		assertEquals("QINIU_PROFILE_UNAVAILABLE", unavailable.code());
+
+		RecordingHttpClient optional = successfulConnectionClient("optional-fields");
+		RealtimeConnectCommand command = new RealtimeConnectCommand(
+				null,
+				"offer-sdp",
+				"user-1",
+				"local-session-1",
+				"freechat-scene-1",
+				null,
+				"Tina");
+		var result = provider(optional, "server-api-key").connect(command, null);
+		assertEquals("optional-fields", result.providerSessionId());
+		assertFalse(readBody(optional.requests.get(1)).contains("scenario"));
+	}
+
+	@Test
+	void mapsMissingQiniuResponseFieldsAndNullBodies() {
+		RecordingHttpClient nullProfiles = new RecordingHttpClient(response(200, null));
+		assertEquals("QINIU_PROFILE_UNAVAILABLE", assertThrows(
+				BusinessException.class,
+				() -> provider(nullProfiles, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient missingEndpointUrl = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, "{\"session_id\":\"safe-session\","
+						+ "\"client_endpoint\":{\"access_token\":\"token\"}}"));
+		assertEquals("QINIU_CLIENT_ENDPOINT_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(missingEndpointUrl, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient missingToken = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, "{\"session_id\":\"safe-session\","
+						+ "\"client_endpoint\":{\"url\":\"/rtc\"}}"));
+		assertEquals("QINIU_CLIENT_TOKEN_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(missingToken, "server-api-key").connect(command(), null)).code());
+
+		RecordingHttpClient missingAnswer = new RecordingHttpClient(
+				response(200, profiles()),
+				response(201, "{\"session_id\":\"safe-session\","
+						+ "\"client_endpoint\":{\"url\":\"/rtc\","
+						+ "\"access_token\":\"token\"}}"),
+				response(200, "{}"),
+				response(200, "{}"));
+		assertEquals("QINIU_ANSWER_SDP_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider(missingAnswer, "server-api-key").connect(command(), null)).code());
+	}
+
+	@Test
+	void mapsQiniuIoAndInterruptedRequests() throws Exception {
+		HttpClient ioClient = mock(HttpClient.class);
+		doThrow(new IOException("network")).when(ioClient)
+				.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+		QiniuRealtimeProperties properties = properties("server-api-key");
+		assertEquals("QINIU_PROFILES_IO_ERROR", assertThrows(
+				BusinessException.class,
+				() -> new QiniuRealtimeProvider(ioClient, new ObjectMapper(), properties)
+						.connect(command(), null)).code());
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled")).when(interruptedClient)
+				.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+		Thread.interrupted();
+		try {
+			assertEquals("QINIU_REQUEST_INTERRUPTED", assertThrows(
+					BusinessException.class,
+					() -> new QiniuRealtimeProvider(
+							interruptedClient, new ObjectMapper(), properties)
+							.connect(command(), null)).code());
+			assertTrue(Thread.currentThread().isInterrupted());
+		}
+		finally {
+			Thread.interrupted();
+		}
+	}
+
 	private RecordingHttpClient successfulConnectionClient(String sessionId) {
 		return new RecordingHttpClient(
 				response(200, profiles()),
@@ -177,7 +376,13 @@ class QiniuRealtimeProviderTest {
 	}
 
 	private QiniuRealtimeProvider provider(RecordingHttpClient client, String apiKey) {
-		QiniuRealtimeProperties properties = new QiniuRealtimeProperties(
+		QiniuRealtimeProperties properties = properties(apiKey);
+		properties.validate();
+		return new QiniuRealtimeProvider(client, new ObjectMapper(), properties);
+	}
+
+	private QiniuRealtimeProperties properties(String apiKey) {
+		return new QiniuRealtimeProperties(
 				"https://miku-rtic.qiniuapi.com",
 				apiKey,
 				"unispeaking_001",
@@ -192,8 +397,6 @@ class QiniuRealtimeProviderTest {
 				"cn-east",
 				Duration.ofSeconds(20),
 				1_048_576);
-		properties.validate();
-		return new QiniuRealtimeProvider(client, new ObjectMapper(), properties);
 	}
 
 	private RealtimeConnectCommand command() {
@@ -209,6 +412,18 @@ class QiniuRealtimeProviderTest {
 				"freechat-scene-1",
 				SceneType.FREE_CHAT,
 				voiceId);
+	}
+
+	private RealtimeConnectCommand commandWithOffer(String offerSdp) {
+		return new RealtimeConnectCommand(
+				"qwen3.5-omni-plus-realtime", offerSdp, "user-1", "local-session-1",
+				"freechat-scene-1", SceneType.FREE_CHAT, "Tina");
+	}
+
+	private RealtimeConnectCommand commandWithModel(String modelId) {
+		return new RealtimeConnectCommand(
+				modelId, "offer-sdp", "user-1", "local-session-1",
+				"freechat-scene-1", SceneType.FREE_CHAT, "Tina");
 	}
 
 	private String profiles() {
@@ -228,7 +443,7 @@ class QiniuRealtimeProviderTest {
 		return new StubResponse(status, body);
 	}
 
-	private static String readBody(HttpRequest request) throws IOException, InterruptedException {
+	private static String readBody(HttpRequest request) {
 		var subscriber = new BodySubscriber();
 		request.bodyPublisher().orElseThrow().subscribe(subscriber);
 		return subscriber.result.join();

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenProvidersCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenProvidersCoverageTest.java
@@ -1,0 +1,373 @@
+package com.unispeaking.infrastructure.ai.qwen;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.provider.MeteredProviderException;
+import com.unispeaking.provider.LlmResponseFormat;
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class QwenProvidersCoverageTest {
+
+	private static final URI QWEN_ENDPOINT = URI.create(
+			"https://workspace.cn-beijing.maas.aliyuncs.com/compatible-mode/v1/chat/completions");
+	private static final URI TTS_ENDPOINT = URI.create(
+			"https://dashscope.aliyuncs.com/api/v1/services/aigc/multimodal-generation/generation");
+	private static final byte[] WAV = new byte[] {
+			'R', 'I', 'F', 'F', 0, 0, 0, 0, 'W', 'A', 'V', 'E'
+	};
+
+	@Test
+	void qwenLlmSendsTextAndJsonFormatAndMeasuresProviderUsage() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				"{\"id\":\"response-id\",\"choices\":[{\"message\":{\"content\":\"{\\\"ok\\\":true}\"}}],"
+						+ "\"usage\":{\"prompt_tokens\":12,\"completion_tokens\":4}}",
+				Map.of("x-request-id", List.of("header-id"))));
+		QwenLlmProvider provider = llm(client, "secret");
+
+		var response = provider.executeLlmTaskMeasured(
+				"  say hello  ", null, LlmResponseFormat.JSON_OBJECT);
+
+		assertEquals("{\"ok\":true}", response.response());
+		assertEquals("header-id", response.providerRequestId());
+		assertEquals(12, response.usage().inputTokens());
+		assertEquals(4, response.usage().outputTokens());
+		assertTrue(body(client.requests.getFirst()).contains("response_format"));
+		assertEquals("Bearer secret",
+				client.requests.getFirst().headers().firstValue("Authorization").orElseThrow());
+	}
+
+	@Test
+	void qwenLlmUsesBodyRequestIdAndMapsBoundaryFailures() {
+		RecordingHttpClient bodyId = new RecordingHttpClient(new QueuedResponse(
+				200,
+				"{\"request_id\":\"body-id\",\"choices\":[{\"message\":{\"content\":\"answer\"}}]}"));
+		assertEquals("body-id", llm(bodyId, "key")
+				.executeLlmTaskMeasured("prompt", null).providerRequestId());
+
+		RecordingHttpClient noCredentialClient = new RecordingHttpClient();
+		assertCode("QWEN_LLM_CREDENTIAL_MISSING", () -> llm(noCredentialClient, "")
+				.executeLlmTask("prompt", null));
+		assertCode("INVALID_LLM_PROMPT", () -> llm(noCredentialClient, "key")
+				.executeLlmTask(" ", null));
+		assertCode("QWEN_LLM_REQUEST_FAILED", () -> llm(
+				new RecordingHttpClient(new QueuedResponse(503, "busy")), "key")
+				.executeLlmTask("prompt", null));
+		assertCode("QWEN_LLM_RESPONSE_INVALID", () -> llm(
+				new RecordingHttpClient(new QueuedResponse(200, "not-json")), "key")
+				.executeLlmTask("prompt", null));
+		assertCode("QWEN_LLM_EMPTY_RESPONSE", () -> llm(
+				new RecordingHttpClient(new QueuedResponse(200,
+						"{\"choices\":[{\"message\":{\"content\":\" \"}}]}")), "key")
+				.executeLlmTask("prompt", null));
+	}
+
+	@Test
+	void qwenLlmRejectsUntrustedEndpointAndTransportInterrupt() throws Exception {
+		RecordingHttpClient client = new RecordingHttpClient();
+		assertCode("QWEN_LLM_ENDPOINT_INVALID", () -> new QwenLlmProvider(
+				client, new ObjectMapper(), "key",
+				URI.create("https://evil.example/chat"), "model", Duration.ofSeconds(1), 128)
+				.executeLlmTask("prompt", null));
+
+		HttpClient ioClient = mock(HttpClient.class);
+		doThrow(new IOException("network")).when(ioClient).send(any(HttpRequest.class),
+				any(HttpResponse.BodyHandler.class));
+		assertCode("QWEN_LLM_IO_ERROR", () -> llm(ioClient, "key")
+				.executeLlmTask("prompt", null));
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled")).when(interruptedClient)
+				.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+		Thread.interrupted();
+		assertCode("QWEN_LLM_INTERRUPTED", () -> llm(interruptedClient, "key")
+				.executeLlmTask("prompt", null));
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
+	void qwenAsrSendsAudioAndSupportsCommonFormats() {
+		RecordingHttpClient client = new RecordingHttpClient(new QueuedResponse(
+				200,
+				"{\"choices\":[{\"message\":{\"content\":\"recognized text\"}}]}"));
+		QwenAsrProvider provider = asr(client, "secret", 128, 1_024);
+
+		assertEquals("recognized text", provider.convertAudioToText(new byte[] {1, 2}, null));
+		String requestBody = body(client.requests.getFirst());
+		assertTrue(requestBody.contains("audio/wav"));
+		assertEquals("Bearer secret",
+				client.requests.getFirst().headers().firstValue("Authorization").orElseThrow());
+	}
+
+	@Test
+	void qwenAsrMapsCredentialAudioHttpAndResponseFailures() {
+		RecordingHttpClient noCredential = new RecordingHttpClient();
+		assertCode("QWEN_ASR_CREDENTIAL_MISSING", () -> asr(noCredential, "", 128, 128)
+				.convertAudioToText(new byte[] {1}, null));
+		assertCode("INVALID_AUDIO", () -> asr(noCredential, "key", 128, 128)
+				.convertAudioToText(new byte[0], null));
+		assertCode("TRANSCRIPTION_AUDIO_TOO_LARGE", () -> asr(noCredential, "key", 1, 128)
+				.convertAudioToText(new byte[] {1, 2}, null));
+		assertCode("QWEN_ASR_REQUEST_FAILED", () -> asr(
+				new RecordingHttpClient(new QueuedResponse(500, "failed")), "key", 128, 128)
+				.convertAudioToText(new byte[] {1}, null));
+		assertCode("QWEN_ASR_RESPONSE_INVALID", () -> asr(
+				new RecordingHttpClient(new QueuedResponse(200, "not-json")), "key", 128, 128)
+				.convertAudioToText(new byte[] {1}, null));
+		assertCode("QWEN_ASR_RESULT_EMPTY", () -> asr(
+				new RecordingHttpClient(new QueuedResponse(200,
+						"{\"choices\":[{\"message\":{\"content\":\"\"}}]}")), "key", 128, 128)
+				.convertAudioToText(new byte[] {1}, null));
+	}
+
+	@Test
+	void qwenAsrRejectsUntrustedEndpointAndTransportFailures() throws Exception {
+		assertCode("QWEN_ASR_ENDPOINT_INVALID", () -> asr(
+				new RecordingHttpClient(), "key", 128, 128,
+				URI.create("https://evil.example/chat"))
+				.convertAudioToText(new byte[] {1}, null));
+		HttpClient ioClient = mock(HttpClient.class);
+		doThrow(new IOException("network")).when(ioClient).send(any(HttpRequest.class),
+				any(HttpResponse.BodyHandler.class));
+		assertCode("QWEN_ASR_IO_ERROR", () -> asr(ioClient, "key", 128, 128)
+				.convertAudioToText(new byte[] {1}, null));
+	}
+
+	@Test
+	void qwenTtsDownloadsWavUsesVoiceMappingAndCachesAudio() {
+		String audioUrl = "http://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(200, "{\"request_id\":\"tts-id\",\"output\":{\"audio\":{\"url\":\""
+						+ audioUrl + "\"}}}"),
+				new QueuedResponse(200, WAV));
+		QwenTtsProvider provider = tts(client, "secret", 1_024, 1_024);
+
+		var measured = provider.generateSpeechAudioMeasured("hello", null, "Harvey");
+		assertArrayEquals(WAV, measured.response());
+		assertEquals("tts-id", measured.providerRequestId());
+		assertEquals(2, client.requests.size());
+		assertTrue(body(client.requests.getFirst()).contains("\"voice\":\"Neil\""));
+		assertEquals("https", client.requests.get(1).uri().getScheme());
+		assertArrayEquals(WAV, provider.generateSpeechAudio("hello", null, "Harvey"));
+		assertEquals(2, client.requests.size(), "second call should use the audio cache");
+	}
+
+	@Test
+	void qwenTtsMapsInvalidResponsesAndMeasuredDownloadFailures() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		assertCode("QWEN_TTS_CREDENTIAL_MISSING", () -> tts(client, "", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertCode("INVALID_TTS_TEXT", () -> tts(client, "key", 128, 128)
+				.generateSpeechAudio(" ", null));
+		assertCode("TTS_TEXT_TOO_LONG", () -> tts(client, "key", 128, 128)
+				.generateSpeechAudio("x".repeat(5_001), null));
+
+		assertCode("QWEN_TTS_REQUEST_FAILED", () -> tts(
+				new RecordingHttpClient(new QueuedResponse(503, "busy")), "key", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertCode("QWEN_TTS_RESPONSE_INVALID", () -> tts(
+				new RecordingHttpClient(new QueuedResponse(200, "not-json")), "key", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertCode("QWEN_TTS_AUDIO_URL_MISSING", () -> tts(
+				new RecordingHttpClient(new QueuedResponse(200, "{\"output\":{}}")), "key", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertCode("QWEN_TTS_AUDIO_URL_UNTRUSTED", () -> tts(
+				new RecordingHttpClient(new QueuedResponse(200,
+						"{\"output\":{\"audio\":{\"url\":\"https://evil.example/a.wav\"}}}")),
+				"key", 128, 128).generateSpeechAudio("hello", null));
+
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		RecordingHttpClient failedDownload = new RecordingHttpClient(
+				new QueuedResponse(200, "{\"request_id\":\"tts-id\",\"output\":{\"audio\":{\"url\":\"" + url + "\"}}}"),
+				new QueuedResponse(502, "failed"));
+		MeteredProviderException metered = assertThrows(MeteredProviderException.class,
+				() -> tts(failedDownload, "key", 128, 128)
+						.generateSpeechAudioMeasured("hello", null));
+		assertEquals("QWEN_TTS_AUDIO_DOWNLOAD_FAILED", metered.code());
+		assertEquals("tts-id", metered.providerRequestId());
+	}
+
+	@Test
+	void qwenTtsRejectsInvalidAudioAndEndpointAndRestoresInterrupt() throws Exception {
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/audio.wav";
+		assertCode("QWEN_TTS_AUDIO_INVALID", () -> tts(new RecordingHttpClient(
+				new QueuedResponse(200, "{\"output\":{\"audio\":{\"url\":\"" + url + "\"}}}"),
+				new QueuedResponse(200, "not-wav")), "key", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertCode("QWEN_TTS_ENDPOINT_INVALID", () -> tts(
+				new RecordingHttpClient(), "key", 128, 128,
+				URI.create("https://evil.example/generate"))
+				.generateSpeechAudio("hello", null));
+
+		HttpClient interrupted = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled")).when(interrupted)
+				.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+		Thread.interrupted();
+		assertCode("QWEN_TTS_INTERRUPTED", () -> tts(interrupted, "key", 128, 128)
+				.generateSpeechAudio("hello", null));
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	private static QwenLlmProvider llm(HttpClient client, String key) {
+		return new QwenLlmProvider(client, new ObjectMapper(), key, QWEN_ENDPOINT,
+				"qwen-model", Duration.ofSeconds(1), 1_024);
+	}
+
+	private static QwenAsrProvider asr(HttpClient client, String key, int maxAudio, int maxResponse) {
+		return asr(client, key, maxAudio, maxResponse, QWEN_ENDPOINT);
+	}
+
+	private static QwenAsrProvider asr(
+			HttpClient client, String key, int maxAudio, int maxResponse, URI endpoint) {
+		return new QwenAsrProvider(client, new ObjectMapper(), key, endpoint, "qwen-asr",
+				Duration.ofSeconds(1), maxAudio, maxResponse);
+	}
+
+	private static QwenTtsProvider tts(HttpClient client, String key, int maxResponse, int maxAudio) {
+		return tts(client, key, maxResponse, maxAudio, TTS_ENDPOINT);
+	}
+
+	private static QwenTtsProvider tts(
+			HttpClient client, String key, int maxResponse, int maxAudio, URI endpoint) {
+		return new QwenTtsProvider(client, new ObjectMapper(), key, endpoint, "qwen-tts",
+				"Aiden", "English", Duration.ofSeconds(1), maxResponse, maxAudio);
+	}
+
+	private static void assertCode(String expected, org.junit.jupiter.api.function.Executable executable) {
+		BusinessException exception = assertThrows(BusinessException.class, executable);
+		assertEquals(expected, exception.code());
+	}
+
+	private static String body(HttpRequest request) {
+		var publisher = request.bodyPublisher().orElseThrow();
+		var bytes = new java.io.ByteArrayOutputStream();
+		var complete = new CompletableFuture<Void>();
+		publisher.subscribe(new Flow.Subscriber<>() {
+			@Override public void onSubscribe(Flow.Subscription subscription) { subscription.request(1); }
+			@Override public void onNext(ByteBuffer item) {
+				var copy = new byte[item.remaining()];
+				item.get(copy);
+				bytes.writeBytes(copy);
+			}
+			@Override public void onError(Throwable throwable) { complete.completeExceptionally(throwable); }
+			@Override public void onComplete() { complete.complete(null); }
+		});
+		complete.join();
+		return bytes.toString(StandardCharsets.UTF_8);
+	}
+
+	private static final class RecordingHttpClient extends HttpClient {
+		private final List<QueuedResponse> responses;
+		private final List<HttpRequest> requests = new ArrayList<>();
+
+		private RecordingHttpClient(QueuedResponse... responses) {
+			this.responses = new ArrayList<>(List.of(responses));
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler)
+				throws IOException {
+			requests.add(request);
+			QueuedResponse response = responses.removeFirst();
+			if (response.ioError()) throw new IOException("simulated network failure");
+			byte[] raw = response.body() instanceof byte[] bytes
+					? bytes : response.body().toString().getBytes(StandardCharsets.UTF_8);
+			HttpResponse.BodySubscriber<T> subscriber = handler.apply(
+					new ResponseInfo(response.status(), response.headers()));
+			subscriber.onSubscribe(new NoopSubscription());
+			subscriber.onNext(List.of(ByteBuffer.wrap(raw)));
+			subscriber.onComplete();
+			T handled;
+			try {
+				handled = subscriber.getBody().toCompletableFuture().join();
+			} catch (java.util.concurrent.CompletionException exception) {
+				if (exception.getCause() instanceof RuntimeException runtime) throw runtime;
+				throw exception;
+			}
+			return (HttpResponse<T>) new RecordedResponse<>(request, response.status(), handled,
+					response.headers());
+		}
+
+		@Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+			HttpRequest request, HttpResponse.BodyHandler<T> handler) {
+			try { return CompletableFuture.completedFuture(send(request, handler)); }
+			catch (IOException exception) { return CompletableFuture.failedFuture(exception); }
+		}
+		@Override public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+			HttpRequest request, HttpResponse.BodyHandler<T> handler,
+			HttpResponse.PushPromiseHandler<T> pushPromiseHandler) { return sendAsync(request, handler); }
+		@Override public Optional<CookieHandler> cookieHandler() { return Optional.empty(); }
+		@Override public Optional<Duration> connectTimeout() { return Optional.empty(); }
+		@Override public Redirect followRedirects() { return Redirect.NEVER; }
+		@Override public Optional<ProxySelector> proxy() { return Optional.empty(); }
+		@Override public SSLContext sslContext() { return null; }
+		@Override public SSLParameters sslParameters() { return new SSLParameters(); }
+		@Override public Optional<Authenticator> authenticator() { return Optional.empty(); }
+		@Override public Version version() { return Version.HTTP_1_1; }
+		@Override public Optional<Executor> executor() { return Optional.empty(); }
+	}
+
+	private static final class NoopSubscription implements Flow.Subscription {
+		@Override public void request(long count) { }
+		@Override public void cancel() { }
+	}
+
+	private record QueuedResponse(int status, Object body,
+			Map<String, List<String>> headers, boolean ioError) {
+		private QueuedResponse(int status, Object body) { this(status, body, Map.of(), false); }
+		private QueuedResponse(int status, Object body, Map<String, List<String>> headers) {
+			this(status, body, headers, false);
+		}
+	}
+
+	private record ResponseInfo(int status, Map<String, List<String>> values)
+			implements HttpResponse.ResponseInfo {
+		@Override public int statusCode() { return status; }
+		@Override public HttpHeaders headers() { return HttpHeaders.of(values, (n, v) -> true); }
+		@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+	}
+
+	private record RecordedResponse<T>(HttpRequest request, int status, T body,
+			Map<String, List<String>> values) implements HttpResponse<T> {
+		@Override public int statusCode() { return status; }
+		@Override public Optional<HttpResponse<T>> previousResponse() { return Optional.empty(); }
+		@Override public HttpHeaders headers() { return HttpHeaders.of(values, (n, v) -> true); }
+		@Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+		@Override public URI uri() { return request.uri(); }
+		@Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenRealtimeProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenRealtimeProviderTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -23,6 +24,7 @@ import com.unispeaking.infrastructure.ai.doubao.DoubaoAsrProvider;
 import com.unispeaking.infrastructure.ai.iflytek.IflytekScoringProvider;
 import com.unispeaking.infrastructure.ai.minimax.MiniMaxTtsProvider;
 import com.unispeaking.infrastructure.realtime.RealtimeCredentialIssuer;
+import com.unispeaking.provider.AiProviderRegistry;
 import com.unispeaking.provider.LlmResponseFormat;
 import com.unispeaking.provider.MeteredProviderException;
 import java.io.ByteArrayOutputStream;
@@ -318,6 +320,110 @@ class QwenRealtimeProviderTest {
 		verify(issuer).issue(ProviderType.QWEN);
 	}
 
+	@Test
+	void rejectsInvalidRealtimeInputsAndConfigurationBeforeOpeningHttpConnections() {
+		RecordingHttpClient httpClient = new RecordingHttpClient();
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		QwenRealtimeProvider provider = provider(httpClient, issuer);
+
+		assertEquals("INVALID_SDP", assertThrows(
+				BusinessException.class,
+				() -> provider.exchangeRealtimeSdp(
+						AiProviderRegistry.QWEN_REALTIME_FLASH, "  ", "token")).code());
+		assertEquals("QWEN_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> provider.exchangeRealtimeSdp(
+						AiProviderRegistry.QWEN_REALTIME_FLASH, "offer", "  ")).code());
+		assertEquals("QWEN_REALTIME_MODEL_NOT_SUPPORTED", assertThrows(
+				BusinessException.class,
+				() -> provider.exchangeRealtimeSdp(
+						"qwen-other-model", "offer", "token")).code());
+
+		RealtimeProperties missingWorkspace = new RealtimeProperties(
+				"", "", "qwen3.5-omni-flash-realtime", "cn-beijing",
+				"https://dashscope.aliyuncs.com/api/v1/tokens", 300,
+				Duration.ofSeconds(10), Duration.ofSeconds(20), 1_048_576);
+		missingWorkspace.validate();
+		QwenRealtimeProvider unconfigured = new QwenRealtimeProvider(
+				httpClient, missingWorkspace, issuer);
+		assertEquals("QWEN_WORKSPACE_OR_MODEL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> unconfigured.exchangeRealtimeSdp(
+						AiProviderRegistry.QWEN_REALTIME_FLASH, "offer", "token")).code());
+
+		assertTrue(httpClient.requests.isEmpty());
+		verify(issuer, never()).issue(any());
+	}
+
+	@Test
+	void retriesAThreeHundredResponseAndUsesTheFreshCredential() {
+		RecordingHttpClient httpClient = new RecordingHttpClient(
+				new QueuedResponse(302, "redirect"),
+				new QueuedResponse(200, "answer-sdp"));
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		when(issuer.issue(any())).thenReturn(freshCredential("fresh-token"));
+		QwenRealtimeProvider provider = provider(httpClient, issuer);
+
+		assertEquals("answer-sdp", provider.exchangeRealtimeSdp(
+				AiProviderRegistry.QWEN_REALTIME_FLASH, "offer-sdp", "temporary-token"));
+		assertEquals(2, httpClient.requests.size());
+		assertEquals("Bearer temporary-token",
+				httpClient.requests.get(0).headers().firstValue("Authorization").orElseThrow());
+		assertEquals("Bearer fresh-token",
+				httpClient.requests.get(1).headers().firstValue("Authorization").orElseThrow());
+		verify(issuer).issue(ProviderType.QWEN);
+	}
+
+	@Test
+	void rejectsAnOversizedAnswerWithoutRetryingTheSignalingRequest() {
+		RecordingHttpClient httpClient = new RecordingHttpClient(
+				new QueuedResponse(200, "123456789"));
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		QwenRealtimeProvider provider = new QwenRealtimeProvider(
+				httpClient,
+				new RealtimeProperties(
+						"", "workspace-123", "qwen3.5-omni-flash-realtime", "cn-beijing",
+						"https://dashscope.aliyuncs.com/api/v1/tokens", 300,
+						Duration.ofSeconds(10), Duration.ofSeconds(20), 8),
+				issuer);
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.exchangeRealtimeSdp(
+						AiProviderRegistry.QWEN_REALTIME_FLASH, "offer-sdp", "token"));
+
+		assertEquals("QWEN_ANSWER_TOO_LARGE", exception.code());
+		assertEquals(1, httpClient.requests.size());
+		verify(issuer, never()).issue(any());
+	}
+
+	@Test
+	void mapsInterruptedSignalingCallsWithoutRetryingAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(httpClient)
+				.send(any(HttpRequest.class), org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<String>>any());
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		QwenRealtimeProvider interrupted = new QwenRealtimeProvider(
+				httpClient,
+				new RealtimeProperties(
+						"", "workspace-123", "qwen3.5-omni-flash-realtime", "cn-beijing",
+						"https://dashscope.aliyuncs.com/api/v1/tokens", 300,
+						Duration.ofSeconds(10), Duration.ofSeconds(20), 1_048_576),
+				issuer);
+
+		Thread.interrupted();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> interrupted.exchangeRealtimeSdp(
+						AiProviderRegistry.QWEN_REALTIME_FLASH, "offer-sdp", "token"));
+
+		assertEquals("QWEN_SIGNALING_INTERRUPTED", exception.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		verify(issuer, never()).issue(any());
+		Thread.interrupted();
+	}
+
 	private QwenRealtimeProvider provider(
 			RecordingHttpClient httpClient,
 			RealtimeCredentialIssuer issuer) {
@@ -481,6 +587,72 @@ class QwenRealtimeProviderTest {
 	}
 
 	@Test
+	void rejectsQwenLlmMissingCredentialAndBlankPromptBeforeSendingRequests() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		QwenLlmProvider configured = qwenLlmProvider(client, "dashscope-key");
+		QwenLlmProvider missingCredential = qwenLlmProvider(client, "");
+
+		assertEquals("INVALID_LLM_PROMPT", assertThrows(
+				BusinessException.class,
+				() -> configured.executeLlmTask("  ", null)).code());
+		assertEquals("QWEN_LLM_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredential.executeLlmTask("hello", null)).code());
+		assertTrue(client.requests.isEmpty());
+	}
+
+	@Test
+	void mapsQwenLlmHttpAndEmptyContentResponsesToBusinessErrors() {
+		RecordingHttpClient httpFailure = new RecordingHttpClient(
+				new QueuedResponse(429, utf8("rate limited")));
+		assertEquals("QWEN_LLM_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> qwenLlmProvider(httpFailure, "dashscope-key")
+						.executeLlmTask("hello", null)).code());
+
+		RecordingHttpClient emptyContent = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"choices\":[{\"message\":{\"content\":\"\"}}]}")));
+		assertEquals("QWEN_LLM_EMPTY_RESPONSE", assertThrows(
+				BusinessException.class,
+				() -> qwenLlmProvider(emptyContent, "dashscope-key")
+						.executeLlmTask("hello", null)).code());
+	}
+
+	@Test
+	void mapsQwenLlmTransportAndInterruptedCallsWithoutLeakingCredentials() throws Exception {
+		RecordingHttpClient ioFailure = new RecordingHttpClient(QueuedResponse.ioError());
+		BusinessException ioException = assertThrows(
+				BusinessException.class,
+				() -> qwenLlmProvider(ioFailure, "dashscope-key")
+						.executeLlmTask("hello", null));
+		assertEquals("QWEN_LLM_IO_ERROR", ioException.code());
+		assertFalse(ioException.getMessage().contains("dashscope-key"));
+
+		HttpClient interruptedClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(interruptedClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		QwenLlmProvider interrupted = new QwenLlmProvider(
+				interruptedClient,
+				new ObjectMapper(),
+				"dashscope-key",
+				URI.create(
+						"https://workspace-123.cn-beijing.maas.aliyuncs.com/"
+								+ "compatible-mode/v1/chat/completions"),
+				"qwen3.5-plus",
+				Duration.ofSeconds(20),
+				128);
+		Thread.interrupted();
+		BusinessException interruptedException = assertThrows(
+				BusinessException.class,
+				() -> interrupted.executeLlmTask("hello", null));
+		assertEquals("QWEN_LLM_INTERRUPTED", interruptedException.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
 	void generatesAliyunSpeechAndDownloadsTheReturnedAudio() {
 		byte[] audio = new byte[] {1, 2, 3, 4};
 		String audioUrl = "http://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/test/audio%2Bfile.mp3?Expires=1&Signature=a%2Fb%3D";
@@ -614,6 +786,215 @@ class QwenRealtimeProviderTest {
 		assertEquals(24, exception.usage().inputCharacters());
 		assertEquals(0, exception.usage().audioOutputSeconds());
 		assertEquals(Boolean.TRUE, exception.retryable());
+	}
+
+	@Test
+	void rejectsQwenTtsMissingCredentialAndBlankTextBeforeOpeningHttpConnections() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		QwenTtsProvider configured = qwenTtsProvider(client, "dashscope-key", 128, 128);
+		QwenTtsProvider missingCredential = qwenTtsProvider(client, "", 128, 128);
+
+		assertEquals("INVALID_TTS_TEXT", assertThrows(
+				BusinessException.class,
+				() -> configured.generateSpeechAudio("  ", null)).code());
+		assertEquals("QWEN_TTS_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredential.generateSpeechAudio("hello", null)).code());
+		assertTrue(client.requests.isEmpty());
+	}
+
+	@Test
+	void measuresDefaultVoiceResponsesWithoutAProviderRequestId() {
+		byte[] wav = wavWithSampleRate(24_000);
+		String url = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/test/default.wav";
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"output\":{\"audio\":{\"url\":\""
+						+ url + "\"}}}")),
+				new QueuedResponse(200, wav));
+		QwenTtsProvider provider = qwenTtsProvider(client, "dashscope-key", 128, 128);
+
+		var measured = provider.generateSpeechAudioMeasured("hello", null);
+
+		assertArrayEquals(wav, measured.response());
+		assertEquals(null, measured.providerRequestId());
+		assertEquals("NONE", measured.usage().source());
+	}
+
+	@Test
+	void validatesSpringConfigurationAndRequiredQwenConstructorArguments() {
+		URI endpoint = URI.create(
+				"https://dashscope.aliyuncs.com/api/v1/services/aigc/"
+						+ "multimodal-generation/generation");
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				new ObjectMapper(), "key", endpoint.toString(), "model", "voice", "English",
+				0, 1, 128, 128));
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				new ObjectMapper(), "key", endpoint.toString(), "model", "voice", "English",
+				1, 0, 128, 128));
+		assertEquals("QWEN_TTS_URL_INVALID", assertThrows(
+				BusinessException.class,
+				() -> new QwenTtsProvider(
+						new ObjectMapper(), "key", "%%%", "model", "voice", "English",
+						1, 1, 128, 128)).code());
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				null, new ObjectMapper(), "key", endpoint, "model", "voice", "English",
+				Duration.ofSeconds(1), 128, 128));
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				new RecordingHttpClient(), new ObjectMapper(), "key", endpoint, " ", "voice",
+					"English", Duration.ofSeconds(1), 128, 128));
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				new RecordingHttpClient(), new ObjectMapper(), "key", endpoint, "model", " ",
+					"English", Duration.ofSeconds(1), 128, 128));
+		assertThrows(IllegalArgumentException.class, () -> new QwenTtsProvider(
+				new RecordingHttpClient(), new ObjectMapper(), "key", endpoint, "model", "voice",
+					" ", Duration.ofSeconds(1), 128, 128));
+	}
+
+	@Test
+	void handlesAnInvalidConfiguredAudioUriAndDefaultLimitFallback() {
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"output\":{\"audio\":{\"url\":\"https://[::1\"}}}")));
+		QwenTtsProvider provider = qwenTtsProvider(client, "key", 0, 0);
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.generateSpeechAudio("hello", null));
+		assertEquals("QWEN_TTS_URL_INVALID", exception.code());
+	}
+
+	@Test
+	void rejectsOversizedAndMalformedQwenTtsGenerationResponsesWhileReadingThem() {
+		RecordingHttpClient oversized = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("0123456789")));
+		BusinessException oversizedFailure = assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(oversized, "dashscope-key", 4, 128)
+						.generateSpeechAudio("hello", null));
+		assertEquals("QWEN_TTS_RESPONSE_TOO_LARGE", oversizedFailure.code());
+
+		RecordingHttpClient missingAudioUrl = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"output\":{\"audio\":{}}}")));
+		BusinessException malformedFailure = assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(missingAudioUrl, "dashscope-key", 128, 128)
+						.generateSpeechAudio("hello", null));
+		assertEquals("QWEN_TTS_AUDIO_URL_MISSING", malformedFailure.code());
+	}
+
+	@Test
+	void mapsQwenTtsGenerationHttpFailuresToRetryableBusinessErrors() {
+		RecordingHttpClient client = new RecordingHttpClient(
+				new QueuedResponse(503, utf8("temporarily unavailable")));
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(client, "dashscope-key", 128, 128)
+						.generateSpeechAudio("hello", null));
+
+		assertEquals("QWEN_TTS_REQUEST_FAILED", exception.code());
+	}
+
+	@Test
+	void rejectsUntrustedQwenTtsAudioUrlsAndInvalidDownloadedAudio() {
+		RecordingHttpClient untrustedUrl = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(
+						"{\"output\":{\"audio\":{\"url\":\"https://evil.example/audio.wav\"}}}")));
+		assertEquals("QWEN_TTS_AUDIO_URL_UNTRUSTED", assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(untrustedUrl, "dashscope-key", 128, 128)
+						.generateSpeechAudio("hello", null)).code());
+		assertEquals(1, untrustedUrl.requests.size());
+
+		String trustedUrl = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/test/audio.wav";
+		RecordingHttpClient invalidWav = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(
+						"{\"output\":{\"audio\":{\"url\":\"%s\"}}}".formatted(trustedUrl))),
+				new QueuedResponse(200, new byte[] {1, 2, 3}));
+		assertEquals("QWEN_TTS_AUDIO_INVALID", assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(invalidWav, "dashscope-key", 128, 128)
+						.generateSpeechAudio("hello", null)).code());
+	}
+
+	@Test
+	void mapsQwenTtsTransportFailureWithoutLeakingCredentials() {
+		RecordingHttpClient client = new RecordingHttpClient(QueuedResponse.ioError());
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(client, "dashscope-key", 128, 128)
+						.generateSpeechAudio("hello", null));
+
+		assertEquals("QWEN_TTS_IO_ERROR", exception.code());
+		assertFalse(exception.getMessage().contains("dashscope-key"));
+	}
+
+	@Test
+	void mapsQwenTtsInvalidEndpointAndTextLengthBeforeSendingRequests() {
+		RecordingHttpClient endpointClient = new RecordingHttpClient();
+		QwenTtsProvider invalidEndpoint = new QwenTtsProvider(
+				endpointClient,
+				new ObjectMapper(),
+				"dashscope-key",
+				URI.create("https://evil.example/generation"),
+				"qwen3-tts-flash",
+				"Aiden",
+				"English",
+				Duration.ofSeconds(20),
+				128,
+				128);
+		assertEquals("QWEN_TTS_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> invalidEndpoint.generateSpeechAudio("hello", null)).code());
+
+		RecordingHttpClient longTextClient = new RecordingHttpClient();
+		assertEquals("TTS_TEXT_TOO_LONG", assertThrows(
+				BusinessException.class,
+				() -> qwenTtsProvider(longTextClient, "dashscope-key", 128, 128)
+						.generateSpeechAudio("x".repeat(5_001), null)).code());
+		assertTrue(endpointClient.requests.isEmpty());
+		assertTrue(longTextClient.requests.isEmpty());
+	}
+
+	@Test
+	void resolvesProductVoiceAliasesAndCachesAudioByVoiceAndText() {
+		byte[] wav = wavWithSampleRate(24_000);
+		String audioUrl = "https://dashscope-result-bj.oss-cn-beijing.aliyuncs.com/test/voice.wav";
+		RecordingHttpClient httpClient = new RecordingHttpClient(
+				new QueuedResponse(200, utf8(
+						"{\"output\":{\"audio\":{\"url\":\"%s\"}}}".formatted(audioUrl))),
+				new QueuedResponse(200, wav));
+		QwenTtsProvider provider = qwenTtsProvider(httpClient, "dashscope-key", 128, 128);
+
+		assertArrayEquals(wav, provider.generateSpeechAudio("hello", null, "Harvey"));
+		assertArrayEquals(wav, provider.generateSpeechAudio("hello", null, "Harvey"));
+
+		assertEquals(2, httpClient.requests.size());
+		assertTrue(readBody(httpClient.requests.getFirst()).contains("\"voice\":\"Neil\""));
+	}
+
+	@Test
+	void mapsQwenTtsInterruptedCallsAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(httpClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		QwenTtsProvider provider = new QwenTtsProvider(
+				httpClient,
+				new ObjectMapper(),
+				"dashscope-key",
+				URI.create(
+						"https://dashscope.aliyuncs.com/api/v1/services/aigc/"
+								+ "multimodal-generation/generation"),
+				"qwen3-tts-flash", "Aiden", "English", Duration.ofSeconds(20), 128, 128);
+
+		Thread.interrupted();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.generateSpeechAudio("hello", null));
+		assertEquals("QWEN_TTS_INTERRUPTED", exception.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
 	}
 
 	@Test
@@ -810,6 +1191,66 @@ class QwenRealtimeProviderTest {
 	}
 
 	@Test
+	void rejectsIflytekInvalidReferenceAndAudioBeforeOpeningTheWebSocket() {
+		RecordingWebSocketConnector connector = new RecordingWebSocketConnector("{}");
+		IflytekScoringProvider provider = iflytekProvider(
+				connector,
+				URI.create("wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720"),
+				Duration.ofSeconds(2));
+
+		assertEquals("INVALID_PRONUNCIATION_REFERENCE", assertThrows(
+				BusinessException.class,
+				() -> provider.evaluatePronunciation("  ", wavWithSampleRate(16_000), null)).code());
+		assertEquals("PRONUNCIATION_REFERENCE_TOO_LONG", assertThrows(
+				BusinessException.class,
+				() -> provider.evaluatePronunciation("x".repeat(4_097), wavWithSampleRate(16_000), null)).code());
+		assertEquals("INVALID_AUDIO", assertThrows(
+				BusinessException.class,
+				() -> provider.evaluatePronunciation("hello", new byte[0], null)).code());
+		assertEquals(null, connector.uri);
+	}
+
+	@Test
+	void rejectsIflytekOversizedAudioAndMissingCredentialsBeforeConnecting() {
+		URI endpoint = URI.create("wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720");
+		RecordingWebSocketConnector oversizedConnector = new RecordingWebSocketConnector("{}");
+		IflytekScoringProvider oversized = iflytekProvider(
+				oversizedConnector, endpoint, Duration.ofSeconds(2), "app", "key", "secret", 45);
+		assertEquals("PRONUNCIATION_AUDIO_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> oversized.evaluatePronunciation("hello", wavWithSampleRate(16_000), null)).code());
+		assertEquals(null, oversizedConnector.uri);
+
+		RecordingWebSocketConnector credentialConnector = new RecordingWebSocketConnector("{}");
+		IflytekScoringProvider missingCredentials = iflytekProvider(
+				credentialConnector, endpoint, Duration.ofSeconds(2), "", "", "", 1_048_576);
+		assertEquals("IFLYTEK_SUNTONE_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredentials.evaluatePronunciation(
+						"hello", wavWithSampleRate(16_000), null)).code());
+		assertEquals(null, credentialConnector.uri);
+	}
+
+	@Test
+	void mapsIflytekProviderAndMalformedFinalResponsesToBusinessErrors() {
+		URI endpoint = URI.create("wss://cn-east-1.ws-api.xf-yun.com/v1/private/s8e098720");
+		RecordingWebSocketConnector rateLimited = new RecordingWebSocketConnector(
+				"{\"header\":{\"code\":11202,\"status\":2}}");
+		BusinessException rateLimitFailure = assertThrows(
+				BusinessException.class,
+				() -> iflytekProvider(rateLimited, endpoint, Duration.ofSeconds(2))
+						.evaluatePronunciation("hello", wavWithSampleRate(16_000), null));
+		assertEquals("IFLYTEK_SUNTONE_RATE_LIMITED", rateLimitFailure.code());
+
+		RecordingWebSocketConnector malformed = new RecordingWebSocketConnector("not-json");
+		BusinessException malformedFailure = assertThrows(
+				BusinessException.class,
+				() -> iflytekProvider(malformed, endpoint, Duration.ofSeconds(2))
+						.evaluatePronunciation("hello", wavWithSampleRate(16_000), null));
+		assertEquals("IFLYTEK_SUNTONE_RESPONSE_INVALID", malformedFailure.code());
+	}
+
+	@Test
 	void executesDeepSeekLlmTaskWithTheServerConfiguredCredential() {
 		RecordingHttpClient httpClient = new RecordingHttpClient(new QueuedResponse(
 				200,
@@ -857,6 +1298,116 @@ class QwenRealtimeProviderTest {
 
 		assertEquals("DEEPSEEK_LLM_ENDPOINT_INVALID", exception.code());
 		assertTrue(httpClient.requests.isEmpty());
+	}
+
+	@Test
+	void rejectsDeepSeekMissingCredentialAndBlankPromptBeforeSendingRequests() {
+		RecordingHttpClient httpClient = new RecordingHttpClient();
+		DeepSeekLlmProvider configured = new DeepSeekLlmProvider(
+				httpClient, new ObjectMapper(), "deepseek-key",
+				URI.create("https://api.deepseek.com/chat/completions"),
+				"deepseek-v4-flash", Duration.ofSeconds(20), 128);
+		DeepSeekLlmProvider missingCredential = new DeepSeekLlmProvider(
+				httpClient, new ObjectMapper(), "",
+				URI.create("https://api.deepseek.com/chat/completions"),
+				"deepseek-v4-flash", Duration.ofSeconds(20), 128);
+
+		assertEquals("INVALID_LLM_PROMPT", assertThrows(
+				BusinessException.class,
+				() -> configured.executeLlmTask("  ", null)).code());
+		assertEquals("DEEPSEEK_LLM_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredential.executeLlmTask("hello", null)).code());
+		assertTrue(httpClient.requests.isEmpty());
+	}
+
+	@Test
+	void mapsDeepSeekHttpJsonAndResponseSizeFailures() {
+		RecordingHttpClient httpFailure = new RecordingHttpClient(
+				new QueuedResponse(503, utf8("temporarily unavailable")));
+		assertEquals("DEEPSEEK_LLM_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(httpFailure, 128)
+						.executeLlmTask("hello", null)).code());
+
+		RecordingHttpClient malformed = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("not-json")));
+		assertEquals("DEEPSEEK_LLM_RESPONSE_INVALID", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(malformed, 128)
+						.executeLlmTask("hello", null)).code());
+
+		RecordingHttpClient empty = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"choices\":[{\"message\":{\"content\":\" \"}}]}")));
+		assertEquals("DEEPSEEK_LLM_EMPTY_RESPONSE", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(empty, 128)
+						.executeLlmTask("hello", null)).code());
+
+		RecordingHttpClient oversized = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("123456789")));
+		assertEquals("DEEPSEEK_LLM_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(oversized, 8)
+						.executeLlmTask("hello", null)).code());
+	}
+
+	@Test
+	void recordsDeepSeekProviderUsageAndMapsTransportFailures() {
+		RecordingHttpClient measured = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("""
+				{"id":"request-1","choices":[{"message":{"content":"answer"}}],
+				"usage":{"prompt_tokens":11,"completion_tokens":7}}
+				""")));
+		var response = deepSeekProvider(measured, 128)
+				.executeLlmTaskMeasured("hello", null);
+		assertEquals("answer", response.response());
+		assertEquals("request-1", response.providerRequestId());
+		assertEquals(11, response.usage().inputTokens());
+		assertEquals(7, response.usage().outputTokens());
+		assertEquals("PROVIDER", response.usage().source());
+
+		RecordingHttpClient estimated = new RecordingHttpClient(new QueuedResponse(
+				200, utf8("{\"choices\":[{\"message\":{\"content\":\"answer\"}}]}")));
+		assertEquals("ESTIMATED", deepSeekProvider(estimated, 128)
+				.executeLlmTaskMeasured("hello", null).usage().source());
+
+		RecordingHttpClient ioFailure = new RecordingHttpClient(QueuedResponse.ioError());
+		BusinessException ioException = assertThrows(
+				BusinessException.class,
+				() -> deepSeekProvider(ioFailure, 128).executeLlmTask("hello", null));
+		assertEquals("DEEPSEEK_LLM_IO_ERROR", ioException.code());
+	}
+
+	@Test
+	void mapsInterruptedDeepSeekCallsAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(httpClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		DeepSeekLlmProvider provider = new DeepSeekLlmProvider(
+				httpClient, new ObjectMapper(), "deepseek-key",
+				URI.create("https://api.deepseek.com/chat/completions"),
+				"deepseek-v4-flash", Duration.ofSeconds(20), 128);
+
+		Thread.interrupted();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.executeLlmTask("hello", null));
+		assertEquals("DEEPSEEK_LLM_INTERRUPTED", exception.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	private DeepSeekLlmProvider deepSeekProvider(
+			RecordingHttpClient httpClient,
+			int maxResponseBytes) {
+		return new DeepSeekLlmProvider(
+				httpClient, new ObjectMapper(), "deepseek-key",
+				URI.create("https://api.deepseek.com/chat/completions"),
+				"deepseek-v4-flash", Duration.ofSeconds(20), maxResponseBytes);
 	}
 
 	@Test
@@ -967,6 +1518,111 @@ class QwenRealtimeProviderTest {
 	}
 
 	@Test
+	void rejectsQwenAsrInvalidAudioAndMissingCredentialsBeforeSendingRequests() {
+		RecordingHttpClient client = new RecordingHttpClient();
+		QwenAsrProvider configured = qwenAsrProvider(client, "dashscope-key", 8, 128);
+		QwenAsrProvider missingCredential = qwenAsrProvider(client, "", 8, 128);
+
+		assertEquals("INVALID_AUDIO", assertThrows(
+				BusinessException.class,
+				() -> configured.convertAudioToText(new byte[0], null)).code());
+		assertEquals("TRANSCRIPTION_AUDIO_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> configured.convertAudioToText(new byte[9], null)).code());
+		assertEquals("QWEN_ASR_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredential.convertAudioToText(new byte[] {1}, null)).code());
+		assertTrue(client.requests.isEmpty());
+	}
+
+	@Test
+	void mapsQwenAsrHttpInvalidAndLimitedResponsesToBusinessErrors() {
+		RecordingHttpClient httpFailure = new RecordingHttpClient(
+				new QueuedResponse(502, utf8("bad gateway")));
+		assertEquals("QWEN_ASR_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> qwenAsrProvider(httpFailure, "dashscope-key", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient invalidJson = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("not-json")));
+		assertEquals("QWEN_ASR_RESPONSE_INVALID", assertThrows(
+				BusinessException.class,
+				() -> qwenAsrProvider(invalidJson, "dashscope-key", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient oversized = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("0123456789")));
+		assertEquals("QWEN_ASR_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> qwenAsrProvider(oversized, "dashscope-key", 128, 4)
+						.convertAudioToText(new byte[] {1}, null)).code());
+	}
+
+	@Test
+	void rejectsUntrustedQwenAsrEndpointsAndEmptyTranscriptions() {
+		RecordingHttpClient untrustedClient = new RecordingHttpClient();
+		QwenAsrProvider untrusted = new QwenAsrProvider(
+				untrustedClient,
+				new ObjectMapper(),
+				"dashscope-key",
+				URI.create("https://evil.example/compatible-mode/v1/chat/completions"),
+				"qwen3-asr-flash",
+				Duration.ofSeconds(20),
+				128,
+				128);
+		assertEquals("QWEN_ASR_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> untrusted.convertAudioToText(new byte[] {1}, null)).code());
+		assertTrue(untrustedClient.requests.isEmpty());
+
+		RecordingHttpClient emptyResult = new RecordingHttpClient(
+				new QueuedResponse(200, utf8("{\"choices\":[{\"message\":{\"content\":\"\"}}]}")));
+		assertEquals("QWEN_ASR_RESULT_EMPTY", assertThrows(
+				BusinessException.class,
+				() -> qwenAsrProvider(emptyResult, "dashscope-key", 128, 128)
+						.convertAudioToText(new byte[] {1}, null)).code());
+	}
+
+	@Test
+	void mapsQwenAsrTransportFailuresWithoutIncludingCredentials() {
+		RecordingHttpClient client = new RecordingHttpClient(QueuedResponse.ioError());
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> qwenAsrProvider(client, "dashscope-key", 128, 128)
+						.convertAudioToText(new byte[] {1}, null));
+
+		assertEquals("QWEN_ASR_IO_ERROR", exception.code());
+		assertFalse(exception.getMessage().contains("dashscope-key"));
+	}
+
+	@Test
+	void mapsQwenAsrInterruptedCallsAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(httpClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		QwenAsrProvider provider = new QwenAsrProvider(
+				httpClient,
+				new ObjectMapper(),
+				"dashscope-key",
+				URI.create(
+						"https://workspace-123.cn-beijing.maas.aliyuncs.com/"
+								+ "compatible-mode/v1/chat/completions"),
+				"qwen3-asr-flash", Duration.ofSeconds(20), 128, 128);
+
+		Thread.interrupted();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[] {1}, null));
+		assertEquals("QWEN_ASR_INTERRUPTED", exception.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	@Test
 	void transcribesAudioWithDoubaoBigAsr() {
 		RecordingHttpClient httpClient = new RecordingHttpClient(new QueuedResponse(
 				200,
@@ -1036,21 +1692,215 @@ class QwenRealtimeProviderTest {
 		assertTrue(exception.getMessage().contains("55000031"));
 	}
 
+	@Test
+	void usesLegacyDoubaoCredentialsWhenApiKeyIsAbsent() {
+		RecordingHttpClient httpClient = new RecordingHttpClient(new QueuedResponse(
+				200,
+				utf8("{\"result\":{\"text\":\"legacy-ok\"}}"),
+				Map.of("X-Api-Status-Code", List.of("20000000"))));
+		DoubaoAsrProvider provider = new DoubaoAsrProvider(
+				httpClient, new ObjectMapper(), "", "app-key", "access-key",
+				"legacy-user",
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"),
+				"resource", Duration.ofSeconds(20), 128, 128);
+
+		assertEquals("legacy-ok", provider.convertAudioToText(new byte[] {1, 2}, null));
+		HttpRequest request = httpClient.requests.getFirst();
+		assertEquals("app-key", request.headers().firstValue("X-Api-App-Key").orElseThrow());
+		assertEquals("access-key", request.headers().firstValue("X-Api-Access-Key").orElseThrow());
+		assertTrue(request.headers().firstValue("X-Api-Key").isEmpty());
+	}
+
+	@Test
+	void rejectsDoubaoInvalidInputsCredentialsEndpointAndResponseSize() {
+		RecordingHttpClient httpClient = new RecordingHttpClient();
+		DoubaoAsrProvider provider = doubaoProvider(httpClient, "doubao-key", 128, 128,
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"));
+		assertEquals("INVALID_AUDIO", assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[0], null)).code());
+		assertEquals("TRANSCRIPTION_AUDIO_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(
+						new RecordingHttpClient(), "doubao-key", 1, 128,
+						URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"))
+						.convertAudioToText(new byte[] {1, 2}, null)).code());
+
+		DoubaoAsrProvider missingCredential = doubaoProvider(
+				httpClient, "", 128, 128,
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"));
+		assertEquals("DOUBAO_ASR_CREDENTIAL_MISSING", assertThrows(
+				BusinessException.class,
+				() -> missingCredential.convertAudioToText(new byte[] {1}, null)).code());
+
+		DoubaoAsrProvider untrusted = doubaoProvider(
+				httpClient, "doubao-key", 128, 128,
+				URI.create("https://evil.example/api/v3/auc/bigmodel/recognize/flash"));
+		assertEquals("DOUBAO_ASR_ENDPOINT_INVALID", assertThrows(
+				BusinessException.class,
+				() -> untrusted.convertAudioToText(new byte[] {1}, null)).code());
+		assertTrue(httpClient.requests.isEmpty());
+
+		DoubaoAsrProvider oversized = doubaoProvider(
+				new RecordingHttpClient(new QueuedResponse(200, utf8("123456789"),
+						Map.of("X-Api-Status-Code", List.of("20000000")))),
+				"doubao-key", 128, 8,
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"));
+		assertEquals("DOUBAO_ASR_RESPONSE_TOO_LARGE", assertThrows(
+				BusinessException.class,
+				() -> oversized.convertAudioToText(new byte[] {1}, null)).code());
+	}
+
+	@Test
+	void mapsDoubaoHttpJsonEmptyAndTransportFailures() {
+		URI endpoint = URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash");
+		RecordingHttpClient httpFailure = new RecordingHttpClient(new QueuedResponse(500, utf8("error")));
+		assertEquals("DOUBAO_ASR_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(httpFailure, "key", 128, 128, endpoint)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient missingStatus = new RecordingHttpClient(new QueuedResponse(
+				200, utf8("{}")));
+		assertEquals("DOUBAO_ASR_REQUEST_FAILED", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(missingStatus, "key", 128, 128, endpoint)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient empty = new RecordingHttpClient(new QueuedResponse(
+				200, utf8("{\"result\":{\"text\":\"\"}}"),
+				Map.of("X-Api-Status-Code", List.of("20000000"))));
+		assertEquals("DOUBAO_ASR_RESULT_EMPTY", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(empty, "key", 128, 128, endpoint)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient malformed = new RecordingHttpClient(new QueuedResponse(
+				200, utf8("not-json"), Map.of("X-Api-Status-Code", List.of("20000000"))));
+		assertEquals("DOUBAO_ASR_RESPONSE_INVALID", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(malformed, "key", 128, 128, endpoint)
+						.convertAudioToText(new byte[] {1}, null)).code());
+
+		RecordingHttpClient ioFailure = new RecordingHttpClient(QueuedResponse.ioError());
+		assertEquals("DOUBAO_ASR_IO_ERROR", assertThrows(
+				BusinessException.class,
+				() -> doubaoProvider(ioFailure, "key", 128, 128, endpoint)
+						.convertAudioToText(new byte[] {1}, null)).code());
+	}
+
+	@Test
+	void mapsInterruptedDoubaoCallsAndRestoresInterruptStatus() throws Exception {
+		HttpClient httpClient = mock(HttpClient.class);
+		doThrow(new InterruptedException("cancelled"))
+				.when(httpClient)
+				.send(any(HttpRequest.class),
+						org.mockito.ArgumentMatchers.<HttpResponse.BodyHandler<byte[]>>any());
+		DoubaoAsrProvider provider = new DoubaoAsrProvider(
+				httpClient, new ObjectMapper(), "key", "", "", "user",
+				URI.create("https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"),
+				"resource", Duration.ofSeconds(20), 128, 128);
+
+		Thread.interrupted();
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> provider.convertAudioToText(new byte[] {1}, null));
+		assertEquals("DOUBAO_ASR_INTERRUPTED", exception.code());
+		assertTrue(Thread.currentThread().isInterrupted());
+		Thread.interrupted();
+	}
+
+	private DoubaoAsrProvider doubaoProvider(
+			RecordingHttpClient httpClient,
+			String apiKey,
+			int maxAudioBytes,
+			int maxResponseBytes,
+			URI endpoint) {
+		return new DoubaoAsrProvider(
+				httpClient, new ObjectMapper(), apiKey, "", "", "user", endpoint,
+				"resource", Duration.ofSeconds(20), maxAudioBytes, maxResponseBytes);
+	}
+
+	private QwenTtsProvider qwenTtsProvider(
+			RecordingHttpClient httpClient,
+			String apiKey,
+			int maxResponseBytes,
+			int maxAudioBytes) {
+		return new QwenTtsProvider(
+				httpClient,
+				new ObjectMapper(),
+				apiKey,
+				URI.create(
+						"https://dashscope.aliyuncs.com/api/v1/services/aigc/"
+								+ "multimodal-generation/generation"),
+				"qwen3-tts-flash",
+				"Aiden",
+				"English",
+				Duration.ofSeconds(20),
+				maxResponseBytes,
+				maxAudioBytes);
+	}
+
+	private QwenLlmProvider qwenLlmProvider(
+			RecordingHttpClient httpClient,
+			String apiKey) {
+		return new QwenLlmProvider(
+				httpClient,
+				new ObjectMapper(),
+				apiKey,
+				URI.create(
+						"https://workspace-123.cn-beijing.maas.aliyuncs.com/"
+								+ "compatible-mode/v1/chat/completions"),
+				"qwen3.5-plus",
+				Duration.ofSeconds(20),
+				128);
+	}
+
+	private QwenAsrProvider qwenAsrProvider(
+			RecordingHttpClient httpClient,
+			String apiKey,
+			int maxAudioBytes,
+			int maxResponseBytes) {
+		return new QwenAsrProvider(
+				httpClient,
+				new ObjectMapper(),
+				apiKey,
+				URI.create(
+						"https://workspace-123.cn-beijing.maas.aliyuncs.com/"
+								+ "compatible-mode/v1/chat/completions"),
+				"qwen3-asr-flash",
+				Duration.ofSeconds(20),
+				maxAudioBytes,
+				maxResponseBytes);
+	}
+
 	private IflytekScoringProvider iflytekProvider(
 			RecordingWebSocketConnector connector,
 			URI endpoint,
 			Duration readTimeout) {
+		return iflytekProvider(
+				connector, endpoint, readTimeout, "app-id", "api-key", "api-secret", 1_048_576);
+	}
+
+	private IflytekScoringProvider iflytekProvider(
+			RecordingWebSocketConnector connector,
+			URI endpoint,
+			Duration readTimeout,
+			String appId,
+			String apiKey,
+			String apiSecret,
+			int maxAudioBytes) {
 		return new IflytekScoringProvider(
 				new ObjectMapper(),
 				connector,
-				"app-id",
-				"api-key",
-				"api-secret",
+				appId,
+				apiKey,
+				apiSecret,
 				endpoint,
 				"en",
 				"sent",
 				readTimeout,
-				1_048_576,
+				maxAudioBytes,
 				Duration.ZERO);
 	}
 

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/config/RealtimePropertiesTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/config/RealtimePropertiesTest.java
@@ -123,6 +123,28 @@ class RealtimePropertiesTest {
 		assertEquals("QWEN_TEMPORARY_KEY_INVALID", exception.code());
 	}
 
+	@Test
+	void mapsCredentialProviderFailuresHttpFailuresInvalidJsonAndInterruptions() {
+		var missing = new RealtimeCredentialIssuer(
+				new RecordingHttpClient(200, "{}"), new ObjectMapper(),
+				realtimeProperties("", "", ""));
+		assertEquals("QWEN_CREDENTIAL_MISSING", assertThrows(BusinessException.class,
+				() -> missing.issue(ProviderType.QWEN)).code());
+		assertEquals("REALTIME_CREDENTIAL_PROVIDER_MISSING", assertThrows(BusinessException.class,
+				() -> missing.issue(ProviderType.QINIU)).code());
+
+		var failed = new RealtimeCredentialIssuer(
+				new RecordingHttpClient(500, "{\"code\":\"bad\",\"message\":\"no\"}"),
+				new ObjectMapper(), realtimeProperties("key", "", ""));
+		assertEquals("QWEN_TEMPORARY_KEY_FAILED", assertThrows(BusinessException.class,
+				() -> failed.issue(ProviderType.QWEN)).code());
+		var invalid = new RealtimeCredentialIssuer(
+				new RecordingHttpClient(200, "not-json"), new ObjectMapper(),
+				realtimeProperties("key", "", ""));
+		assertEquals("QWEN_TEMPORARY_KEY_INVALID", assertThrows(BusinessException.class,
+				() -> invalid.issue(ProviderType.QWEN)).code());
+	}
+
 	private RealtimeProperties realtimeProperties(
 			String apiKey, String workspaceId, String model) {
 		return realtimeProperties(

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/evaluation/client/EvaluationLlmClientTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/evaluation/client/EvaluationLlmClientTest.java
@@ -1,0 +1,113 @@
+package com.unispeaking.infrastructure.evaluation.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.evaluation.EvaluationProviderFailureTranslator;
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
+import com.unispeaking.common.exception.evaluation.EvaluationException;
+import com.unispeaking.common.prompt.evaluation.ConversationReportEvaluationPromptBuilder;
+import com.unispeaking.common.prompt.evaluation.DialogueTurnEvaluationPromptBuilder;
+import com.unispeaking.common.prompt.evaluation.DialogueTurnEvaluationPromptInput;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.provider.AiInvocationContext;
+import com.unispeaking.provider.AiProviderRegistry;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class EvaluationLlmClientTest {
+
+	@Test
+	void assessesDialogueAndTurnWithAndWithoutInvocationContext() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed(validReportJson()));
+		when(registry.executeLlmTaskRouted(any(AiInvocationContext.class), anyString(), isNull()))
+				.thenReturn(routed(validReportJson()));
+		EvaluationLlmClient client = client(registry);
+
+		var report = client.assessDialogue(List.of(new Message(0, "hello", null)));
+		assertEquals("80", report.grammarScore().toString());
+		var context = AiInvocationContext.create("user", "session", "evaluation");
+		assertEquals("80", client.assessDialogue(List.of(new Message(1, "answer", null)), context)
+				.grammarScore().toString());
+		verify(registry).executeLlmTaskRouted(eq(context), anyString(), isNull());
+
+		when(registry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(routed("{\"feedbackSummary\":\"表达清楚\",\"suggestedExpression\":\"A natural answer.\"}"));
+		var input = new DialogueTurnEvaluationPromptInput(
+				"FREE_CHAT", null, null, null, null, List.of(), null, "I agree.");
+		assertEquals("表达清楚", client.assessTurn(input).feedbackSummary());
+	}
+
+	@Test
+	void translatesProviderBusinessFailuresAndPropagatesParserFailures() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenThrow(new BusinessException("AI_PROVIDER_ROUTE_NOT_FOUND", "secret detail"));
+		EvaluationLlmClient client = client(registry);
+		EvaluationException translated = assertThrows(
+				EvaluationException.class,
+				() -> client.assessTurn(new DialogueTurnEvaluationPromptInput(
+						"FREE_CHAT", null, null, null, null, List.of(), null, "I agree.")));
+		assertEquals(EvaluationErrorCode.PROVIDER_NOT_CONFIGURED, translated.errorCode());
+
+		AiProviderRegistry invalidRegistry = mock(AiProviderRegistry.class);
+		doReturn(routed("not-json")).when(invalidRegistry)
+				.executeLlmTaskRouted(anyString(), isNull());
+		EvaluationException invalid = assertThrows(
+				EvaluationException.class,
+				() -> client(invalidRegistry).assessTurn(new DialogueTurnEvaluationPromptInput(
+						"FREE_CHAT", null, null, null, null, List.of(), null, "I agree.")));
+		assertEquals(EvaluationErrorCode.PROVIDER_RESPONSE_INVALID, invalid.errorCode());
+	}
+
+	@Test
+	void mapsAsyncExecutionFailuresToProviderCallFailed() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenThrow(new RuntimeException("network failure"));
+		EvaluationException failure = assertThrows(
+				EvaluationException.class,
+				() -> client(registry).assessDialogue(
+						List.of(new Message(1, "answer", null))));
+		assertEquals(EvaluationErrorCode.PROVIDER_CALL_FAILED, failure.errorCode());
+	}
+
+	private EvaluationLlmClient client(AiProviderRegistry registry) {
+		return new EvaluationLlmClient(
+				registry,
+				new EvaluationProviderFailureTranslator(),
+				new ConversationReportEvaluationPromptBuilder(
+						new ObjectMapper(),
+						new com.unispeaking.common.prompt.evaluation.ConversationReportEvaluationPromptTemplateLoader()),
+				new DialogueTurnEvaluationPromptBuilder(
+						new ObjectMapper(),
+						new com.unispeaking.common.prompt.evaluation.DialogueTurnEvaluationPromptTemplateLoader()),
+				new ObjectMapper());
+	}
+
+	private AiProviderRegistry.RoutedResult<String> routed(String response) {
+		return new AiProviderRegistry.RoutedResult<>("model", "provider",
+				com.unispeaking.domain.vo.provider.AiCapability.LLM, response);
+	}
+
+	private String validReportJson() {
+		return """
+				{"assessment_status":"ok","scores":{"grammar":80,"vocabulary":75,"text_naturalness":70},"confidence":0.8,
+				"dimensions":{"grammar":{"strengths":[{"evidence":"准确","reason":"表达清楚"}],"improvements":[{"evidence":"word","correction":"更自然","reason":"更自然"}]},
+				"vocabulary":{"strengths":[],"improvements":[]},"text_naturalness":{"strengths":[],"improvements":[]}},"data_quality_notes":["信息充分"]}
+				""";
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ocr/PaddleOcrProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ocr/PaddleOcrProviderTest.java
@@ -14,7 +14,9 @@ import com.unispeaking.infrastructure.config.OcrProperties;
 import java.awt.Color;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
@@ -23,8 +25,11 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
 import java.util.zip.CRC32;
 import javax.imageio.ImageIO;
+import java.lang.reflect.Method;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import tools.jackson.databind.ObjectMapper;
@@ -192,6 +197,219 @@ class PaddleOcrProviderTest {
 				() -> provider.recognizeText(List.of(new OcrImage(png()))));
 
 		assertSame(OcrErrorCode.RESPONSE_INVALID, exception.errorCode());
+	}
+
+	@Test
+	void startsAndStopsConfiguredWorkerDuringApplicationLifecycle() throws IOException {
+		Path processId = tempRoot.resolve("lifecycle-process-id.txt");
+		Path script = script("""
+				import json, os, pathlib, sys
+				pathlib.Path(r'%s').write_text(str(os.getpid()))
+				print(json.dumps({'ready': True}), flush=True)
+				for line in sys.stdin:
+					pass
+				""".formatted(processId));
+		PaddleOcrProvider provider = provider(script, Duration.ofSeconds(2));
+
+		provider.startWorkerOnApplicationStartup();
+		long pid = Long.parseLong(Files.readString(processId));
+		assertTrue(provider.available());
+
+		provider.stopWorkerOnApplicationShutdown();
+
+		assertAll(
+				() -> assertFalse(provider.available()),
+				() -> assertFalse(ProcessHandle.of(pid).map(ProcessHandle::isAlive).orElse(false)));
+	}
+
+	@Test
+	void skipsStartupWhenOcrIsNotConfiguredAndReportsStartupFailure() throws IOException {
+		OcrProperties disabled = properties(Duration.ofSeconds(1));
+		disabled.setEnabled(false);
+		PaddleOcrProvider disabledProvider = new PaddleOcrProvider(disabled, new ObjectMapper());
+		disabledProvider.startWorkerOnApplicationStartup();
+		assertFalse(disabledProvider.available());
+
+		OcrProperties broken = properties(Duration.ofSeconds(1));
+		broken.setRunnerPath(tempRoot.resolve("runner-that-does-not-exist.py").toString());
+		broken.setModelDirectory(createModelDirectory().toString());
+		PaddleOcrProvider brokenProvider = new PaddleOcrProvider(broken, new ObjectMapper());
+		brokenProvider.startWorkerOnApplicationStartup();
+		assertFalse(brokenProvider.available());
+	}
+
+	@Test
+	void rejectsInvalidWorkerReadyLinesAndWorkerErrorResponses() throws IOException {
+		PaddleOcrProvider notReady = provider(script("print('{\\\"ready\\\": false}', flush=True)"),
+				Duration.ofSeconds(2));
+		OcrException startupException = assertThrows(
+				OcrException.class,
+				() -> notReady.recognizeText(List.of(new OcrImage(png()))));
+
+		Path errorScript = script("""
+				import json, sys
+				print(json.dumps({'ready': True}), flush=True)
+				request = json.loads(sys.stdin.readline())
+				print(json.dumps({'id': request['id'], 'error': 'worker rejected request'}), flush=True)
+				""");
+		PaddleOcrProvider workerError = provider(errorScript, Duration.ofSeconds(2));
+		OcrException responseException = assertThrows(
+				OcrException.class,
+				() -> workerError.recognizeText(List.of(new OcrImage(png()))));
+
+		assertAll(
+				() -> assertSame(OcrErrorCode.PROCESS_FAILED, startupException.errorCode()),
+				() -> assertSame(OcrErrorCode.PROCESS_FAILED, responseException.errorCode()),
+				() -> assertFalse(workerError.available()),
+				() -> assertTempDirectoryClean());
+	}
+
+	@Test
+	void rejectsMismatchedAndMalformedWorkerResults() throws IOException {
+		assertWorkerResponseError("""
+				print(json.dumps({'id': 'different-request-id', 'results': []}), flush=True)
+				""", OcrErrorCode.RESPONSE_INVALID);
+		assertWorkerResponseError("""
+				print(json.dumps({'id': request['id'], 'results': []}), flush=True)
+				""", OcrErrorCode.RESPONSE_INVALID);
+		assertWorkerResponseError("""
+				print(json.dumps({'id': request['id'], 'results': [{'text': None}]}), flush=True)
+				""", OcrErrorCode.RESPONSE_INVALID);
+		assertWorkerResponseError("""
+				print(json.dumps({'id': request['id'], 'results': [{'text': '  ' }]}), flush=True)
+				""", null);
+	}
+
+	@Test
+	void coversLimitedOutputNormalTruncatedAndFutureFailurePaths() throws Exception {
+		Object normal = invokeReadLimited(new ByteArrayInputStream("hello".getBytes(StandardCharsets.UTF_8)), 5);
+		Object truncated = invokeReadLimited(new ByteArrayInputStream("hello!".getBytes(StandardCharsets.UTF_8)), 5);
+		assertAll(
+				() -> assertEquals("hello", recordValue(normal, "text")),
+				() -> assertFalse((Boolean) recordValue(normal, "truncated")),
+				() -> assertEquals("hello", recordValue(truncated, "text")),
+				() -> assertTrue((Boolean) recordValue(truncated, "truncated")));
+
+		OcrException interrupted = assertThrows(OcrException.class,
+				() -> invokeGetOutput(new ThrowingFuture(new InterruptedException())));
+		OcrException failed = assertThrows(OcrException.class,
+				() -> invokeGetOutput(new ThrowingFuture(new ExecutionException("failed", null))));
+		assertAll(
+				() -> assertSame(OcrErrorCode.PROCESS_FAILED, interrupted.errorCode()),
+				() -> assertSame(OcrErrorCode.PROCESS_FAILED, failed.errorCode()),
+				() -> assertTrue(Thread.currentThread().isInterrupted()));
+		Thread.interrupted();
+	}
+
+	@Test
+	void rejectsEmptyAndMalformedImageContentBeforeStartingWorker() throws IOException {
+		Path marker = tempRoot.resolve("worker-started.txt");
+		Path script = script("""
+				import pathlib
+				pathlib.Path(r'%s').write_text('started')
+				""".formatted(marker));
+		PaddleOcrProvider provider = provider(script, Duration.ofSeconds(1));
+
+		assertAll(
+				() -> assertError(provider, List.of(new OcrImage(new byte[0])), OcrErrorCode.INPUT_REQUIRED),
+				() -> assertError(provider, List.of(new OcrImage(pngHeader(0, 0))), OcrErrorCode.CONTENT_INVALID),
+				() -> assertError(provider, List.of(new OcrImage(new byte[] {(byte) 0xff, (byte) 0xd8, 1})),
+						OcrErrorCode.CONTENT_INVALID),
+				() -> assertFalse(Files.exists(marker)));
+	}
+
+	private void assertWorkerResponseError(String responseBody, OcrErrorCode expected)
+			throws IOException {
+		Path script = script("""
+				import json, sys
+				print(json.dumps({'ready': True}), flush=True)
+				request = json.loads(sys.stdin.readline())
+				%s
+				""".formatted(responseBody));
+		PaddleOcrProvider provider = provider(script, Duration.ofSeconds(2));
+		if (expected == null) {
+			assertEquals("", provider.recognizeText(List.of(new OcrImage(png()))));
+		}
+		else {
+			OcrException exception = assertThrows(OcrException.class,
+					() -> provider.recognizeText(List.of(new OcrImage(png()))));
+			assertSame(expected, exception.errorCode());
+		}
+	}
+
+	private void assertError(PaddleOcrProvider provider, List<OcrImage> images, OcrErrorCode expected) {
+		OcrException exception = assertThrows(OcrException.class, () -> provider.recognizeText(images));
+		assertSame(expected, exception.errorCode());
+	}
+
+	private Path createModelDirectory() throws IOException {
+		Path modelDirectory = tempRoot.resolve("models-for-test");
+		Files.createDirectories(modelDirectory.resolve("official_models/PP-OCRv5_mobile_det"));
+		Files.createDirectories(modelDirectory.resolve("official_models/PP-OCRv5_mobile_rec"));
+		return modelDirectory;
+	}
+
+	private static Object invokeReadLimited(InputStream input, int limit) throws Exception {
+		Method method = PaddleOcrProvider.class.getDeclaredMethod("readLimited", InputStream.class, int.class);
+		method.setAccessible(true);
+		return method.invoke(null, input, limit);
+	}
+
+	private static Object invokeGetOutput(Future<?> future) throws Exception {
+		Method method = PaddleOcrProvider.class.getDeclaredMethod("getOutput", Future.class);
+		method.setAccessible(true);
+		try {
+			return method.invoke(null, future);
+		}
+		catch (java.lang.reflect.InvocationTargetException exception) {
+			if (exception.getCause() instanceof OcrException ocrException) {
+				throw ocrException;
+			}
+			throw exception;
+		}
+	}
+
+	private static Object recordValue(Object record, String accessor) throws Exception {
+		Method method = record.getClass().getDeclaredMethod(accessor);
+		method.setAccessible(true);
+		return method.invoke(record);
+	}
+
+	private static final class ThrowingFuture implements Future<Object> {
+
+		private final Exception exception;
+
+		private ThrowingFuture(Exception exception) {
+			this.exception = exception;
+		}
+
+		@Override
+		public Object get() throws InterruptedException, ExecutionException {
+			if (exception instanceof InterruptedException interrupted) {
+				throw interrupted;
+			}
+			throw (ExecutionException) exception;
+		}
+
+		@Override
+		public Object get(long timeout, java.util.concurrent.TimeUnit unit) {
+			throw new UnsupportedOperationException();
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return false;
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return false;
+		}
+
+		@Override
+		public boolean isDone() {
+			return true;
+		}
 	}
 
 	private void assertError(List<OcrImage> images, OcrErrorCode expected) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/entity/achievement/UserAchievementUnlockEntityTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/entity/achievement/UserAchievementUnlockEntityTest.java
@@ -1,0 +1,53 @@
+package com.unispeaking.infrastructure.persistence.entity.achievement;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class UserAchievementUnlockEntityTest {
+
+	@Test
+	void retainsCompositeKeyTimestampsAndNullableAcknowledgement() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		OffsetDateTime unlockedAt = OffsetDateTime.parse("2026-08-04T02:00:00Z");
+		UserAchievementUnlockEntity entity = new UserAchievementUnlockEntity();
+
+		entity.setUserId(userId);
+		entity.setAchievementId("conversation-1");
+		entity.setUnlockedAt(unlockedAt);
+		entity.setAcknowledgedAt(null);
+		entity.setCreatedAt(unlockedAt);
+		entity.setUpdatedAt(unlockedAt.plusSeconds(1));
+
+		assertEquals(userId, entity.getUserId());
+		assertEquals("conversation-1", entity.getAchievementId());
+		assertEquals(unlockedAt, entity.getUnlockedAt());
+		assertNull(entity.getAcknowledgedAt());
+		assertEquals(unlockedAt, entity.getCreatedAt());
+		assertEquals(unlockedAt.plusSeconds(1), entity.getUpdatedAt());
+	}
+
+	@Test
+	void supportsAcknowledgementLifecycleWithoutChangingTheCompositeKey() {
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime unlockedAt = OffsetDateTime.parse("2026-08-04T02:00:00+08:00");
+		UserAchievementUnlockEntity entity = new UserAchievementUnlockEntity();
+
+		assertNull(entity.getUserId());
+		assertNull(entity.getAchievementId());
+		assertNull(entity.getAcknowledgedAt());
+		entity.setUserId(userId);
+		entity.setAchievementId("daily-streak-7");
+		entity.setUnlockedAt(unlockedAt);
+		entity.setAcknowledgedAt(unlockedAt.plusMinutes(2));
+		entity.setUpdatedAt(unlockedAt.plusMinutes(2));
+
+		assertEquals(userId, entity.getUserId());
+		assertEquals("daily-streak-7", entity.getAchievementId());
+		assertEquals(unlockedAt.plusMinutes(2), entity.getAcknowledgedAt());
+		assertEquals(unlockedAt.plusMinutes(2), entity.getUpdatedAt());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/entity/evaluation/InterviewReportEntityTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/entity/evaluation/InterviewReportEntityTest.java
@@ -1,0 +1,60 @@
+package com.unispeaking.infrastructure.persistence.entity.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class InterviewReportEntityTest {
+
+	@Test
+	void retainsNullableAssessmentFieldsAndAsyncStateColumns() {
+		InterviewReportEntity entity = new InterviewReportEntity();
+		UUID userId = UUID.randomUUID();
+		OffsetDateTime now = OffsetDateTime.parse("2026-08-01T00:00:00Z");
+
+		entity.setSessionId("session-1");
+		entity.setSceneId("scene-1");
+		entity.setUserId(userId);
+		entity.setStatus("PROCESSING");
+		entity.setRetryCount(0);
+		entity.setFailureReason(null);
+		entity.setOverallScore(new BigDecimal("8.5"));
+		entity.setCreatedAt(now);
+		entity.setUpdatedAt(now.plusSeconds(1));
+
+		assertEquals("session-1", entity.getSessionId());
+		assertEquals("scene-1", entity.getSceneId());
+		assertEquals(userId, entity.getUserId());
+		assertEquals("PROCESSING", entity.getStatus());
+		assertEquals(0, entity.getRetryCount());
+		assertNull(entity.getFailureReason());
+		assertEquals(new BigDecimal("8.5"), entity.getOverallScore());
+		assertEquals(now.plusSeconds(1), entity.getUpdatedAt());
+	}
+
+	@Test
+	void supportsCompletedScoresAndFailureTransitionValues() {
+		InterviewReportEntity entity = new InterviewReportEntity();
+		entity.setStatus("FAILED");
+		entity.setFailureReason("PROVIDER_TIMEOUT");
+		entity.setRetryCount(3);
+		entity.setFluencyScore(new BigDecimal("7.0"));
+		entity.setPronunciationIntelligibilityScore(new BigDecimal("6.5"));
+		entity.setLogicCoherenceScore(new BigDecimal("7.5"));
+		entity.setGrammarControlScore(new BigDecimal("6.0"));
+		entity.setVocabularyExpressionScore(new BigDecimal("7.0"));
+
+		assertEquals("FAILED", entity.getStatus());
+		assertEquals("PROVIDER_TIMEOUT", entity.getFailureReason());
+		assertEquals(3, entity.getRetryCount());
+		assertEquals(new BigDecimal("7.0"), entity.getFluencyScore());
+		assertEquals(new BigDecimal("6.5"), entity.getPronunciationIntelligibilityScore());
+		assertEquals(new BigDecimal("7.5"), entity.getLogicCoherenceScore());
+		assertEquals(new BigDecimal("6.0"), entity.getGrammarControlScore());
+		assertEquals(new BigDecimal("7.0"), entity.getVocabularyExpressionScore());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/achievement/AchievementUnlockRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/achievement/AchievementUnlockRepositoryTest.java
@@ -139,6 +139,123 @@ class AchievementUnlockRepositoryTest {
 		verify(unlockMapper, never()).update(any(), any());
 	}
 
+	@Test
+	void mapsStateAndUnlockQueriesAndConvertsMapperFailures() {
+		assertTrue(repository.findState(userId).isEmpty());
+		when(stateMapper.selectById(userId)).thenReturn(stateEntity());
+		assertEquals(new UserAchievementState(userId, unlockedAt),
+				repository.findState(userId).orElseThrow());
+
+		UserAchievementUnlockEntity acknowledged = unlockEntity(
+				unlockedAt.plusSeconds(5));
+		when(unlockMapper.selectList(any())).thenReturn(List.of(
+				unlockEntity(null), acknowledged));
+		List<UserAchievementUnlock> unlocks = repository.findAll(userId);
+		assertEquals(2, unlocks.size());
+		assertTrue(unlocks.getFirst().pendingNotification());
+		assertEquals(unlockedAt.plusSeconds(5), unlocks.get(1).acknowledgedAt());
+
+		when(unlockMapper.selectList(any())).thenThrow(
+				new IllegalStateException("database unavailable"));
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.findPending(userId));
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void rejectsAcknowledgementBeforeUnlockWithoutUpdating() {
+		when(unlockMapper.selectOne(any())).thenReturn(unlockEntity(null));
+
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> repository.acknowledge(
+						userId, "conversation-1", unlockedAt.minusSeconds(1)));
+
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", exception.code());
+		verify(unlockMapper, never()).update(any(), any());
+	}
+
+	@Test
+	void acknowledgesConcurrentUpdateByReadingPersistedAcknowledgement() {
+		Instant acknowledgedAt = unlockedAt.plusSeconds(5);
+		when(unlockMapper.selectOne(any())).thenReturn(
+				unlockEntity(null), unlockEntity(acknowledgedAt));
+		when(unlockMapper.update(any(), any())).thenReturn(0);
+
+		UserAchievementUnlock result = repository.acknowledge(
+				userId, " conversation-1 ", acknowledgedAt);
+
+		assertEquals(acknowledgedAt, result.acknowledgedAt());
+		assertFalse(result.pendingNotification());
+	}
+
+	@Test
+	void rejectsBlankIdsAndUnexpectedCreateOrInitializeResults() {
+		BusinessException blankId = assertThrows(BusinessException.class,
+				() -> repository.find(userId, " \t"));
+		assertEquals("ACHIEVEMENT_UNLOCK_NOT_FOUND", blankId.code());
+
+		when(unlockMapper.insert(any(UserAchievementUnlockEntity.class))).thenReturn(0);
+		BusinessException createFailure = assertThrows(BusinessException.class,
+				() -> repository.create(pendingUnlock()));
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", createFailure.code());
+
+		when(stateMapper.insert(any(UserAchievementStateEntity.class))).thenReturn(0);
+		BusinessException initializeFailure = assertThrows(BusinessException.class,
+				() -> repository.initialize(new UserAchievementState(userId, unlockedAt)));
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", initializeFailure.code());
+	}
+
+	@Test
+	void findReturnsEmptyForMissingUnlockAndWrapsReadFailures() {
+		when(unlockMapper.selectOne(any())).thenReturn(null);
+		assertTrue(repository.find(userId, " conversation-1 ").isEmpty());
+		when(unlockMapper.selectOne(any())).thenThrow(new IllegalStateException("read"));
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.find(userId, "conversation-1")).code());
+
+		when(stateMapper.selectById(userId)).thenThrow(new IllegalStateException("read"));
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.findState(userId)).code());
+	}
+
+	@Test
+	void findAllPreservesAcknowledgedAndEmptyResultSemantics() {
+		when(unlockMapper.selectList(any())).thenReturn(List.of());
+		assertTrue(repository.findAll(userId).isEmpty());
+
+		UserAchievementUnlockEntity acknowledged = unlockEntity(unlockedAt.plusSeconds(30));
+		when(unlockMapper.selectList(any())).thenReturn(List.of(acknowledged));
+		UserAchievementUnlock result = repository.findAll(userId).getFirst();
+		assertEquals(unlockedAt.plusSeconds(30), result.acknowledgedAt());
+		assertFalse(result.pendingNotification());
+	}
+
+	@Test
+	void concurrentAcknowledgementMustObservePersistedTerminalState() {
+		when(unlockMapper.selectOne(any())).thenReturn(unlockEntity(null), unlockEntity(null));
+		when(unlockMapper.update(any(), any())).thenReturn(0);
+
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.acknowledge(userId, "conversation-1", unlockedAt.plusSeconds(1)));
+
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void duplicateCreateAndInitializeFailWhenConcurrentRowsCannotBeRead() {
+		when(unlockMapper.insert(any(UserAchievementUnlockEntity.class)))
+				.thenThrow(new DuplicateKeyException("duplicate"));
+		when(unlockMapper.selectOne(any())).thenReturn(null);
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.create(pendingUnlock())).code());
+
+		when(stateMapper.insert(any(UserAchievementStateEntity.class)))
+				.thenThrow(new DuplicateKeyException("duplicate"));
+		when(stateMapper.selectById(userId)).thenReturn(null);
+		assertEquals("ACHIEVEMENT_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.initialize(new UserAchievementState(userId, unlockedAt))).code());
+	}
+
 	private UserAchievementUnlock pendingUnlock() {
 		return new UserAchievementUnlock(
 				userId,

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/auth/AuthRefreshTokenRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/auth/AuthRefreshTokenRepositoryTest.java
@@ -1,0 +1,108 @@
+package com.unispeaking.infrastructure.persistence.repository.auth;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+class AuthRefreshTokenRepositoryTest {
+
+	private final JdbcTemplate jdbc = mock(JdbcTemplate.class);
+	private final AuthRefreshTokenRepository repository = new AuthRefreshTokenRepository(jdbc);
+	private final UUID userId = UUID.randomUUID();
+	private final Instant now = Instant.parse("2026-08-21T00:00:00Z");
+
+	@Test
+	void insertsTokenWithCreatedAndLastUsedAtSetToTheSameInstant() {
+		repository.insert("digest", userId, now, now.plusSeconds(3600));
+
+		verify(jdbc).update(anyString(), eq("digest"), eq(userId),
+				eq(Timestamp.from(now)), eq(Timestamp.from(now)),
+			eq(Timestamp.from(now.plusSeconds(3600))));
+	}
+
+	@Test
+	void consumesOnlyAValidAndRecentlyUsedTokenAndReturnsDatabaseCount() {
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(1, 0);
+
+		assertThat(repository.consume("digest", now, now.minusSeconds(300))).isEqualTo(1);
+		assertThat(repository.consume("digest", now, now.minusSeconds(300))).isZero();
+		verify(jdbc, org.mockito.Mockito.times(2)).update(anyString(), any(Object[].class));
+	}
+
+	@Test
+	void mapsFoundTokenIncludingNullableRevocationTime() {
+		when(jdbc.query(anyString(), any(RowMapper.class), eq("digest"))).thenAnswer(invocation -> {
+			@SuppressWarnings("unchecked")
+			RowMapper<AuthRefreshTokenRepository.Record> mapper = invocation.getArgument(1);
+			ResultSet result = mock(ResultSet.class);
+			when(result.getString("token_digest")).thenReturn("digest");
+			when(result.getObject("user_id", UUID.class)).thenReturn(userId);
+			when(result.getTimestamp("created_at")).thenReturn(Timestamp.from(now));
+			when(result.getTimestamp("last_used_at")).thenReturn(Timestamp.from(now.plusSeconds(1)));
+			when(result.getTimestamp("expires_at")).thenReturn(Timestamp.from(now.plusSeconds(3600)));
+			when(result.getTimestamp("revoked_at")).thenReturn(null);
+			return List.of(mapper.mapRow(result, 0));
+		});
+
+		var record = repository.find("digest");
+
+		assertThat(record).isNotNull();
+		assertThat(record.digest()).isEqualTo("digest");
+		assertThat(record.userId()).isEqualTo(userId);
+		assertThat(record.createdAt()).isEqualTo(now);
+		assertThat(record.lastUsedAt()).isEqualTo(now.plusSeconds(1));
+		assertThat(record.expiresAt()).isEqualTo(now.plusSeconds(3600));
+		assertThat(record.revokedAt()).isNull();
+	}
+
+	@Test
+	void mapsRevokedTokenAndReturnsNullWhenNoRowExists() {
+		when(jdbc.query(anyString(), any(RowMapper.class), eq("revoked"))).thenAnswer(invocation -> {
+			@SuppressWarnings("unchecked")
+			RowMapper<AuthRefreshTokenRepository.Record> mapper = invocation.getArgument(1);
+			ResultSet result = mock(ResultSet.class);
+			when(result.getString("token_digest")).thenReturn("revoked");
+			when(result.getObject("user_id", UUID.class)).thenReturn(userId);
+			when(result.getTimestamp("created_at")).thenReturn(Timestamp.from(now));
+			when(result.getTimestamp("last_used_at")).thenReturn(Timestamp.from(now));
+			when(result.getTimestamp("expires_at")).thenReturn(Timestamp.from(now.plusSeconds(60)));
+			when(result.getTimestamp("revoked_at")).thenReturn(Timestamp.from(now.plusSeconds(2)));
+			return List.of(mapper.mapRow(result, 0));
+		});
+		when(jdbc.query(anyString(), any(RowMapper.class), eq("missing"))).thenReturn(List.of());
+
+		assertThat(repository.find("revoked").revokedAt()).isEqualTo(now.plusSeconds(2));
+		assertThat(repository.find("missing")).isNull();
+	}
+
+	@Test
+	void revokesOneTokenOrAllTokensForAUser() {
+		repository.revoke("digest", now);
+		repository.revokeAll(userId, now);
+
+		verify(jdbc).update(anyString(), eq(Timestamp.from(now)), eq("digest"));
+		verify(jdbc).update(anyString(), eq(Timestamp.from(now)), eq(userId));
+	}
+
+	@Test
+	void deletesAtMostTheExpiredBatchAndReturnsDeletedCount() {
+		when(jdbc.update(anyString(), any(Object[].class))).thenReturn(37);
+
+		assertThat(repository.deleteExpired(now)).isEqualTo(37);
+		verify(jdbc).update(anyString(), eq(Timestamp.from(now)));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/auth/JdbcEmailAuthStoreTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/auth/JdbcEmailAuthStoreTest.java
@@ -8,6 +8,8 @@ import java.util.UUID;
 import com.unispeaking.service.auth.EmailAuthStore;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.dao.DataAccessResourceFailureException;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabase;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
@@ -58,6 +60,21 @@ class JdbcEmailAuthStoreTest {
     }
 
     @Test
+    void doesNotConsumeAnExpiredChallengeAndReadsConsumedAt() {
+        var challengeId = UUID.randomUUID();
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        store.saveChallenge(challengeId, "person@example.com", new byte[] {1}, now, now.minusSeconds(600));
+
+        assertThat(store.consumeChallenge(challengeId, now)).isFalse();
+
+        var jdbc = new JdbcTemplate(database);
+        jdbc.update("update auth_email_challenges set consumed_at = ? where id = ?", now, challengeId);
+        var record = store.findChallenge(challengeId).orElseThrow();
+        assertThat(record.consumed()).isTrue();
+        assertThat(record.consumedAt()).isEqualTo(now);
+    }
+
+    @Test
     void usesTheUnifiedUserIdentityAndRejectsDuplicateEmailWithoutServerError() {
         var userId = UUID.randomUUID();
         var now = Instant.parse("2026-08-06T08:00:00Z");
@@ -87,6 +104,19 @@ class JdbcEmailAuthStoreTest {
                 "select email_verified_at from users where id = ?", Instant.class, userId)).isEqualTo(now);
         assertThat(new JdbcTemplate(database).queryForObject(
                 "select count(*) from user_entitlements where user_id = ?", Integer.class, userId)).isEqualTo(1);
+
+        store.ensureGovernance(store.findUserByEmail("legacy@example.com").orElseThrow(), now.plusSeconds(30));
+        assertThat(new JdbcTemplate(database).queryForObject(
+                "select email_verified_at from users where id = ?", Instant.class, userId)).isEqualTo(now);
+    }
+
+    @Test
+    void governanceRejectsAUserThatNoLongerMatchesTheStoredIdentity() {
+        var user = new EmailAuthStore.UserRecord(UUID.randomUUID(), "missing@example.com", "hash");
+
+        assertThatThrownBy(() -> store.ensureGovernance(user, Instant.parse("2026-08-06T08:00:00Z")))
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .hasMessage("User identity no longer exists");
     }
 
     @Test
@@ -96,6 +126,8 @@ class JdbcEmailAuthStoreTest {
         assertThat(store.saveUser(userId, "person@example.com", "hash", null, now, now)).isTrue();
 
         assertThat(store.findUserByEmail("PERSON@EXAMPLE.COM").orElseThrow().id()).isEqualTo(userId);
+        assertThat(store.findUserById(userId).orElseThrow().email()).isEqualTo("person@example.com");
+        assertThat(store.findUserById(UUID.randomUUID())).isEmpty();
     }
 
     @Test
@@ -144,5 +176,54 @@ class JdbcEmailAuthStoreTest {
         assertThat(jdbc.queryForObject(
                 "select password_hash from users where id = ?", String.class, userId))
                 .isEqualTo("old-hash");
+    }
+
+    @Test
+    void saveUserRollsBackWhenTheEntitlementWriteFails() {
+        var userId = UUID.randomUUID();
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        var jdbc = new JdbcTemplate(database);
+        jdbc.execute("drop table user_entitlements");
+
+        assertThatThrownBy(() -> store.saveUser(userId, "person@example.com", "hash", null, now, now))
+                .isInstanceOf(DataAccessResourceFailureException.class);
+        assertThat(jdbc.queryForObject(
+                "select count(*) from users where id = ?", Integer.class, userId)).isZero();
+    }
+
+    @Test
+    void updatePasswordAndGovernanceRejectMissingUsers() {
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+
+        assertThatThrownBy(() -> store.updatePassword("missing@example.com", "hash", now))
+                .isInstanceOf(DataIntegrityViolationException.class)
+                .hasMessage("Email identity no longer exists");
+    }
+
+    @Test
+    void sessionLookupMapsRevocationAndLogoutIsIdempotent() {
+        var userId = UUID.randomUUID();
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        assertThat(store.saveUser(userId, "person@example.com", "hash", null, now, now)).isTrue();
+        store.saveSession("session", userId, now, now, now.plusSeconds(600));
+
+        assertThat(store.findSession("session").orElseThrow().revokedAt()).isNull();
+        store.revokeSession("session");
+        var revoked = store.findSession("session").orElseThrow();
+        assertThat(revoked.revokedAt()).isNotNull();
+        store.revokeSession("session");
+        store.revokeSession("missing-session");
+        assertThat(store.findSession("missing-session")).isEmpty();
+    }
+
+    @Test
+    void saveUserTranslatesDuplicateIdentityAndRestoresConnectionState() {
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        var existingId = UUID.randomUUID();
+        assertThat(store.saveUser(existingId, "person@example.com", "hash", null, now, now)).isTrue();
+
+        assertThat(store.saveUser(UUID.randomUUID(), "person@example.com", "other-hash", null, now, now)).isFalse();
+        assertThat(new JdbcTemplate(database).queryForObject(
+                "select count(*) from users where username = ?", Integer.class, "person@example.com")).isOne();
     }
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/IeltsEvaluationRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/IeltsEvaluationRepositoryTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.infrastructure.persistence.repository.evaluation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -9,6 +10,8 @@ import static org.mockito.Mockito.when;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.unispeaking.domain.dto.evaluation.IeltsEvaluationResult;
+import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
+import com.unispeaking.common.exception.evaluation.EvaluationException;
 import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.infrastructure.persistence.entity.evaluation.IeltsEvaluationEntity;
 import com.unispeaking.infrastructure.persistence.entity.evaluation.IeltsPartEvaluationEntity;
@@ -87,6 +90,80 @@ class IeltsEvaluationRepositoryTest {
 		assertEquals(existing.getCreatedAt(), captor.getValue().getCreatedAt());
 	}
 
+	@Test
+	void savesFinalEvaluationWithTheFinalMapperAndPreservesExistingCreationTime() {
+		IeltsEvaluationMapper mapper = mock(IeltsEvaluationMapper.class);
+		IeltsPartEvaluationMapper partMapper = mock(IeltsPartEvaluationMapper.class);
+		IeltsEvaluationEntity existing = new IeltsEvaluationEntity();
+		OffsetDateTime createdAt = OffsetDateTime.of(
+				2026, 8, 4, 8, 0, 0, 0, ZoneOffset.UTC);
+		existing.setCreatedAt(createdAt);
+		when(mapper.selectById("ielts_mock_ielts-mock-1")).thenReturn(existing);
+		when(mapper.updateById(any(IeltsEvaluationEntity.class))).thenReturn(1);
+
+		new IeltsEvaluationRepository(mapper, partMapper)
+				.save("ielts-mock-1", "ignored-for-final", finalResult());
+
+		ArgumentCaptor<IeltsEvaluationEntity> captor =
+				ArgumentCaptor.forClass(IeltsEvaluationEntity.class);
+		verify(mapper).updateById(captor.capture());
+		IeltsEvaluationEntity saved = captor.getValue();
+		assertEquals("ielts_mock_ielts-mock-1", saved.getEvaluationId());
+		assertEquals("ielts-mock-1", saved.getIeltsId());
+		assertEquals("COMPLETED", saved.getEvaluationStatus());
+		assertEquals(createdAt, saved.getCreatedAt());
+		assertEquals(new BigDecimal("6.5"), saved.getOverallBandScore());
+		assertEquals(List.of("表达连贯"), List.of(saved.getStrengths()));
+	}
+
+	@Test
+	void convertsMapperFailuresAndUnexpectedAffectedCountsToPersistenceFailures() {
+		IeltsEvaluationMapper mapper = mock(IeltsEvaluationMapper.class);
+		IeltsPartEvaluationMapper partMapper = mock(IeltsPartEvaluationMapper.class);
+		when(partMapper.selectById(any())).thenReturn(null);
+		when(partMapper.insert(any(IeltsPartEvaluationEntity.class))).thenReturn(0);
+		IeltsEvaluationRepository repository =
+				new IeltsEvaluationRepository(mapper, partMapper);
+
+		EvaluationException partFailure = assertThrows(
+				EvaluationException.class,
+				() -> repository.savePart("ielts-1", "session-1", result()));
+		assertEquals(EvaluationErrorCode.PERSISTENCE_FAILED, partFailure.errorCode());
+
+		when(mapper.selectById(any())).thenReturn(null);
+		when(mapper.insert(any(IeltsEvaluationEntity.class))).thenThrow(
+				new IllegalStateException("database unavailable"));
+		EvaluationException finalFailure = assertThrows(
+				EvaluationException.class,
+				() -> repository.saveFinal("ielts-1", finalResult()));
+		assertEquals(EvaluationErrorCode.PERSISTENCE_FAILED, finalFailure.errorCode());
+	}
+
+	@Test
+	void readsPartFinalAndOrderedPartsAndTranslatesReadFailures() {
+		IeltsEvaluationMapper mapper = mock(IeltsEvaluationMapper.class);
+		IeltsPartEvaluationMapper partMapper = mock(IeltsPartEvaluationMapper.class);
+		IeltsPartEvaluationEntity part = new IeltsPartEvaluationEntity();
+		part.setSessionId("session-1");
+		IeltsEvaluationEntity finalEvaluation = new IeltsEvaluationEntity();
+		finalEvaluation.setIeltsId("ielts-1");
+		when(partMapper.selectOne(any())).thenReturn(part);
+		when(mapper.selectOne(any())).thenReturn(finalEvaluation);
+		when(partMapper.selectList(any())).thenReturn(List.of(part));
+		IeltsEvaluationRepository repository =
+				new IeltsEvaluationRepository(mapper, partMapper);
+
+		assertEquals("session-1", repository.findPart("session-1").orElseThrow().getSessionId());
+		assertEquals("ielts-1", repository.findFinal("ielts-1").orElseThrow().getIeltsId());
+		assertEquals(1, repository.findParts("ielts-1").size());
+
+		when(partMapper.selectOne(any())).thenThrow(new IllegalStateException("read failed"));
+		EvaluationException failure = assertThrows(
+				EvaluationException.class,
+				() -> repository.findPart("session-1"));
+		assertEquals(EvaluationErrorCode.PERSISTENCE_FAILED, failure.errorCode());
+	}
+
 	private IeltsEvaluationResult result() {
 		return new IeltsEvaluationResult(
 				IeltsPart.PART_1,
@@ -105,5 +182,25 @@ class IeltsEvaluationRepositoryTest {
 				"能够使用话题词汇，但改述有限。",
 				"简单句准确，复杂结构控制有限。",
 				"基于 3 轮原始语音，整体清晰可懂。");
+	}
+
+	private IeltsEvaluationResult finalResult() {
+		return new IeltsEvaluationResult(
+				null,
+				"FINAL",
+				new BigDecimal("6.5"),
+				new BigDecimal("7.0"),
+				new BigDecimal("6.0"),
+				new BigDecimal("6.0"),
+				new BigDecimal("6.5"),
+				"完整模拟考试。",
+				List.of("表达连贯"),
+				List.of("丰富词汇"),
+				List.of(),
+				List.of("use a wider range"),
+				"流利。",
+				"词汇准确。",
+				"语法稳定。",
+				"发音清晰。");
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/InterviewReportRepositoryContractTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/InterviewReportRepositoryContractTest.java
@@ -1,0 +1,115 @@
+package com.unispeaking.infrastructure.persistence.repository.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.InterviewErrorCode;
+import com.unispeaking.domain.po.evaluation.InterviewReportRecord;
+import com.unispeaking.domain.vo.evaluation.ReportStatus;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.InterviewReportEntity;
+import com.unispeaking.infrastructure.persistence.mapper.evaluation.InterviewReportMapper;
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Additional contract tests kept separate from mapper-focused repository tests. */
+class InterviewReportRepositoryContractTest {
+
+	@Test
+	void findByIdHandlesBlankMissingAndNullablePersistedFields() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		assertTrue(repository.findById(null).isEmpty());
+		assertTrue(repository.findById(" ").isEmpty());
+		verify(mapper, never()).selectById(any());
+
+		when(mapper.selectById("missing")).thenReturn(null);
+		assertTrue(repository.findById("missing").isEmpty());
+		InterviewReportEntity entity = entity();
+		entity.setUserId(null);
+		entity.setStatus(null);
+		entity.setRetryCount(null);
+		when(mapper.selectById("nullable")).thenReturn(entity);
+
+		InterviewReportRecord record = repository.findById("nullable").orElseThrow();
+		assertEquals(null, record.userId());
+		assertEquals(null, record.status());
+		assertEquals(0, record.retryCount());
+	}
+
+	@Test
+	void readQueriesTranslateMapperFailuresAndMapSceneResults() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.selectList(any())).thenReturn(List.of(entity()));
+		assertEquals(List.of("session-1"), repository.findBySceneId("scene-1")
+				.stream().map(InterviewReportRecord::sessionId).toList());
+		when(mapper.selectById("broken")).thenThrow(new IllegalStateException("read"));
+		assertFailure(() -> repository.findById("broken"));
+		when(mapper.selectList(any())).thenThrow(new IllegalStateException("read"));
+		assertFailure(() -> repository.findBySceneId("scene-1"));
+	}
+
+	@Test
+	void terminalWritesAreBestEffortButCasMethodsExposeTheirOutcome() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.update(any(), any())).thenReturn(0);
+
+		assertDoesNotThrow(() -> repository.markCompleted(record()));
+		assertDoesNotThrow(() -> repository.markFailed("session-1", "provider unavailable"));
+		assertFalse(repository.retryFromFailed("session-1", 2));
+		assertFalse(repository.casFailedToProcessing("session-1"));
+
+		when(mapper.update(any(), any())).thenReturn(1);
+		assertTrue(repository.retryFromFailed("session-1", 2));
+		assertTrue(repository.casFailedToProcessing("session-1"));
+	}
+
+	@Test
+	void writeFailuresAreTranslatedForEachStateTransition() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.update(any(), any())).thenThrow(new IllegalStateException("write"));
+
+		assertFailure(() -> repository.markCompleted(record()));
+		assertFailure(() -> repository.markFailed("session-1", "failed"));
+		assertFailure(() -> repository.retryFromFailed("session-1", 0));
+		assertFailure(() -> repository.casFailedToProcessing("session-1"));
+	}
+
+	private void assertFailure(org.junit.jupiter.api.function.Executable executable) {
+		BusinessException failure = assertThrows(BusinessException.class, executable);
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED, failure.code());
+	}
+
+	private InterviewReportEntity entity() {
+		InterviewReportEntity entity = new InterviewReportEntity();
+		entity.setSessionId("session-1");
+		entity.setSceneId("scene-1");
+		entity.setStatus(ReportStatus.PROCESSING.name());
+		entity.setOverallScore(new BigDecimal("8.5"));
+		entity.setSummary("summary");
+		entity.setCreatedAt(OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+		entity.setUpdatedAt(OffsetDateTime.parse("2026-08-01T00:01:00Z"));
+		return entity;
+	}
+
+	private InterviewReportRecord record() {
+		OffsetDateTime now = OffsetDateTime.parse("2026-08-01T00:00:00Z");
+		return new InterviewReportRecord("session-1", "scene-1", "11111111-1111-4111-8111-111111111111",
+				ReportStatus.COMPLETED, new BigDecimal("8.5"), "summary",
+				null, null, null, null, null, null, null, null, null, null, null, null,
+				null, null, null, 2, null, now, now);
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/InterviewReportRepositoryContractTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/InterviewReportRepositoryContractTest.java
@@ -11,6 +11,8 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.baomidou.mybatisplus.core.MybatisConfiguration;
+import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.common.exception.InterviewErrorCode;
 import com.unispeaking.domain.po.evaluation.InterviewReportRecord;
@@ -20,10 +22,21 @@ import com.unispeaking.infrastructure.persistence.mapper.evaluation.InterviewRep
 import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
+import org.apache.ibatis.builder.MapperBuilderAssistant;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
 /** Additional contract tests kept separate from mapper-focused repository tests. */
 class InterviewReportRepositoryContractTest {
+
+	@BeforeAll
+	static void initializeMybatisMetadata() {
+		TableInfoHelper.initTableInfo(
+				new MapperBuilderAssistant(
+						new MybatisConfiguration(),
+						"interview-report-repository-contract-test"),
+				InterviewReportEntity.class);
+	}
 
 	@Test
 	void findByIdHandlesBlankMissingAndNullablePersistedFields() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/MybatisInterviewReportRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/MybatisInterviewReportRepositoryTest.java
@@ -2,6 +2,7 @@ package com.unispeaking.infrastructure.persistence.repository.evaluation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -11,6 +12,8 @@ import static org.mockito.Mockito.when;
 
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.InterviewErrorCode;
 import com.unispeaking.domain.po.evaluation.InterviewReportRecord;
 import com.unispeaking.domain.vo.evaluation.ReportStatus;
 import com.unispeaking.infrastructure.persistence.entity.evaluation.InterviewReportEntity;
@@ -19,6 +22,7 @@ import java.math.BigDecimal;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.UUID;
+import java.lang.reflect.Method;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -73,6 +77,20 @@ class MybatisInterviewReportRepositoryTest {
 	}
 
 	@Test
+	void translatesCreateFailuresAndInvalidUserIds() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.insert(any(InterviewReportEntity.class)))
+				.thenThrow(new IllegalStateException("db down"));
+
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.createIfAbsent("session-1", "interview-1", USER_ID));
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED, failure.code());
+		assertThrows(IllegalArgumentException.class,
+				() -> repository.createIfAbsent("session-1", "interview-1", "not-a-uuid"));
+	}
+
+	@Test
 	void findByIdConvertsEntityToRecord() {
 		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
 		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
@@ -86,6 +104,47 @@ class MybatisInterviewReportRepositoryTest {
 		assertEquals(new BigDecimal("82.0"), record.fluencyScore());
 		assertEquals("流利", record.fluencyEvaluation());
 		assertTrue(repository.findById("missing").isEmpty());
+	}
+
+	@Test
+	void mapsAllPersistedReportFieldsAndNullableDefaults() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		InterviewReportEntity source = entity();
+		source.setUserId(null);
+		source.setStatus(null);
+		source.setRetryCount(null);
+		source.setPronunciationIntelligibilityScore(new BigDecimal("80.0"));
+		source.setPronunciationIntelligibilityEvaluation("清晰");
+		source.setPronunciationIntelligibilityAdvice("保持语速");
+		source.setLogicCoherenceScore(new BigDecimal("81.0"));
+		source.setLogicCoherenceEvaluation("连贯");
+		source.setLogicCoherenceAdvice("加强衔接");
+		source.setGrammarControlScore(new BigDecimal("79.0"));
+		source.setGrammarControlEvaluation("准确");
+		source.setGrammarControlAdvice("检查时态");
+		source.setVocabularyExpressionScore(new BigDecimal("83.0"));
+		source.setVocabularyExpressionEvaluation("丰富");
+		source.setVocabularyExpressionAdvice("扩展表达");
+		when(mapper.selectById("session-1")).thenReturn(source);
+
+		InterviewReportRecord mapped = repository.findById("session-1").orElseThrow();
+
+		assertEquals(null, mapped.userId());
+		assertEquals(null, mapped.status());
+		assertEquals(0, mapped.retryCount());
+		assertEquals(new BigDecimal("80.0"), mapped.pronunciationIntelligibilityScore());
+		assertEquals("清晰", mapped.pronunciationIntelligibilityEvaluation());
+		assertEquals("保持语速", mapped.pronunciationIntelligibilityAdvice());
+		assertEquals(new BigDecimal("81.0"), mapped.logicCoherenceScore());
+		assertEquals("连贯", mapped.logicCoherenceEvaluation());
+		assertEquals("加强衔接", mapped.logicCoherenceAdvice());
+		assertEquals(new BigDecimal("79.0"), mapped.grammarControlScore());
+		assertEquals("准确", mapped.grammarControlEvaluation());
+		assertEquals("检查时态", mapped.grammarControlAdvice());
+		assertEquals(new BigDecimal("83.0"), mapped.vocabularyExpressionScore());
+		assertEquals("丰富", mapped.vocabularyExpressionEvaluation());
+		assertEquals("扩展表达", mapped.vocabularyExpressionAdvice());
 	}
 
 	@Test
@@ -138,11 +197,118 @@ class MybatisInterviewReportRepositoryTest {
 		verify(mapper, never()).selectList(any());
 	}
 
+	@Test
+	void rejectsIncompleteIdentifiersBeforeAccessingTheMapper() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.createIfAbsent(" ", "scene-1", USER_ID));
+		assertEquals(InterviewErrorCode.INTERVIEW_REQUEST_INVALID, failure.code());
+		assertThrows(BusinessException.class,
+				() -> repository.createIfAbsent("session-1", null, USER_ID));
+		assertThrows(BusinessException.class,
+				() -> repository.createIfAbsent("session-1", "scene-1", ""));
+		verify(mapper, never()).insert(any(InterviewReportEntity.class));
+	}
+
+	@Test
+	void writesCompletedFailedAndManualRetryTransitions() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		when(mapper.update(any(), any())).thenReturn(1);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+
+		repository.markCompleted(record());
+		repository.markFailed("session-1", "PROVIDER_RETRYABLE");
+		assertTrue(repository.casFailedToProcessing("session-1"));
+		verify(mapper, org.mockito.Mockito.times(3)).update(any(), any());
+	}
+
+	@Test
+	void toleratesCompletedUpdateThatLostItsProcessingRace() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		when(mapper.update(any(), any())).thenReturn(0);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+
+		repository.markCompleted(record());
+		verify(mapper).update(any(), any());
+	}
+
+	@Test
+	void translatesMapperReadAndWriteFailures() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.update(any(), any())).thenThrow(new IllegalStateException("db down"));
+
+		BusinessException writeFailure = assertThrows(BusinessException.class,
+				() -> repository.markFailed("session-1", "FAILED"));
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED,
+				writeFailure.code());
+
+		when(mapper.selectList(any())).thenThrow(new IllegalStateException("read failed"));
+		BusinessException readFailure = assertThrows(BusinessException.class,
+				() -> repository.findStuckProcessingBefore(OffsetDateTime.now()));
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED,
+				readFailure.code());
+	}
+
+	@Test
+	void translatesCreateAndFindBySceneWriteFailures() {
+		InterviewReportMapper mapper = mock(InterviewReportMapper.class);
+		InterviewReportRepository repository = new MybatisInterviewReportRepository(mapper);
+		when(mapper.selectList(any())).thenThrow(new IllegalStateException("read failed"));
+
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.findBySceneId("interview-1"));
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED, failure.code());
+
+		when(mapper.insert(any(InterviewReportEntity.class)))
+				.thenThrow(new IllegalStateException("insert failed"));
+		failure = assertThrows(BusinessException.class,
+				() -> repository.createIfAbsent("session-1", "interview-1", USER_ID));
+		assertEquals(InterviewErrorCode.INTERVIEW_REPORT_PERSISTENCE_FAILED, failure.code());
+	}
+
+	@Test
+	void convertsACompleteRecordToPersistenceEntity() throws Exception {
+		MybatisInterviewReportRepository repository =
+				new MybatisInterviewReportRepository(mock(InterviewReportMapper.class));
+		Method method = MybatisInterviewReportRepository.class
+				.getDeclaredMethod("toEntity", InterviewReportRecord.class);
+		method.setAccessible(true);
+		InterviewReportRecord source = record();
+		InterviewReportEntity entity = (InterviewReportEntity) method.invoke(repository, source);
+		assertEquals("session-1", entity.getSessionId());
+		assertEquals("interview_1", entity.getSceneId());
+		assertEquals(UUID.fromString(USER_ID), entity.getUserId());
+		assertEquals(ReportStatus.COMPLETED.name(), entity.getStatus());
+		assertEquals(new BigDecimal("85.0"), entity.getOverallScore());
+		assertEquals(new BigDecimal("82.0"), entity.getFluencyScore());
+		assertEquals("流利", entity.getFluencyEvaluation());
+		assertEquals("保持节奏", entity.getFluencyAdvice());
+		assertEquals(new BigDecimal("80.0"), entity.getPronunciationIntelligibilityScore());
+		assertEquals("清晰", entity.getPronunciationIntelligibilityEvaluation());
+		assertEquals("继续练习", entity.getPronunciationIntelligibilityAdvice());
+		assertEquals(new BigDecimal("81.0"), entity.getLogicCoherenceScore());
+		assertEquals("连贯", entity.getLogicCoherenceEvaluation());
+		assertEquals("组织结构", entity.getLogicCoherenceAdvice());
+		assertEquals(new BigDecimal("79.0"), entity.getGrammarControlScore());
+		assertEquals("准确", entity.getGrammarControlEvaluation());
+		assertEquals("检查时态", entity.getGrammarControlAdvice());
+		assertEquals(new BigDecimal("83.0"), entity.getVocabularyExpressionScore());
+		assertEquals("丰富", entity.getVocabularyExpressionEvaluation());
+		assertEquals("扩展表达", entity.getVocabularyExpressionAdvice());
+		assertEquals(0, entity.getRetryCount());
+		assertEquals(null, entity.getFailureReason());
+		assertEquals(source.createdAt(), entity.getCreatedAt());
+		assertEquals(source.updatedAt(), entity.getUpdatedAt());
+	}
+
 	private InterviewReportEntity entity() {
 		InterviewReportEntity entity = new InterviewReportEntity();
 		entity.setSessionId("session-1");
 		entity.setSceneId("interview_1");
-		entity.setUserId(UUID.fromString("11111111-1111-4111-8111-111111111111"));
+		entity.setUserId(UUID.fromString(USER_ID));
 		entity.setStatus(ReportStatus.COMPLETED.name());
 		entity.setOverallScore(new BigDecimal("85.0"));
 		entity.setSummary("整体表现良好。");
@@ -154,4 +320,19 @@ class MybatisInterviewReportRepositoryTest {
 		entity.setUpdatedAt(OffsetDateTime.now());
 		return entity;
 	}
+
+	private InterviewReportRecord record() {
+		OffsetDateTime now = OffsetDateTime.now();
+		return new InterviewReportRecord(
+				"session-1", "interview_1", USER_ID, ReportStatus.COMPLETED,
+				new BigDecimal("85.0"), "整体表现良好。",
+				new BigDecimal("82.0"), "流利", "保持节奏",
+				new BigDecimal("80.0"), "清晰", "继续练习",
+				new BigDecimal("81.0"), "连贯", "组织结构",
+				new BigDecimal("79.0"), "准确", "检查时态",
+				new BigDecimal("83.0"), "丰富", "扩展表达",
+				0, null, now, now);
+	}
+
+	private static final String USER_ID = "11111111-1111-4111-8111-111111111111";
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/IeltsPracticeRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/IeltsPracticeRepositoryTest.java
@@ -1,6 +1,8 @@
 package com.unispeaking.infrastructure.persistence.repository.scene;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.isNull;
@@ -11,7 +13,10 @@ import static org.mockito.Mockito.when;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.po.scene.IeltsPracticeRecord;
+import com.unispeaking.domain.po.scene.IeltsTopicPracticeSummary;
+import com.unispeaking.domain.po.scene.IeltsUserSettings;
 import com.unispeaking.domain.vo.scene.IeltsContent;
 import com.unispeaking.domain.vo.scene.IeltsContentQuestion;
 import com.unispeaking.domain.vo.scene.IeltsMode;
@@ -19,10 +24,14 @@ import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.domain.vo.scene.RecommendedExpression;
 import com.unispeaking.infrastructure.persistence.entity.scene.IeltsPracticeEntity;
 import com.unispeaking.infrastructure.persistence.entity.scene.UserIeltsEntity;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.IeltsPartEvaluationEntity;
 import com.unispeaking.infrastructure.persistence.mapper.scene.IeltsPracticeMapper;
 import com.unispeaking.infrastructure.persistence.mapper.scene.UserIeltsMapper;
 import java.util.List;
+import java.util.Map;
+import java.math.BigDecimal;
 import java.util.UUID;
+import java.time.LocalDate;
 import org.apache.ibatis.builder.MapperBuilderAssistant;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -38,6 +47,7 @@ class IeltsPracticeRepositoryTest {
 				"ielts-practice-repository-test");
 		TableInfoHelper.initTableInfo(assistant, IeltsPracticeEntity.class);
 		TableInfoHelper.initTableInfo(assistant, UserIeltsEntity.class);
+		TableInfoHelper.initTableInfo(assistant, IeltsPartEvaluationEntity.class);
 	}
 
 	private final IeltsPracticeMapper practiceMapper =
@@ -110,5 +120,364 @@ class IeltsPracticeRepositoryTest {
 		assertEquals(3, repository.resetCompletedCounts());
 
 		verify(userIeltsMapper).update(isNull(), any(Wrapper.class));
+	}
+
+	@Test
+	void returnsExistingSettingsAndCreatesMissingSettings() {
+		UUID userId = UUID.randomUUID();
+		UserIeltsEntity existing = settingsEntity(userId, 2);
+		existing.setTargetScore(new BigDecimal("7.0"));
+		existing.setPreferredVoice("Daniel");
+		when(userIeltsMapper.selectById(userId)).thenReturn(existing);
+
+		IeltsUserSettings found = repository.getOrCreateSettings(userId);
+
+		assertEquals(new BigDecimal("7.0"), found.targetScore());
+		assertEquals(2, found.todayCompletedCount());
+		verify(userIeltsMapper, org.mockito.Mockito.never()).insert(any(UserIeltsEntity.class));
+
+		UUID missingId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(missingId)).thenReturn(null);
+		when(userIeltsMapper.insert(any(UserIeltsEntity.class))).thenReturn(1);
+		IeltsUserSettings created = repository.getOrCreateSettings(missingId);
+		assertEquals(missingId, created.userId());
+		assertEquals(0, created.todayCompletedCount());
+		verify(userIeltsMapper).insert(any(UserIeltsEntity.class));
+	}
+
+	@Test
+	void recoversConcurrentSettingsCreationAndWrapsFailures() {
+		UUID concurrentId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(concurrentId))
+				.thenReturn(null, settingsEntity(concurrentId, 1));
+		when(userIeltsMapper.insert(any(UserIeltsEntity.class))).thenThrow(new RuntimeException("duplicate"));
+		assertEquals(1, repository.getOrCreateSettings(concurrentId).todayCompletedCount());
+
+		UUID failedId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(failedId)).thenReturn(null);
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.getOrCreateSettings(failedId));
+		assertEquals("IELTS_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void findPracticeHandlesBlankMissingAndStoredRecords() {
+		assertFalse(repository.findPractice(" ").isPresent());
+		when(practiceMapper.selectById("missing")).thenReturn(null);
+		assertFalse(repository.findPractice("missing").isPresent());
+
+		UUID userId = UUID.randomUUID();
+		IeltsPracticeEntity entity = new IeltsPracticeEntity();
+		entity.setIeltsId("stored");
+		entity.setUserId(userId);
+		entity.setMode("PART_PRACTICE");
+		entity.setSelectedPart("PART_2");
+		entity.setSelectedTopicId("topic");
+		entity.setTopicSelectionMethod("RANDOM");
+		entity.setPart2TopicId("topic");
+		entity.setContent("{\"part1\":[],\"part2\":[],\"part3\":[]}");
+		when(practiceMapper.selectById("stored")).thenReturn(entity);
+
+		var found = repository.findPractice("stored").orElseThrow();
+		assertEquals(IeltsPart.PART_2, found.selectedPart());
+		assertEquals("RANDOM", found.topicSelectionMethod());
+		assertEquals("topic", found.part2TopicId());
+	}
+
+	@Test
+	void createAndUpdateWrapPersistenceFailures() {
+		when(practiceMapper.insert(any(IeltsPracticeEntity.class))).thenReturn(0);
+		BusinessException createFailure = assertThrows(BusinessException.class,
+				() -> repository.createPractice(new IeltsPracticeRecord("failure", UUID.randomUUID(),
+						IeltsMode.PART_PRACTICE, IeltsPart.PART_1, "topic", content())));
+		assertEquals("IELTS_PERSISTENCE_FAILED", createFailure.code());
+
+		UUID userId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(userId)).thenReturn(settingsEntity(userId, 0));
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(0);
+		BusinessException updateFailure = assertThrows(BusinessException.class,
+				() -> repository.updateSettings(userId, new BigDecimal("6.5"), "Daniel"));
+		assertEquals("IELTS_PERSISTENCE_FAILED", updateFailure.code());
+	}
+
+	@Test
+	void incrementRejectsLimitsMissingSettingsAndRepeatedConflicts() {
+		UUID limitedId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(limitedId)).thenReturn(settingsEntity(limitedId, 5));
+		BusinessException limit = assertThrows(BusinessException.class,
+				() -> repository.incrementCompletedCount(limitedId));
+		assertEquals("IELTS_DAILY_LIMIT_REACHED", limit.code());
+
+		UUID missingId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(missingId)).thenReturn(null);
+		BusinessException missing = assertThrows(BusinessException.class,
+				() -> repository.incrementCompletedCount(missingId));
+		assertEquals("IELTS_PERSISTENCE_FAILED", missing.code());
+
+		UUID contestedId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(contestedId)).thenReturn(settingsEntity(contestedId, 0));
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(0);
+		BusinessException contested = assertThrows(BusinessException.class,
+				() -> repository.incrementCompletedCount(contestedId));
+		assertEquals("IELTS_PERSISTENCE_FAILED", contested.code());
+	}
+
+	@Test
+	void createsAndUpdatesSettingsWithAllOptionalFields() {
+		UUID userId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(userId)).thenReturn(
+				settingsEntity(userId, 1), settingsEntity(userId, 1));
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(1);
+
+		IeltsUserSettings result = repository.updateSettings(
+				userId, new BigDecimal("7.5"), "Harvey");
+
+		assertEquals(userId, result.userId());
+		verify(userIeltsMapper).update(isNull(), any(Wrapper.class));
+	}
+
+	@Test
+	void findPracticeWrapsMalformedStoredJsonAsPersistenceFailure() {
+		IeltsPracticeEntity entity = new IeltsPracticeEntity();
+		entity.setIeltsId("broken");
+		entity.setUserId(UUID.randomUUID());
+		entity.setMode("PART_PRACTICE");
+		entity.setSelectedPart("PART_1");
+		entity.setTopicSelectionMethod("USER_SELECTED");
+		entity.setContent("not-json");
+		when(practiceMapper.selectById("broken")).thenReturn(entity);
+
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.findPractice("broken"));
+
+		assertEquals("IELTS_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void topicPracticeSummariesSkipEmptyTopicsAndAggregateLatestEvaluation() {
+		UUID userId = UUID.randomUUID();
+		assertEquals(Map.of(), repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_1, List.of()));
+
+		IeltsPracticeEntity latest = practiceEntity("latest", "topic-1", "PART_PRACTICE", "RANDOM");
+		IeltsPracticeEntity selected = practiceEntity("selected", "topic-1", "PART_PRACTICE", "USER_SELECTED");
+		IeltsPracticeEntity mock = practiceEntity("mock", "topic-1", "MOCK_TEST", "RANDOM");
+		when(practiceMapper.selectList(any())).thenReturn(List.of(latest, selected, mock));
+		IeltsPartEvaluationEntity evaluation = new IeltsPartEvaluationEntity();
+		evaluation.setIeltsId("latest");
+		evaluation.setFluencyCoherenceScore(new BigDecimal("6.0"));
+		evaluation.setLexicalResourceScore(new BigDecimal("7.0"));
+		evaluation.setSummary("latest summary");
+		evaluation.setCompletedAt(java.time.OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+		IeltsPartEvaluationEntity selectedEvaluation = new IeltsPartEvaluationEntity();
+		selectedEvaluation.setIeltsId("selected");
+		IeltsPartEvaluationEntity mockEvaluation = new IeltsPartEvaluationEntity();
+		mockEvaluation.setIeltsId("mock");
+		when(partEvaluationMapper.selectList(any())).thenReturn(List.of(
+				evaluation, selectedEvaluation, mockEvaluation));
+
+		Map<String, IeltsTopicPracticeSummary> summaries = repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_1, List.of("topic-1"));
+
+		IeltsTopicPracticeSummary summary = summaries.get("topic-1");
+		assertEquals(3, summary.practiceCount());
+		assertEquals(1, summary.mockTestCount());
+		assertEquals(1, summary.randomPartPracticeCount());
+		assertEquals(1, summary.selectedPartPracticeCount());
+		assertEquals(new BigDecimal("6.5"), summary.latestPerformanceScore());
+		assertEquals("RANDOM_PART_PRACTICE", summary.latestPracticeType());
+	}
+
+	@Test
+	void topicPracticeSummariesSupportPartTwoAndPartThreeAndIgnoreUnscoredPractices() {
+		UUID userId = UUID.randomUUID();
+		IeltsPracticeEntity partTwo = practiceEntity("part-two", "topic-2", "PART_PRACTICE", "USER_SELECTED");
+		partTwo.setPart1TopicId(null);
+		partTwo.setPart2TopicId("topic-2");
+		IeltsPracticeEntity partThree = practiceEntity("part-three", "topic-3", "MOCK_TEST", "RANDOM");
+		partThree.setPart1TopicId(null);
+		partThree.setPart2TopicId(null);
+		partThree.setPart3TopicId("topic-3");
+		when(practiceMapper.selectList(any())).thenReturn(List.of(partTwo), List.of(partThree), List.of());
+		when(partEvaluationMapper.selectList(any())).thenReturn(
+				List.of(evaluation("part-two", "summary-2")),
+				List.of(evaluation("part-three", "summary-3")));
+
+		Map<String, IeltsTopicPracticeSummary> partTwoResult = repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_2, List.of("topic-2"));
+		assertEquals("SELECTED_PART_PRACTICE", partTwoResult.get("topic-2").latestPracticeType());
+
+		Map<String, IeltsTopicPracticeSummary> partThreeResult = repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_3, List.of("topic-3"));
+		assertEquals("MOCK_TEST", partThreeResult.get("topic-3").latestPracticeType());
+
+		when(practiceMapper.selectList(any())).thenReturn(List.of());
+		assertEquals(Map.of(), repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_3, List.of("topic-3")));
+	}
+
+	@Test
+	void topicPracticeSummariesReturnNullAverageWhenAllScoresAreMissing() {
+		UUID userId = UUID.randomUUID();
+		when(practiceMapper.selectList(any())).thenReturn(List.of(
+				practiceEntity("no-score", "topic", "PART_PRACTICE", "USER_SELECTED")));
+		IeltsPartEvaluationEntity evaluation = evaluation("no-score", "no score");
+		when(partEvaluationMapper.selectList(any())).thenReturn(List.of(evaluation));
+
+		var summary = repository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_1, List.of("topic")).get("topic");
+
+		assertEquals(null, summary.latestPerformanceScore());
+		assertEquals("no score", summary.latestPerformanceSummary());
+	}
+
+	@Test
+	void updateSettingsAllowsPartialUpdatesAndWrapsMapperExceptions() {
+		UUID userId = UUID.randomUUID();
+		UserIeltsEntity current = settingsEntity(userId, 1);
+		current.setPreferredVoice("Daniel");
+		when(userIeltsMapper.selectById(userId)).thenReturn(current);
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(1);
+		when(userIeltsMapper.selectById(userId)).thenReturn(current);
+
+		var unchanged = repository.updateSettings(userId, null, " ");
+		assertEquals("Daniel", unchanged.preferredVoice());
+
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class)))
+				.thenThrow(new IllegalStateException("db down"));
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.updateSettings(userId, new BigDecimal("7.0"), "Harvey"));
+		assertEquals("IELTS_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void incrementCompletedCountHandlesNullCountersAndConsecutiveCheckIn() {
+		UUID userId = UUID.randomUUID();
+		UserIeltsEntity current = settingsEntity(userId, 0);
+		current.setTodayCompletedCount(null);
+		current.setCurrentStreakDays(null);
+		current.setTotalCheckInDays(null);
+		current.setLastCheckInDate(LocalDate.now(java.time.ZoneId.of("Asia/Shanghai")).minusDays(1));
+		when(userIeltsMapper.selectById(userId)).thenReturn(current);
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(1);
+
+		repository.incrementCompletedCount(userId);
+
+		verify(userIeltsMapper).update(isNull(), any(Wrapper.class));
+	}
+
+	@Test
+	void incrementWrapsMapperFailureAndResetWrapsMapperFailure() {
+		UUID userId = UUID.randomUUID();
+		when(userIeltsMapper.selectById(userId)).thenThrow(new IllegalStateException("db down"));
+		BusinessException incrementFailure = assertThrows(BusinessException.class,
+				() -> repository.incrementCompletedCount(userId));
+		assertEquals("IELTS_PERSISTENCE_FAILED", incrementFailure.code());
+
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class)))
+				.thenThrow(new IllegalStateException("db down"));
+		BusinessException resetFailure = assertThrows(BusinessException.class,
+				() -> repository.resetCompletedCounts());
+		assertEquals("IELTS_PERSISTENCE_FAILED", resetFailure.code());
+	}
+
+	@Test
+	void createPracticeMapsNullSelectedPartAndWrapsSerializationFailure() {
+		when(practiceMapper.insert(any(IeltsPracticeEntity.class))).thenReturn(1);
+		repository.createPractice(new IeltsPracticeRecord(
+				"mock", UUID.randomUUID(), IeltsMode.MOCK_TEST, null, null,
+				"RANDOM", null, "topic", "topic", content()));
+		ArgumentCaptor<IeltsPracticeEntity> entity = ArgumentCaptor.forClass(IeltsPracticeEntity.class);
+		verify(practiceMapper).insert(entity.capture());
+		assertEquals(null, entity.getValue().getSelectedPart());
+
+		ObjectMapper brokenMapper = mock(ObjectMapper.class);
+		when(brokenMapper.writeValueAsString(any())).thenThrow(
+				new tools.jackson.core.JacksonException("cannot serialize") { });
+		IeltsPracticeRepository brokenRepository = new IeltsPracticeRepository(
+				practiceMapper, userIeltsMapper, partEvaluationMapper, brokenMapper);
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> brokenRepository.createPractice(new IeltsPracticeRecord(
+						"broken", UUID.randomUUID(), IeltsMode.PART_PRACTICE, IeltsPart.PART_1,
+						"topic", "USER_SELECTED", "topic", null, null, content())));
+		assertEquals("IELTS_CONTENT_INVALID", failure.code());
+	}
+
+	@Test
+	void readsRecordsWithNullSelectedPartAndWrapsInvalidEnum() throws Exception {
+		IeltsPracticeEntity entity = new IeltsPracticeEntity();
+		entity.setIeltsId("mock-record");
+		entity.setUserId(UUID.randomUUID());
+		entity.setMode("MOCK_TEST");
+		entity.setSelectedPart(null);
+		entity.setTopicSelectionMethod("RANDOM");
+		entity.setContent(new ObjectMapper().writeValueAsString(content()));
+		when(practiceMapper.selectById("mock-record")).thenReturn(entity);
+		assertTrue(repository.findPractice("mock-record").orElseThrow().selectedPart() == null);
+
+		entity.setMode("INVALID");
+		BusinessException failure = assertThrows(BusinessException.class,
+				() -> repository.findPractice("mock-record"));
+		assertEquals("IELTS_PERSISTENCE_FAILED", failure.code());
+	}
+
+	@Test
+	void handlesSameDayCompletionAndRetriesOptimisticConflicts() {
+		UUID userId = UUID.randomUUID();
+		UserIeltsEntity current = settingsEntity(userId, 1);
+		current.setLastCheckInDate(LocalDate.now(java.time.ZoneId.of("Asia/Shanghai")));
+		current.setCurrentStreakDays(3);
+		current.setTotalCheckInDays(7);
+		when(userIeltsMapper.selectById(userId)).thenReturn(current);
+		when(userIeltsMapper.update(isNull(), any(Wrapper.class))).thenReturn(0, 1);
+		repository.incrementCompletedCount(userId);
+		verify(userIeltsMapper, org.mockito.Mockito.times(2)).update(isNull(), any(Wrapper.class));
+	}
+
+	@Test
+	void convertsNullCountersInSettingsToZero() {
+		UUID userId = UUID.randomUUID();
+		UserIeltsEntity entity = new UserIeltsEntity();
+		entity.setUserId(userId);
+		when(userIeltsMapper.selectById(userId)).thenReturn(entity);
+		IeltsUserSettings settings = repository.getOrCreateSettings(userId);
+		assertEquals(0, settings.todayCompletedCount());
+		assertEquals(0, settings.currentStreakDays());
+		assertEquals(0, settings.totalCheckInDays());
+	}
+
+	private UserIeltsEntity settingsEntity(UUID userId, int completed) {
+		UserIeltsEntity entity = new UserIeltsEntity();
+		entity.setUserId(userId);
+		entity.setTodayCompletedCount(completed);
+		return entity;
+	}
+
+	private IeltsContent content() {
+		return new IeltsContent(List.of(), List.of(), List.of());
+	}
+
+	private IeltsPracticeEntity practiceEntity(
+			String ieltsId,
+			String topicId,
+			String mode,
+			String selectionMethod) {
+		IeltsPracticeEntity entity = new IeltsPracticeEntity();
+		entity.setIeltsId(ieltsId);
+		entity.setUserId(UUID.randomUUID());
+		entity.setMode(mode);
+		entity.setTopicSelectionMethod(selectionMethod);
+		entity.setPart1TopicId(topicId);
+		entity.setCreatedAt(java.time.OffsetDateTime.parse("2026-08-01T00:00:00Z"));
+		return entity;
+	}
+
+	private IeltsPartEvaluationEntity evaluation(String ieltsId, String summary) {
+		IeltsPartEvaluationEntity evaluation = new IeltsPartEvaluationEntity();
+		evaluation.setIeltsId(ieltsId);
+		evaluation.setEvaluationStatus("COMPLETED");
+		evaluation.setSummary(summary);
+		evaluation.setCompletedAt(java.time.OffsetDateTime.parse("2026-08-02T00:00:00Z"));
+		return evaluation;
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisInterviewSceneRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/scene/MybatisInterviewSceneRepositoryTest.java
@@ -2,6 +2,7 @@ package com.unispeaking.infrastructure.persistence.repository.scene;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.when;
 import com.baomidou.mybatisplus.core.MybatisConfiguration;
 import com.baomidou.mybatisplus.core.metadata.TableInfoHelper;
 import com.unispeaking.domain.po.scene.InterviewSceneDefinition;
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.vo.scene.InterviewDifficulty;
 import com.unispeaking.infrastructure.persistence.entity.scene.InterviewSceneEntity;
 import com.unispeaking.infrastructure.persistence.mapper.scene.InterviewSceneMapper;
@@ -112,6 +114,49 @@ class MybatisInterviewSceneRepositoryTest {
 		assertTrue(repository.findOwnedById(
 				"interview_active",
 				"not-a-uuid").isEmpty());
+	}
+
+	@Test
+	void softDeleteValidatesOwnerAndReturnsUpdateResult() {
+		InterviewSceneMapper mapper = mock(InterviewSceneMapper.class);
+		InterviewSceneRepository repository = new MybatisInterviewSceneRepository(mapper);
+		when(mapper.update(any(), any())).thenReturn(1, 0);
+
+		assertTrue(repository.softDelete(
+				"interview_active", "11111111-1111-4111-8111-111111111111"));
+		assertTrue(!repository.softDelete(
+				"interview_active", "11111111-1111-4111-8111-111111111111"));
+		assertTrue(!repository.softDelete("interview_active", "not-a-uuid"));
+	}
+
+	@Test
+	void wrapsSaveAndDeleteMapperFailures() {
+		InterviewSceneMapper mapper = mock(InterviewSceneMapper.class);
+		InterviewSceneRepository repository = new MybatisInterviewSceneRepository(mapper);
+		when(mapper.insert((InterviewSceneEntity) any()))
+				.thenThrow(new IllegalStateException("db down"));
+		BusinessException saveFailure = assertThrows(BusinessException.class,
+				() -> repository.save(definition()));
+		assertEquals("INTERVIEW_SCENE_PERSISTENCE_FAILED", saveFailure.code());
+
+		when(mapper.update(any(), any())).thenThrow(new IllegalStateException("db down"));
+		BusinessException deleteFailure = assertThrows(BusinessException.class,
+				() -> repository.softDelete(
+						"interview_active", "11111111-1111-4111-8111-111111111111"));
+		assertEquals("INTERVIEW_SCENE_PERSISTENCE_FAILED", deleteFailure.code());
+	}
+
+	@Test
+	void mapsNullableDifficultyAndReturnsEmptyWhenOwnedSceneIsMissing() {
+		InterviewSceneMapper mapper = mock(InterviewSceneMapper.class);
+		InterviewSceneRepository repository = new MybatisInterviewSceneRepository(mapper);
+		InterviewSceneEntity entity = entity();
+		entity.setDifficulty(null);
+		when(mapper.selectOne(any())).thenReturn(null);
+		assertTrue(repository.findOwnedById(
+				"interview_active", "11111111-1111-4111-8111-111111111111").isEmpty());
+		when(mapper.selectById("nullable")).thenReturn(entity);
+		assertTrue(repository.findById("nullable").orElseThrow().difficulty() == null);
 	}
 
 	private InterviewSceneDefinition definition() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/session/PracticeSessionRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/session/PracticeSessionRepositoryTest.java
@@ -373,6 +373,64 @@ class PracticeSessionRepositoryTest {
 								LocalDate.now())).code());
 	}
 
+	@Test
+	void findsBySessionAndSceneWithBlankAndMissingInputsHandled() {
+		PracticeSessionMapper mapper = mock(PracticeSessionMapper.class);
+		PracticeSessionRepository repository = new PracticeSessionRepository(mapper);
+		assertTrue(repository.findBySessionId(null).isEmpty());
+		assertTrue(repository.findBySessionId(" ").isEmpty());
+
+		when(mapper.selectOne(any(Wrapper.class))).thenReturn(null);
+		assertTrue(repository.findBySessionId("missing").isEmpty());
+		PracticeSessionEntity entity = completedEntity();
+		when(mapper.selectOne(any(Wrapper.class))).thenReturn(entity);
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(entity));
+
+		assertEquals("freechat_session_1",
+				repository.findBySessionId("session").orElseThrow().sessionId());
+		assertEquals(List.of("freechat_session_1"), repository.findBySceneId(entity.getSceneId())
+				.stream().map(PracticeSessionRecord::sessionId).toList());
+	}
+
+	@Test
+	void queriesCompletedSessionsByUserAndSceneTypeAndWrapsFailures() {
+		PracticeSessionMapper mapper = mock(PracticeSessionMapper.class);
+		PracticeSessionRepository repository = new PracticeSessionRepository(mapper);
+		PracticeSessionEntity entity = completedEntity();
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(entity));
+
+		assertEquals(List.of(entity.getSessionId()),
+				repository.findCompletedByUserAndSceneType(entity.getUserId(), SceneType.FREE_CHAT)
+						.stream().map(PracticeSessionRecord::sessionId).toList());
+		when(mapper.selectOne(any(Wrapper.class))).thenThrow(new IllegalStateException("read"));
+		assertEquals("PRACTICE_SESSION_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.findBySessionId("broken")).code());
+		when(mapper.selectList(any(Wrapper.class))).thenThrow(new IllegalStateException("read"));
+		assertEquals("PRACTICE_SESSION_PERSISTENCE_FAILED", assertThrows(BusinessException.class,
+				() -> repository.findBySceneId("broken")).code());
+	}
+
+	@Test
+	void validatesProviderBindingAndNormalizesRealtimeMetadata() {
+		PracticeSessionMapper mapper = mock(PracticeSessionMapper.class);
+		PracticeSessionRepository repository = new PracticeSessionRepository(mapper);
+		UUID userId = UUID.randomUUID();
+		assertEquals("PROVIDER_SESSION_ID_REQUIRED", assertThrows(BusinessException.class,
+				() -> repository.bindProviderSession("session", userId, " ")).code());
+		assertEquals("REALTIME_PROVIDER_METADATA_REQUIRED", assertThrows(BusinessException.class,
+				() -> repository.updateRealtimeProvider("session", userId, "id", null, "model", null)).code());
+		assertEquals("REALTIME_PROVIDER_METADATA_REQUIRED", assertThrows(BusinessException.class,
+				() -> repository.updateRealtimeProvider("session", userId, "id", ProviderType.QINIU, " ", null)).code());
+
+		when(mapper.update(isNull(), any(LambdaUpdateWrapper.class))).thenReturn(1);
+		repository.updateRealtimeProvider("session", userId, " ", ProviderType.QINIU, " model ", null);
+		@SuppressWarnings("unchecked")
+		ArgumentCaptor<LambdaUpdateWrapper<PracticeSessionEntity>> update = ArgumentCaptor.forClass(LambdaUpdateWrapper.class);
+		verify(mapper).update(isNull(), update.capture());
+		assertTrue(update.getValue().getParamNameValuePairs().values().contains("model"));
+		assertTrue(update.getValue().getParamNameValuePairs().values().contains(null));
+	}
+
 	private PracticeSessionEntity completedEntity() {
 		PracticeSessionEntity entity = new PracticeSessionEntity();
 		entity.setSessionId("freechat_session_1");

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/session/SessionMessageRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/session/SessionMessageRepositoryTest.java
@@ -4,16 +4,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.never;
 
 import com.baomidou.mybatisplus.core.conditions.Wrapper;
 import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.po.session.LearnerMessageRecord;
 import com.unispeaking.infrastructure.persistence.entity.session.SessionMessageEntity;
 import com.unispeaking.infrastructure.persistence.mapper.session.SessionMessageMapper;
 import java.util.List;
+import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -113,6 +117,91 @@ class SessionMessageRepositoryTest {
 	}
 
 	@Test
+	void readsLearnerMessagesAndAudioObjectKeysAndPreservesOnlyNonBlankUrls() {
+		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
+		SessionMessageEntity assistant = new SessionMessageEntity();
+		assistant.setOwner(0);
+		assistant.setContent("question");
+		SessionMessageEntity learner = new SessionMessageEntity();
+		learner.setOwner(1);
+		learner.setContent("answer");
+		learner.setMessageNo(2);
+		learner.setAudioUrl("/audio/answer.wav");
+		learner.setAudioObjectKey("sessions/s1/turn-1.wav");
+		SessionMessageEntity blankUrl = new SessionMessageEntity();
+		blankUrl.setOwner(1);
+		blankUrl.setContent("second answer");
+		blankUrl.setAudioUrl(" ");
+		blankUrl.setAudioObjectKey(null);
+		when(mapper.selectList(any(Wrapper.class)))
+				.thenReturn(List.of(learner, blankUrl))
+				.thenReturn(List.of(learner, blankUrl))
+				.thenReturn(List.of(learner, blankUrl));
+		SessionMessageRepository repository = new SessionMessageRepository(mapper);
+
+		assertEquals(List.of(
+				new Message(1, "answer", null),
+				new Message(1, "second answer", null)),
+				repository.findLearnerMessages("s1"));
+		assertEquals(List.of("/audio/answer.wav"), repository.findAudioUrls("s1"));
+		assertEquals(Arrays.asList("sessions/s1/turn-1.wav", null), repository.findAudioObjectKeys("s1"));
+	}
+
+	@Test
+	void mapsLearnerMessagesWithAudioKeys() {
+		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
+		SessionMessageEntity learner = new SessionMessageEntity();
+		learner.setOwner(1);
+		learner.setMessageNo(4);
+		learner.setContent("answer");
+		learner.setAudioObjectKey("sessions/s1/turn-4.wav");
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(learner));
+		SessionMessageRepository repository = new SessionMessageRepository(mapper);
+
+		assertEquals(List.of(new LearnerMessageRecord(4, "answer", "sessions/s1/turn-4.wav")),
+				repository.findMessagesWithAudioObjectKeys("s1"));
+	}
+
+	@Test
+	void rejectsObjectKeyUpdateWhenNoRowWasChangedOrMapperFails() {
+		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
+		SessionMessageEntity learner = new SessionMessageEntity();
+		learner.setOwner(1);
+		learner.setMessageNo(1);
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(learner));
+		org.mockito.Mockito.doAnswer(invocation -> 0).when(mapper)
+				.update(isNull(SessionMessageEntity.class), any(Wrapper.class));
+		SessionMessageRepository repository = new SessionMessageRepository(mapper);
+
+		assertFailure(() -> repository.attachLearnerAudioObjectKey("s1", 1, "new.wav"));
+
+		org.mockito.Mockito.doThrow(new IllegalStateException("update"))
+				.when(mapper).update(org.mockito.ArgumentMatchers.nullable(SessionMessageEntity.class),
+						any(Wrapper.class));
+		assertFailure(() -> repository.attachLearnerAudioObjectKey("s1", 1, "new.wav"));
+	}
+
+	@Test
+	void translatesAudioUrlUpdateAndAudioKeyReadFailures() {
+		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
+		SessionMessageEntity learner = new SessionMessageEntity();
+		learner.setOwner(1);
+		learner.setMessageNo(1);
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of(learner));
+		when(mapper.update(any(SessionMessageEntity.class), any(Wrapper.class))).thenReturn(0);
+		SessionMessageRepository repository = new SessionMessageRepository(mapper);
+
+		assertFailure(() -> repository.attachLearnerAudioUrl("s1", 1, "audio.wav"));
+
+		when(mapper.selectList(any(Wrapper.class)))
+				.thenThrow(new IllegalStateException("read"));
+		assertFailure(() -> repository.findLearnerMessages("s1"));
+		assertFailure(() -> repository.findAudioUrls("s1"));
+		assertFailure(() -> repository.findAudioObjectKeys("s1"));
+		assertFailure(() -> repository.findMessagesWithAudioObjectKeys("s1"));
+	}
+
+	@Test
 	void translatesWriteReadAndDeleteFailures() {
 		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
 		SessionMessageRepository repository =
@@ -130,6 +219,17 @@ class SessionMessageRepositoryTest {
 				.thenThrow(new IllegalStateException("delete"));
 		assertFailure(() -> repository.deleteObsoleteForScene(
 				"custom_1", "session_1"));
+	}
+
+	@Test
+	void rejectsInvalidAudioAttachmentAndMissingLearnerTurn() {
+		SessionMessageMapper mapper = mock(SessionMessageMapper.class);
+		SessionMessageRepository repository = new SessionMessageRepository(mapper);
+		assertFailure(() -> repository.attachLearnerAudioObjectKey("session", 0, "audio.wav"));
+		assertFailure(() -> repository.attachLearnerAudioUrl("session", 1, " "));
+		when(mapper.selectList(any(Wrapper.class))).thenReturn(List.of());
+		assertFailure(() -> repository.attachLearnerAudioObjectKey("session", 1, "audio.wav"));
+		verify(mapper, never()).update(any(), any(Wrapper.class));
 	}
 
 	private void assertFailure(org.junit.jupiter.api.function.Executable action) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/user/WeeklyLearningGoalRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/user/WeeklyLearningGoalRepositoryTest.java
@@ -125,4 +125,31 @@ class WeeklyLearningGoalRepositoryTest {
 				() -> repository.findByUserId(userId));
 		assertEquals("PROFILE_GOALS_PERSISTENCE_FAILED", failure.code());
 	}
+
+	@Test
+	void readsJsonTargetsAndTranslatesSaveFailures() {
+		UUID userId = UUID.randomUUID();
+		UserPreferenceMapper mapper = mock(UserPreferenceMapper.class);
+		UserPreferenceEntity entity = new UserPreferenceEntity();
+		entity.setPreferences("{\"weekly_duration_target_minutes\":210,\"weekly_training_count_target\":9}");
+		when(mapper.selectById(userId)).thenReturn(entity);
+		var goals = new WeeklyLearningGoalRepository(mapper, objectMapper).findByUserId(userId).orElseThrow();
+		assertEquals(210, goals.durationTargetMinutes());
+		assertEquals(9, goals.trainingCountTarget());
+		entity.setPreferences("[]");
+		assertThrows(BusinessException.class, () -> new WeeklyLearningGoalRepository(mapper, objectMapper).findByUserId(userId));
+
+		when(mapper.selectById(userId)).thenReturn(null);
+		when(mapper.insert(any(UserPreferenceEntity.class))).thenReturn(0);
+		assertThrows(BusinessException.class, () -> new WeeklyLearningGoalRepository(mapper, objectMapper)
+				.save(userId, new WeeklyLearningGoals(1, 1)));
+		when(mapper.insert(any(UserPreferenceEntity.class))).thenThrow(new IllegalStateException("db"));
+		assertThrows(BusinessException.class, () -> new WeeklyLearningGoalRepository(mapper, objectMapper)
+				.save(userId, new WeeklyLearningGoals(1, 1)));
+		when(mapper.selectById(userId)).thenReturn(entity);
+		when(mapper.updateById(any(UserPreferenceEntity.class))).thenReturn(0);
+		entity.setPreferences("{}");
+		assertThrows(BusinessException.class, () -> new WeeklyLearningGoalRepository(mapper, objectMapper)
+				.save(userId, new WeeklyLearningGoals(1, 1)));
+	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/realtime/RealtimeSdpExchangeTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/realtime/RealtimeSdpExchangeTest.java
@@ -1,0 +1,190 @@
+package com.unispeaking.infrastructure.realtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.domain.dto.session.RealtimeConnectCommand;
+import com.unispeaking.domain.dto.session.StartCommand;
+import com.unispeaking.domain.po.session.CustomSceneSession;
+import com.unispeaking.domain.vo.provider.ProviderType;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.RealtimeConnectionResult;
+import com.unispeaking.domain.vo.session.RealtimeCredential;
+import com.unispeaking.domain.vo.session.SessionPrompt;
+import com.unispeaking.provider.AiInvocationContext;
+import com.unispeaking.provider.AiProviderRegistry;
+import com.unispeaking.provider.RealtimeProvider;
+import java.time.Instant;
+import java.util.Set;
+import java.util.function.BiFunction;
+import org.junit.jupiter.api.Test;
+
+class RealtimeSdpExchangeTest {
+
+	@Test
+	void issuesCredentialAndMapsAllConnectionFields() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		RealtimeProvider provider = new CredentialProvider();
+		RealtimeCredential credential = new RealtimeCredential(
+				"temporary-token", Instant.parse("2026-08-21T00:00:00Z"));
+		when(issuer.issue(ProviderType.QWEN)).thenReturn(credential);
+		RealtimeConnectionResult expected = new RealtimeConnectionResult(
+				"provider-session", ProviderType.QWEN, "model-1", "Tina", "trace-1",
+				"answer-sdp", credential.expiresAt());
+		whenExchangeInvokesOperation(registry, ProviderType.QWEN, "model-1", provider, expected);
+
+		CustomSceneSession session = new CustomSceneSession("session-1", "user-1");
+		StartCommand command = new StartCommand(
+				SceneType.CUSTOM_SCENE, "user-1", "scene-1", "offer-sdp", "topic",
+				ProviderType.QWEN, "model-1", "Tina", true);
+		RealtimeConnectionResult result = new RealtimeSdpExchange(registry, issuer)
+				.exchangeSdp(ProviderType.QWEN, session, new SessionPrompt("prompt"), command);
+
+		assertEquals(expected, result);
+		verify(issuer).issue(ProviderType.QWEN);
+	}
+
+	@Test
+	void skipsCredentialIssuerForProviderWithServerSideCredential() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		RealtimeProvider provider = new ServerCredentialProvider();
+		RealtimeConnectionResult expected = new RealtimeConnectionResult(
+				"provider-session", ProviderType.QINIU, "model-2", "Margaret", "trace-2",
+				"answer", null);
+		whenExchangeInvokesOperation(registry, ProviderType.QINIU, "model-2", provider, expected);
+
+		CustomSceneSession session = new CustomSceneSession("session-2", "user-2");
+		StartCommand command = new StartCommand(
+				SceneType.CUSTOM_SCENE, "user-2", "scene-2", "offer", null,
+				ProviderType.QINIU, "model-2", "Margaret", false);
+
+		assertEquals(expected, new RealtimeSdpExchange(registry, issuer)
+				.exchangeSdp(ProviderType.QINIU, session, new SessionPrompt("prompt"), command));
+		verifyNoInteractions(issuer);
+	}
+
+	@Test
+	void propagatesCredentialProviderAndRealtimeFailuresWithoutChangingThem() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		RealtimeCredentialIssuer issuer = mock(RealtimeCredentialIssuer.class);
+		BusinessException credentialFailure = new BusinessException(
+				"CREDENTIAL_FAILED", "credential unavailable");
+		when(issuer.issue(ProviderType.QWEN)).thenThrow(credentialFailure);
+		doAnswer(invocation -> {
+				@SuppressWarnings("rawtypes")
+				BiFunction operation = (BiFunction) invocation.getArgument(3);
+				return operation.apply("model-1", new CredentialProvider());
+			}).when(registry).routeRealtime(
+				any(AiInvocationContext.class), eq(ProviderType.QWEN), eq("model-1"),
+				anyBiFunction());
+		CustomSceneSession session = new CustomSceneSession("session-3", "user-3");
+		StartCommand command = command(ProviderType.QWEN, "model-1");
+
+		assertSame(credentialFailure, assertThrows(BusinessException.class, () ->
+				new RealtimeSdpExchange(registry, issuer)
+						.exchangeSdp(ProviderType.QWEN, session, new SessionPrompt("prompt"), command)));
+
+		RuntimeException connectionFailure = new IllegalStateException("connect failed");
+		doReturn(new RealtimeCredential("token", null)).when(issuer).issue(ProviderType.QWEN);
+		doAnswer(invocation -> {
+				@SuppressWarnings("rawtypes")
+				BiFunction operation = (BiFunction) invocation.getArgument(3);
+				throw connectionFailure;
+			}).when(registry).routeRealtime(
+				any(AiInvocationContext.class), eq(ProviderType.QWEN), eq("model-1"),
+				anyBiFunction());
+		assertSame(connectionFailure, assertThrows(RuntimeException.class, () ->
+				new RealtimeSdpExchange(registry, issuer)
+						.exchangeSdp(ProviderType.QWEN, session, new SessionPrompt("prompt"), command)));
+	}
+
+	private void whenExchangeInvokesOperation(
+			AiProviderRegistry registry,
+			ProviderType type,
+			String model,
+			RealtimeProvider provider,
+			RealtimeConnectionResult expected) {
+		doAnswer(invocation -> {
+			@SuppressWarnings("rawtypes")
+			BiFunction operation = (BiFunction) invocation.getArgument(3);
+			return operation.apply(model, provider);
+		}).when(registry).routeRealtime(
+				any(AiInvocationContext.class), eq(type), eq(model), anyBiFunction());
+	}
+
+	@SuppressWarnings("unchecked")
+	private BiFunction<String, RealtimeProvider, RealtimeConnectionResult> anyBiFunction() {
+		return (BiFunction<String, RealtimeProvider, RealtimeConnectionResult>) any(BiFunction.class);
+	}
+
+	private StartCommand command(ProviderType type, String model) {
+		return new StartCommand(
+				SceneType.CUSTOM_SCENE, "user-3", "scene-3", "offer", null,
+				type, model, "Tina", true);
+	}
+
+	private static final class CredentialProvider extends RealtimeProvider {
+		private CredentialProvider() {
+			super(ProviderType.QWEN, Set.of("model-1"));
+		}
+
+		@Override
+		public String exchangeRealtimeSdp(String modelId, String offerSdp, String token) {
+			return "unused";
+		}
+
+		@Override
+		public RealtimeConnectionResult connect(
+				RealtimeConnectCommand command, RealtimeCredential credential) {
+			assertEquals("model-1", command.modelId());
+			assertEquals("offer-sdp", command.offerSdp());
+			assertEquals("user-1", command.userId());
+			assertEquals("session-1", command.clientId());
+			assertEquals("scene-1", command.sceneId());
+			assertEquals(SceneType.CUSTOM_SCENE, command.sceneType());
+			assertEquals("Tina", command.voiceId());
+			assertEquals("temporary-token", credential.bearerToken());
+			return new RealtimeConnectionResult(
+					"provider-session", ProviderType.QWEN, command.modelId(), command.voiceId(),
+					"trace-1", "answer-sdp", credential.expiresAt());
+		}
+	}
+
+	private static final class ServerCredentialProvider extends RealtimeProvider {
+		private ServerCredentialProvider() {
+			super(ProviderType.QINIU, Set.of("model-2"));
+		}
+
+		@Override
+		public String exchangeRealtimeSdp(String modelId, String offerSdp, String token) {
+			return "unused";
+		}
+
+		@Override
+		public boolean requiresIssuedCredential() {
+			return false;
+		}
+
+		@Override
+		public RealtimeConnectionResult connect(
+				RealtimeConnectCommand command, RealtimeCredential credential) {
+			assertEquals("", credential.bearerToken());
+			assertEquals(null, credential.expiresAt());
+			return new RealtimeConnectionResult(
+					"provider-session", ProviderType.QINIU, command.modelId(), command.voiceId(),
+					"trace-2", "answer", null);
+		}
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/security/captcha/TurnstileHumanVerificationGatewayTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/security/captcha/TurnstileHumanVerificationGatewayTest.java
@@ -1,0 +1,176 @@
+package com.unispeaking.infrastructure.security.captcha;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpHeaders;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Flow;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSession;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.json.JsonMapper;
+
+class TurnstileHumanVerificationGatewayTest {
+
+    @Test
+    void rejectsMissingSecretOrTokenWithoutMakingARequest() throws Exception {
+        var emptySecret = gateway(new RecordingHttpClient(response(200, "{\"success\":true}")), " ");
+        assertThat(emptySecret.verify("token")).isFalse();
+
+        var client = new RecordingHttpClient(response(200, "{\"success\":true}"));
+        var gateway = gateway(client, "secret");
+        assertThat(gateway.verify(null)).isFalse();
+        assertThat(gateway.verify(" ")).isFalse();
+        assertThat(client.request).isNull();
+    }
+
+    @Test
+    void sendsEncodedSecretAndTokenAndAcceptsSuccessfulResponse() throws Exception {
+        var client = new RecordingHttpClient(response(200, "{\"success\":true}"));
+        var gateway = gateway(client, "secret +/=?");
+
+        assertThat(gateway.verify("token +/=?")).isTrue();
+        assertThat(client.request.uri())
+                .isEqualTo(URI.create("https://challenges.cloudflare.com/turnstile/v0/siteverify"));
+        assertThat(client.request.timeout()).hasValue(Duration.ofSeconds(8));
+        assertThat(client.request.headers().firstValue("Content-Type"))
+                .hasValue("application/x-www-form-urlencoded");
+        assertThat(client.request.bodyPublisher()).isPresent();
+        assertThat(client.body).isEqualTo("secret=secret+%2B%2F%3D%3F&response=token+%2B%2F%3D%3F");
+    }
+
+    @Test
+    void failsClosedForNonSuccessResponsesAndUnsuccessfulJson() throws Exception {
+        var nonSuccess = gateway(new RecordingHttpClient(response(503, "{\"success\":true}")), "secret");
+        assertThat(nonSuccess.verify("token")).isFalse();
+
+        var unsuccessful = gateway(new RecordingHttpClient(response(200, "{\"success\":false}")), "secret");
+        assertThat(unsuccessful.verify("token")).isFalse();
+
+        var missingFlag = gateway(new RecordingHttpClient(response(200, "{}")), "secret");
+        assertThat(missingFlag.verify("token")).isFalse();
+    }
+
+    @Test
+    void failsClosedForMalformedResponsesAndTransportFailures() throws Exception {
+        var malformed = gateway(new RecordingHttpClient(response(200, "not-json")), "secret");
+        assertThat(malformed.verify("token")).isFalse();
+
+        var ioFailure = gateway(new RecordingHttpClient(new java.io.IOException("network down")), "secret");
+        assertThat(ioFailure.verify("token")).isFalse();
+
+        var interrupted = gateway(new RecordingHttpClient(new InterruptedException("cancelled")), "secret");
+        assertThat(interrupted.verify("token")).isFalse();
+    }
+
+    private TurnstileHumanVerificationGateway gateway(HttpClient client, String secret) throws Exception {
+        var gateway = new TurnstileHumanVerificationGateway(JsonMapper.builder().build(), secret);
+        var field = TurnstileHumanVerificationGateway.class.getDeclaredField("client");
+        field.setAccessible(true);
+        field.set(gateway, client);
+        return gateway;
+    }
+
+    private static HttpResponse<String> response(int statusCode, String body) {
+        return new StubResponse(statusCode, body);
+    }
+
+    private static final class RecordingHttpClient extends HttpClient {
+        private final Object outcome;
+        private HttpRequest request;
+        private String body;
+
+        private RecordingHttpClient(Object outcome) {
+            this.outcome = outcome;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public <T> HttpResponse<T> send(HttpRequest request, HttpResponse.BodyHandler<T> handler)
+                throws java.io.IOException, InterruptedException {
+            this.request = request;
+            this.body = readBody(request);
+            if (outcome instanceof java.io.IOException exception) {
+                throw exception;
+            }
+            if (outcome instanceof InterruptedException exception) {
+                throw exception;
+            }
+            return (HttpResponse<T>) outcome;
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request, HttpResponse.BodyHandler<T> handler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public <T> CompletableFuture<HttpResponse<T>> sendAsync(
+                HttpRequest request,
+                HttpResponse.BodyHandler<T> handler,
+                HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override public Optional<CookieHandler> cookieHandler() { return Optional.empty(); }
+        @Override public Optional<Duration> connectTimeout() { return Optional.empty(); }
+        @Override public Redirect followRedirects() { return Redirect.NEVER; }
+        @Override public Optional<ProxySelector> proxy() { return Optional.empty(); }
+        @Override public SSLContext sslContext() { return null; }
+        @Override public SSLParameters sslParameters() { return new SSLParameters(); }
+        @Override public Optional<Authenticator> authenticator() { return Optional.empty(); }
+        @Override public Version version() { return Version.HTTP_1_1; }
+        @Override public Optional<Executor> executor() { return Optional.empty(); }
+
+        private static String readBody(HttpRequest request) {
+            var result = new AtomicReference<>(new StringBuilder());
+            var completed = new java.util.concurrent.CountDownLatch(1);
+            request.bodyPublisher().orElseThrow().subscribe(new Flow.Subscriber<java.nio.ByteBuffer>() {
+                @Override public void onSubscribe(Flow.Subscription subscription) {
+                    subscription.request(Long.MAX_VALUE);
+                }
+                @Override public void onNext(java.nio.ByteBuffer item) {
+                    var bytes = new byte[item.remaining()];
+                    item.get(bytes);
+                    result.get().append(new String(bytes, java.nio.charset.StandardCharsets.UTF_8));
+                }
+                @Override public void onError(Throwable throwable) { completed.countDown(); }
+                @Override public void onComplete() { completed.countDown(); }
+            });
+            try {
+                if (!completed.await(1, java.util.concurrent.TimeUnit.SECONDS)) {
+                    throw new AssertionError("request body was not published");
+                }
+            } catch (InterruptedException exception) {
+                Thread.currentThread().interrupt();
+                throw new AssertionError(exception);
+            }
+            return result.get().toString();
+        }
+    }
+
+    private record StubResponse(int statusCode, String body) implements HttpResponse<String> {
+        @Override public HttpRequest request() { return null; }
+        @Override public Optional<HttpResponse<String>> previousResponse() { return Optional.empty(); }
+        @Override public HttpHeaders headers() {
+            return HttpHeaders.of(Map.of(), (name, value) -> true);
+        }
+        @Override public Optional<SSLSession> sslSession() { return Optional.empty(); }
+        @Override public URI uri() { return URI.create("https://challenges.cloudflare.com/turnstile/v0/siteverify"); }
+        @Override public HttpClient.Version version() { return HttpClient.Version.HTTP_1_1; }
+    }
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/storage/qiniu/QiniuObjectStorageProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/storage/qiniu/QiniuObjectStorageProviderTest.java
@@ -4,11 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 
 import com.qiniu.http.Response;
 import com.qiniu.storage.BucketManager;
@@ -98,5 +100,31 @@ class QiniuObjectStorageProviderTest {
 						uploadManager,
 						bucketManager,
 						properties));
+	}
+
+	@Test
+	void mapsUploadDeleteSigningAndDomainFailures() throws Exception {
+		when(uploadManager.put(any(byte[].class), anyString(), anyString(), isNull(), anyString(), eq(false)))
+				.thenThrow(new com.qiniu.common.QiniuException(new java.io.IOException("upload failed")));
+		assertEquals("OBJECT_STORAGE_FAILED", assertThrows(
+				com.unispeaking.common.exception.BusinessException.class,
+				() -> provider.put(OBJECT_KEY, new byte[] {1}, "image/png")).code());
+		when(bucketManager.delete(BUCKET, OBJECT_KEY))
+				.thenThrow(new com.qiniu.common.QiniuException(new java.io.IOException("delete failed")));
+		assertEquals("OBJECT_STORAGE_FAILED", assertThrows(
+				com.unispeaking.common.exception.BusinessException.class,
+				() -> provider.delete(OBJECT_KEY)).code());
+		assertThrows(com.unispeaking.common.exception.BusinessException.class,
+				() -> provider.signGetUrl(OBJECT_KEY, Duration.ZERO));
+		assertThrows(com.unispeaking.common.exception.BusinessException.class,
+				() -> provider.signGetUrl(OBJECT_KEY, null));
+		assertTrue(provider.available());
+		for (String domain : new String[] {"https://x.example.com/path", "https://user:x@example.com",
+				"https://x.example.com?x=1", "https://x.example.com#f", "http://x.example.com"}) {
+			ObjectStorageProperties properties = new ObjectStorageProperties();
+			properties.setDomain(domain);
+			assertThrows(IllegalArgumentException.class, () -> new QiniuObjectStorageProvider(
+					Auth.create("a", "b"), uploadManager, bucketManager, properties));
+		}
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/provider/AbstractAiProviderCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/provider/AbstractAiProviderCoverageTest.java
@@ -1,0 +1,49 @@
+package com.unispeaking.provider;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.unispeaking.domain.vo.provider.AiCapability;
+import com.unispeaking.common.exception.BusinessException;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class AbstractAiProviderCoverageTest {
+	@Test
+	void defaultMeasuredOperationsAndUnsupportedCapabilitiesAreCovered() {
+		StubProvider provider = new StubProvider();
+		assertEquals("answer", provider.executeLlmTaskMeasured("hello", null).response());
+		assertEquals("ESTIMATED", provider.executeLlmTaskMeasured("hello", null).usage().source());
+		assertArrayEquals(new byte[] {1, 2}, provider.generateSpeechAudioMeasured("hello", null).response());
+		assertArrayEquals(new byte[] {1, 2}, provider.generateSpeechAudioMeasured("hello", null, "voice").response());
+		assertEquals("text", provider.convertAudioToTextMeasured(new byte[] {1}, null).response());
+		assertEquals("score", provider.evaluatePronunciationMeasured("hello", new byte[] {1}, null).response());
+		BareProvider bare = new BareProvider();
+		assertThrows(UnsupportedOperationException.class, () -> bare.exchangeRealtimeSdp("offer", null));
+		assertThrows(UnsupportedOperationException.class, () -> bare.generateSpeechAudio("x", null));
+		assertThrows(UnsupportedOperationException.class, () -> bare.executeLlmTask("x", null));
+		assertThrows(UnsupportedOperationException.class, () -> bare.convertAudioToText(new byte[] {1}, null));
+		assertThrows(UnsupportedOperationException.class, () -> bare.evaluatePronunciation("x", new byte[] {1}, null));
+		assertThrows(BusinessException.class, () -> provider.requireAudioForTest(null));
+		assertEquals("stub", provider.providerId());
+		assertEquals(Set.of("model"), provider.supportedModels());
+		assertEquals(true, provider.supports(" MODEL "));
+		assertEquals(false, provider.supports("other"));
+	}
+
+	private static final class StubProvider extends AbstractAiProvider {
+		StubProvider() { super(" STUB ", Set.of(" MODEL ")); }
+		@Override public AiCapability capability() { return AiCapability.LLM; }
+		@Override public String executeLlmTask(String prompt, String token) { return "answer"; }
+		@Override public byte[] generateSpeechAudio(String text, String token) { return new byte[] {1, 2}; }
+		@Override public String convertAudioToText(byte[] audio, String token) { return "text"; }
+		@Override public String evaluatePronunciation(String text, byte[] audio, String token) { return "score"; }
+		void requireAudioForTest(byte[] audio) { requireAudio(audio, "stub"); }
+	}
+
+	private static final class BareProvider extends AbstractAiProvider {
+		BareProvider() { super("bare", Set.of("model")); }
+		@Override public AiCapability capability() { return AiCapability.LLM; }
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/provider/AiProviderRegistryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/provider/AiProviderRegistryTest.java
@@ -1,6 +1,7 @@
 package com.unispeaking.provider;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -416,14 +417,555 @@ class AiProviderRegistryTest {
 		assertEquals("SUCCEEDED", attempts.get(1).status());
 	}
 
+	@Test
+	void rejectsDisabledRuntimeModelsInsteadOfRoutingToTheirAdapters() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+		registry.configureDynamicRuntime(
+				() -> runtime(
+						Map.of("qwen", provider("qwen", "qwen", true)),
+						Map.of(AiProviderRegistry.QWEN_LLM_PLUS, new AiModelConfiguration(
+								AiProviderRegistry.QWEN_LLM_PLUS,
+								"qwen",
+								AiProviderRegistry.QWEN_LLM_PLUS,
+								AiCapability.LLM,
+								false,
+								"TOKENS",
+								BigDecimal.ZERO,
+								BigDecimal.ZERO,
+								BigDecimal.ZERO,
+								BigDecimal.ZERO,
+								BigDecimal.ZERO,
+								BigDecimal.ZERO,
+								"CNY"))),
+				attempt -> {},
+				null,
+				credentials());
+
+		assertTrue(registry.models().isEmpty());
+		assertEquals("AI_MODEL_NOT_AVAILABLE", assertThrows(
+				BusinessException.class,
+				() -> registry.getModel(AiProviderRegistry.QWEN_LLM_PLUS)).code());
+		assertEquals("AI_PROVIDER_ROUTE_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.route(AiCapability.LLM)).code());
+		assertEquals(0, qwen.calls);
+	}
+
+	@Test
+	void usesRuntimeCredentialForAnExplicitModelRequest() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+		registry.configureDynamicRuntime(null, attempt -> {}, null, new AiProviderCredentialStore() {
+			@Override public String credentialOrFallback(String providerId, String fallback) {
+				return "runtime-secret";
+			}
+			@Override public String credentialOrFallback(String providerId, String field, String fallback) {
+				return credentialOrFallback(providerId, fallback);
+			}
+			@Override public Map<String, String> credentialsOrFallback(String providerId, Map<String, String> fallback) {
+				return Map.of("apiKey", "runtime-secret");
+			}
+			@Override public CredentialStatus status(String providerId) {
+				return new CredentialStatus(true, null, false, List.of());
+			}
+			@Override public CredentialStatus replace(String providerId, Map<String, String> values) {
+				throw new UnsupportedOperationException();
+			}
+		});
+
+		assertEquals("qwen", registry.executeLlmTask(
+				AiProviderRegistry.QWEN_LLM_PLUS, "prompt", null));
+		assertEquals("runtime-secret", qwen.token);
+	}
+
+	@Test
+	void rejectsExplicitRealtimeModelThatDoesNotBelongToTheRequestedProvider() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+
+		assertEquals("AI_PROVIDER_MODEL_MISMATCH", assertThrows(
+				BusinessException.class,
+				() -> registry.routeRealtime(
+						ProviderType.DEEPSEEK,
+						AiProviderRegistry.QWEN_REALTIME_FLASH,
+						(modelId, provider) -> "unused")).code());
+		assertEquals("AI_TTS_MODEL_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> registry.generateSpeechAudioBytes(
+						(String) null, "hello", null, "Katerina")).code());
+	}
+
+	@Test
+	void recordsAndRethrowsTheLastRetryableFailureWhenAllCandidatesAreExhausted() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		qwen.failure = new BusinessException("QWEN_LLM_IO_ERROR", "qwen offline");
+		StubDeepSeekLlmProvider deepSeek = new StubDeepSeekLlmProvider();
+		deepSeek.failure = new BusinessException("DEEPSEEK_LLM_IO_ERROR", "deepseek offline");
+		AiProviderRegistry registry = registry(List.of(qwen, deepSeek), Map.of(
+				AiCapability.LLM,
+				List.of(AiProviderRegistry.QWEN_LLM_PLUS, AiProviderRegistry.DEEPSEEK_CHAT)));
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, credentials());
+
+		BusinessException failure = assertThrows(
+				BusinessException.class,
+				() -> registry.executeLlmTask("prompt", null));
+
+		assertEquals("DEEPSEEK_LLM_IO_ERROR", failure.code());
+		assertEquals(List.of("FAILED", "FAILED"), attempts.stream()
+				.map(AiInvocationAttempt::status).toList());
+		assertEquals(AiProviderRegistry.QWEN_LLM_PLUS, attempts.get(1).fallbackFromModelId());
+	}
+
+	@Test
+	void exposesEnabledRuntimeModelsAndFallsBackToTheDefaultNamedRoute() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+		registry.configureDynamicRuntime(
+				() -> runtime(
+						Map.of("qwen", provider("qwen", "qwen", true)),
+						Map.of(AiProviderRegistry.QWEN_LLM_PLUS,
+								model(AiProviderRegistry.QWEN_LLM_PLUS, "qwen"))),
+				attempt -> {},
+				null,
+				credentials());
+
+		AiModelDefinition available = registry.models().getFirst();
+		assertEquals(AiProviderRegistry.QWEN_LLM_PLUS, available.modelId());
+		assertTrue(available.defaultModel());
+		assertEquals(available, registry.getModel("  QWEN3.5-PLUS  "));
+		assertEquals(List.of(AiProviderRegistry.QWEN_LLM_PLUS),
+				registry.route("evaluation", AiCapability.LLM));
+	}
+
+	@Test
+	void routesDefaultRealtimeTranscriptionAndScoringOperationsThroughRegisteredAdapters() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+
+		assertEquals("answer", registry.exchangeRealtimeSdp("offer", "credential"));
+		assertEquals("transcript", registry.convertAudioToText(new Byte[] {1, 2}, null));
+		assertEquals("{}", registry.evaluatePronunciation("hello", new Byte[] {1}, null));
+		assertEquals("AI_MODEL_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.getModel("missing-model")).code());
+	}
+
+	@Test
+	void ignoresIncompleteRealtimeUsageAndClampsClockSkewToZero() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, null);
+
+		registry.recordRealtimeSession(
+				"user", "", AiProviderRegistry.QWEN_REALTIME_FLASH, "request", Instant.now(), Instant.now());
+		registry.recordRealtimeSession(
+				"user",
+				"session-clock-skew",
+				AiProviderRegistry.QWEN_REALTIME_FLASH,
+				"request",
+				Instant.parse("2026-08-21T08:01:00Z"),
+				Instant.parse("2026-08-21T08:00:00Z"));
+
+		assertEquals(1, attempts.size());
+		assertEquals(0L, attempts.getFirst().durationMs());
+		assertEquals(0D, attempts.getFirst().usage().audioInputSeconds());
+	}
+
+	@Test
+	void reportsMissingRoutesAndModelsWhenNoAdaptersAreDeployed() {
+		AiProviderRegistry registry = new AiProviderRegistry(
+				null, null, null, null, null);
+
+		assertTrue(registry.models().isEmpty());
+		assertTrue(registry.deployedModels().isEmpty());
+		assertEquals("AI_DEFAULT_MODEL_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.defaultModel(AiCapability.LLM)).code());
+		assertEquals("AI_PROVIDER_ROUTE_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.route("missing-route", AiCapability.LLM)).code());
+		assertEquals("AI_MODEL_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.getModel(null)).code());
+	}
+
+	@Test
+	void rejectsConfiguredRoutesThatReferenceAnUnavailableModel() {
+		assertThrows(
+				IllegalStateException.class,
+				() -> new AiProviderRegistry(
+						List.of(new StubRealtimeProvider()),
+						llmProviders(),
+						List.of(new StubScoringProvider()),
+						ttsProviders(),
+						List.of(new StubTranscriptionProvider()),
+						Map.of(AiCapability.LLM, List.of("unknown-model"))));
+	}
+
+	@Test
+	void filtersRuntimeModelsWithMissingDisabledOrMismatchedProviders() {
+		AiProviderRegistry registry = registry(List.of(new StubQwenLlmProvider()), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+		registry.configureDynamicRuntime(
+				() -> runtime(
+						Map.of(
+								"enabled", provider("enabled", "qwen", true),
+								"disabled", provider("disabled", "qwen", false),
+								"wrong-adapter", provider("wrong-adapter", "deepseek", true)),
+						Map.of(
+								"enabled-model", model("enabled-model", "enabled"),
+								"disabled-model", model("disabled-model", "disabled"),
+								"wrong-adapter-model", model("wrong-adapter-model", "wrong-adapter"),
+								"missing-provider-model", model("missing-provider-model", "missing"))),
+				attempt -> {}, null, credentials());
+
+		assertTrue(registry.models().isEmpty());
+		assertEquals("AI_MODEL_NOT_AVAILABLE", assertThrows(
+				BusinessException.class,
+				() -> registry.getModel("wrong-adapter-model")).code());
+		assertEquals("AI_PROVIDER_ROUTE_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.route(AiCapability.LLM)).code());
+	}
+
+	@Test
+	void routesExplicitAndAutomaticRequestsAcrossAllCapabilityAdapters() {
+		StubQwenTtsProvider tts = new StubQwenTtsProvider();
+		StubTranscriptionProvider asr = new StubTranscriptionProvider();
+		AiProviderRegistry registry = new AiProviderRegistry(
+				List.of(new StubRealtimeProvider()),
+				llmProviders(),
+				List.of(new StubScoringProvider()),
+				List.of(tts),
+				List.of(asr),
+				Map.of(
+						AiCapability.REALTIME, List.of(AiProviderRegistry.QWEN_REALTIME_FLASH),
+						AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS),
+						AiCapability.TTS, List.of(AiProviderRegistry.QWEN_TTS),
+						AiCapability.TRANSCRIPTION, List.of(StubTranscriptionProvider.MODEL_ID),
+						AiCapability.SCORING, List.of(AiProviderRegistry.IFLYTEK_PRONUNCIATION_SCORING)));
+
+		assertEquals("answer", registry.exchangeRealtimeSdp(
+				AiProviderRegistry.QWEN_REALTIME_FLASH, "offer", "token"));
+		assertEquals("qwen", registry.executeLlmTask(
+				AiProviderRegistry.QWEN_LLM_PLUS, "prompt", "token"));
+		assertEquals("transcript", registry.convertAudioToText(
+				StubTranscriptionProvider.MODEL_ID, new Byte[] {1}, "token"));
+		assertEquals("{}", registry.evaluatePronunciation(
+				AiProviderRegistry.IFLYTEK_PRONUNCIATION_SCORING,
+				"hello", new Byte[] {1}, "token"));
+		assertArrayEquals(new byte[] {1, 2}, registry.generateSpeechAudioBytes(
+				AiProviderRegistry.QWEN_TTS, "hello", "token"));
+		assertArrayEquals(new byte[] {1, 2}, registry.generateSpeechAudioBytes(
+				AiProviderRegistry.QWEN_TTS, "hello", "token", "voice-a"));
+		assertEquals(2, tts.calls);
+		assertEquals(1, asr.calls);
+	}
+
+	@Test
+	void rejectsNullAudioBytesAndRequiresModelForExplicitVoiceRequests() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+
+		assertEquals("INVALID_AUDIO", assertThrows(
+				BusinessException.class,
+				() -> registry.evaluatePronunciation("hello", new Byte[] {null}, null)).code());
+		assertEquals("AI_TTS_MODEL_REQUIRED", assertThrows(
+				BusinessException.class,
+				() -> registry.generateSpeechAudioBytes(" ", "hello", null, "voice-a")).code());
+		assertEquals("AI_MODEL_NOT_FOUND", assertThrows(
+				BusinessException.class,
+				() -> registry.executeLlmTask("missing", "prompt", null)).code());
+	}
+
+	@Test
+	void preservesRoutedResultMetadataAndScopedInvocationContext() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+		AiInvocationContext context = new AiInvocationContext(
+				UUID.randomUUID(), "user-1", "session-1", "practice", "default");
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, credentials());
+
+		AiProviderRegistry.RoutedResult<String> result =
+				AiInvocationContexts.call(context,
+						() -> registry.executeLlmTaskRouted("hello", null));
+
+		assertEquals(AiProviderRegistry.QINIU_MAAS_QWEN_PLUS, result.modelId());
+		assertEquals("qiniu-maas", result.providerId());
+		assertEquals(AiCapability.LLM, result.capability());
+		assertEquals("qiniu-maas", result.response());
+		assertEquals(context, attempts.getFirst().context());
+	}
+
+	@Test
+	void usesAuthenticatedUserWhenCreatingAnAutomaticContextAndIgnoresAuthFailures() {
+		AiProviderRegistry registry = registry(new StubRealtimeProvider());
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(
+				null, attempts::add, new AuthService() {
+					@Override public com.unispeaking.domain.dto.auth.UserAccountResponse currentUser() { return null; }
+					@Override public String currentUserIdOrNull() { return "user-from-auth"; }
+					@Override public com.unispeaking.domain.dto.auth.AuthResponse register(com.unispeaking.domain.dto.auth.RegisterRequest request) { return null; }
+					@Override public com.unispeaking.domain.dto.auth.AuthResponse login(com.unispeaking.domain.dto.auth.LoginRequest request) { return null; }
+					@Override public String requireUserId(String requestedUserId) { return requestedUserId; }
+				}, credentials());
+
+		registry.executeLlmTask("hello", null);
+		assertEquals("user-from-auth", attempts.getFirst().context().userId());
+
+		List<AiInvocationAttempt> failedAuthAttempts = new ArrayList<>();
+		registry.configureDynamicRuntime(
+				null, failedAuthAttempts::add, new AuthService() {
+					@Override public com.unispeaking.domain.dto.auth.UserAccountResponse currentUser() { return null; }
+					@Override public com.unispeaking.domain.dto.auth.AuthResponse register(com.unispeaking.domain.dto.auth.RegisterRequest request) { return null; }
+					@Override public com.unispeaking.domain.dto.auth.AuthResponse login(com.unispeaking.domain.dto.auth.LoginRequest request) { return null; }
+					@Override public String currentUserIdOrNull() {
+						throw new IllegalStateException("outside request");
+					}
+					@Override public String requireUserId(String requestedUserId) { return requestedUserId; }
+				}, credentials());
+		registry.executeLlmTask("hello", null);
+		assertEquals(null, failedAuthAttempts.getFirst().context().userId());
+	}
+
+	@Test
+	void classifiesNonRetryableFailureCodesWithoutFailingOver() {
+		List<String> nonRetryableCodes = List.of(
+				"INVALID_LLM_PROMPT", "UNSUPPORTED_LLM_FORMAT",
+				"QWEN_LLM_INTERRUPTED", "TTS_TEXT_TOO_LONG",
+				"PRONUNCIATION_AUDIO_TOO_LARGE",
+				"PRONUNCIATION_AUDIO_TOO_LONG",
+				"PRONUNCIATION_REFERENCE_TOO_LONG");
+		for (String code : nonRetryableCodes) {
+			StubQwenLlmProvider primary = new StubQwenLlmProvider();
+			primary.failure = new BusinessException(code, code);
+			StubDeepSeekLlmProvider fallback = new StubDeepSeekLlmProvider();
+			AiProviderRegistry registry = registry(
+					List.of(primary, fallback),
+					Map.of(AiCapability.LLM, List.of(
+							AiProviderRegistry.QWEN_LLM_PLUS,
+							AiProviderRegistry.DEEPSEEK_CHAT)));
+
+			BusinessException actual = assertThrows(
+					BusinessException.class,
+					() -> registry.executeLlmTask("prompt", null));
+			assertEquals(code, actual.code());
+			assertEquals(0, fallback.calls);
+		}
+	}
+
+	@Test
+	void handlesNullCredentialStoreAndNullLedgerWithoutChangingRouting() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+		registry.configureDynamicRuntime(null, null, null, null);
+
+		assertEquals("qwen", registry.executeLlmTask(
+				AiProviderRegistry.QWEN_LLM_PLUS, "prompt", "supplied-token"));
+		registry.recordRealtimeSession(
+				"user", "session", AiProviderRegistry.QWEN_REALTIME_FLASH,
+				"request", Instant.now(), Instant.now());
+		assertEquals("supplied-token", qwen.token);
+	}
+
+	@Test
+	void parsesConfiguredEnvironmentRoutesAndNormalizesTheirModelIds() {
+		AiProviderRegistry registry = new AiProviderRegistry(
+				List.of(new StubRealtimeProvider()),
+				List.of(new StubQwenLlmProvider(), new StubDeepSeekLlmProvider()),
+				List.of(new StubScoringProvider()),
+				ttsProviders(),
+				List.of(new StubTranscriptionProvider()),
+				"  " + AiProviderRegistry.QWEN_REALTIME_FLASH + " , "
+						+ AiProviderRegistry.QWEN_REALTIME_FLASH,
+				" qwen3.5-plus , DEEPSEEK-V4-FLASH ",
+				" iflytek-suntone ",
+				" qwen3-tts-flash ",
+				" stub-asr ",
+				true);
+
+		assertEquals(List.of(AiProviderRegistry.QWEN_REALTIME_FLASH),
+				registry.route(AiCapability.REALTIME));
+		assertEquals(List.of(
+				AiProviderRegistry.QWEN_LLM_PLUS,
+				AiProviderRegistry.DEEPSEEK_CHAT), registry.route(AiCapability.LLM));
+	}
+
+	@Test
+	void usesNamedDatabaseRouteOnlyWhenItIsAvailableAndFallsBackToDefaultPolicy() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		StubDeepSeekLlmProvider deepSeek = new StubDeepSeekLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen, deepSeek), Map.of());
+		registry.configureDynamicRuntime(
+				() -> runtime(
+						Map.of(
+								"qwen", provider("qwen", "qwen", true),
+								"deepseek", provider("deepseek", "deepseek", true)),
+						Map.of(
+								AiProviderRegistry.QWEN_LLM_PLUS,
+								model(AiProviderRegistry.QWEN_LLM_PLUS, "qwen"),
+								AiProviderRegistry.DEEPSEEK_CHAT,
+								model(AiProviderRegistry.DEEPSEEK_CHAT, "deepseek")),
+						Map.of(
+								"evaluation", Map.of(AiCapability.LLM,
+										List.of(AiProviderRegistry.DEEPSEEK_CHAT)),
+								"default", Map.of(AiCapability.LLM,
+										List.of(AiProviderRegistry.QWEN_LLM_PLUS)))),
+				attempt -> {}, null, credentials());
+
+		assertEquals(List.of(AiProviderRegistry.DEEPSEEK_CHAT),
+				registry.route("evaluation", AiCapability.LLM));
+		assertEquals(List.of(AiProviderRegistry.QWEN_LLM_PLUS),
+				registry.route("unknown-route", AiCapability.LLM));
+		assertEquals("deepseek", registry.executeLlmTask(
+				new AiInvocationContext(null, null, null, "evaluation", "evaluation"),
+				null, "prompt", null));
+		assertEquals(0, qwen.calls);
+		assertEquals(1, deepSeek.calls);
+	}
+
+	@Test
+	void routesLlmResponseFormatAndAllConvenienceOverloads() {
+		StubQwenLlmProvider qwen = new StubQwenLlmProvider();
+		AiProviderRegistry registry = registry(List.of(qwen), Map.of(
+				AiCapability.LLM, List.of(AiProviderRegistry.QWEN_LLM_PLUS)));
+
+		assertEquals("qwen", registry.executeLlmTask(
+				AiProviderRegistry.QWEN_LLM_PLUS, "prompt", "token",
+				LlmResponseFormat.JSON_OBJECT));
+		assertEquals("qwen", registry.executeLlmTaskRouted(
+				"prompt", "token", LlmResponseFormat.TEXT).response());
+		assertArrayEquals(new byte[] {1, 2}, registry.generateSpeechAudioBytes(
+				"hello", "token"));
+		assertArrayEquals(new Byte[] {1, 2}, registry.generateSpeechAudio(
+				AiProviderRegistry.QWEN_TTS, "hello", "token"));
+		assertEquals(2, qwen.calls);
+	}
+
+	@Test
+	void failsOverRealtimeScoringAndTranscriptionRequests() {
+		FailingRealtimeProvider realtime = new FailingRealtimeProvider(
+				"realtime-primary", ProviderType.QWEN);
+		SuccessfulRealtimeProvider realtimeFallback = new SuccessfulRealtimeProvider(
+				"realtime-backup", ProviderType.OPENAI);
+		FailingScoringProvider scoring = new FailingScoringProvider("scoring-primary");
+		AlternativeScoringProvider scoringFallback = new AlternativeScoringProvider();
+		FailingTranscriptionProvider transcription = new FailingTranscriptionProvider("asr-primary");
+		AlternativeTranscriptionProvider transcriptionFallback =
+				new AlternativeTranscriptionProvider("asr-backup");
+		AiProviderRegistry registry = new AiProviderRegistry(
+				List.of(realtime, realtimeFallback),
+				llmProviders(),
+				List.of(scoring, scoringFallback),
+				ttsProviders(),
+				List.of(transcription, transcriptionFallback),
+				Map.of(
+						AiCapability.REALTIME, List.of("realtime-primary", "realtime-backup"),
+						AiCapability.SCORING, List.of("scoring-primary", AlternativeScoringProvider.MODEL_ID),
+						AiCapability.TRANSCRIPTION, List.of("asr-primary", "asr-backup")));
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, credentials());
+
+		assertEquals("realtime-answer", registry.exchangeRealtimeSdp("offer", "token"));
+		assertEquals("{\"totalScore\":99}", registry.evaluatePronunciation(
+				"hello", new Byte[] {1}, "token"));
+		assertEquals("backup-transcript", registry.convertAudioToText(
+				new Byte[] {1}, "token"));
+		assertEquals(List.of("FAILED", "SUCCEEDED", "FAILED", "SUCCEEDED", "FAILED", "SUCCEEDED"),
+				attempts.stream().map(AiInvocationAttempt::status).toList());
+		assertEquals(List.of(AiCapability.REALTIME, AiCapability.REALTIME,
+				AiCapability.SCORING, AiCapability.SCORING,
+				AiCapability.TRANSCRIPTION, AiCapability.TRANSCRIPTION),
+				attempts.stream().map(AiInvocationAttempt::capability).toList());
+	}
+
+	@Test
+	void failsOverTtsAndPreservesSuccessfulRoutedResultMetadata() {
+		FailingTtsProvider primary = new FailingTtsProvider("tts-primary");
+		SuccessfulTtsProvider fallback = new SuccessfulTtsProvider("tts-backup");
+		AiProviderRegistry registry = new AiProviderRegistry(
+				List.of(new StubRealtimeProvider()),
+				llmProviders(),
+				List.of(new StubScoringProvider()),
+				List.of(primary, fallback),
+				List.of(new StubTranscriptionProvider()),
+				Map.of(AiCapability.TTS, List.of("tts-primary", "tts-backup")));
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, credentials());
+
+		AiProviderRegistry.RoutedResult<Byte[]> result = registry.generateSpeechAudioRouted(
+				new AiInvocationContext(UUID.randomUUID(), "user", "session", "tts", "default"),
+				"hello", "token");
+
+		assertEquals("tts-backup", result.modelId());
+		assertEquals("tts-backup", result.providerId());
+		assertArrayEquals(new Byte[] {3, 4}, result.response());
+		assertEquals("SUCCEEDED", attempts.getLast().status());
+		assertEquals("tts-primary", attempts.getLast().fallbackFromModelId());
+	}
+
+	@Test
+	void rethrowsFinalFailureForEachRoutedCapabilityAndAuditsIt() {
+		FailingRealtimeProvider realtime = new FailingRealtimeProvider("realtime-only", ProviderType.QWEN);
+		FailingScoringProvider scoring = new FailingScoringProvider("scoring-only");
+		FailingTranscriptionProvider transcription = new FailingTranscriptionProvider("asr-only");
+		FailingTtsProvider tts = new FailingTtsProvider("tts-only");
+		AiProviderRegistry registry = new AiProviderRegistry(
+				List.of(realtime), llmProviders(), List.of(scoring), List.of(tts), List.of(transcription),
+				Map.of(
+						AiCapability.REALTIME, List.of("realtime-only"),
+						AiCapability.SCORING, List.of("scoring-only"),
+						AiCapability.TRANSCRIPTION, List.of("asr-only"),
+						AiCapability.TTS, List.of("tts-only")));
+		List<AiInvocationAttempt> attempts = new ArrayList<>();
+		registry.configureDynamicRuntime(null, attempts::add, null, credentials());
+
+		assertEquals("REALTIME_DOWN", assertThrows(BusinessException.class,
+				() -> registry.exchangeRealtimeSdp("offer", "token")).code());
+		assertEquals("SCORING_DOWN", assertThrows(BusinessException.class,
+				() -> registry.evaluatePronunciation("hello", new Byte[] {1}, "token")).code());
+		assertEquals("ASR_DOWN", assertThrows(BusinessException.class,
+				() -> registry.convertAudioToText(new Byte[] {1}, "token")).code());
+		assertEquals("TTS_DOWN", assertThrows(BusinessException.class,
+				() -> registry.generateSpeechAudioBytes("hello", "token")).code());
+		assertEquals(List.of("FAILED", "FAILED", "FAILED", "FAILED"), attempts.stream()
+				.map(AiInvocationAttempt::status).toList());
+		assertTrue(attempts.stream().allMatch(AiInvocationAttempt::retryable));
+	}
+
+	@Test
+	void rejectsCapabilityMismatchedProviderAndDuplicateModelsAcrossCapabilities() {
+		@SuppressWarnings({"rawtypes", "unchecked"})
+		List<RealtimeProvider> wrongProviders = (List) List.of(new StubScoringProvider());
+		assertThrows(IllegalStateException.class, () -> new AiProviderRegistry(
+				wrongProviders, llmProviders(), List.of(), List.of(), List.of()));
+
+		assertThrows(IllegalStateException.class, () -> new AiProviderRegistry(
+				List.of(),
+				List.of(new ConfiguredModelLlmProvider("qwen", "shared-model")),
+				List.of(),
+				List.of(new SharedModelTtsProvider()),
+				List.of()));
+	}
+
 	private static AiRuntimeConfiguration runtime(
 			Map<String, AiProviderConfiguration> providers,
 			Map<String, AiModelConfiguration> models) {
+		return runtime(providers, models, Map.of("default", Map.of(AiCapability.LLM, List.of(
+				AiProviderRegistry.QWEN_LLM_PLUS, AiProviderRegistry.DEEPSEEK_CHAT))));
+	}
+
+	private static AiRuntimeConfiguration runtime(
+			Map<String, AiProviderConfiguration> providers,
+			Map<String, AiModelConfiguration> models,
+			Map<String, Map<AiCapability, List<String>>> routes) {
 		return new AiRuntimeConfiguration(
 				providers,
 				models,
-				Map.of("default", Map.of(AiCapability.LLM, List.of(
-						AiProviderRegistry.QWEN_LLM_PLUS, AiProviderRegistry.DEEPSEEK_CHAT))),
+				routes,
 				true);
 	}
 
@@ -524,9 +1066,32 @@ class AiProviderRegistryTest {
 		}
 	}
 
+	private static final class FailingRealtimeProvider extends RealtimeProvider {
+		private FailingRealtimeProvider(String modelId, ProviderType providerType) {
+			super(providerType, Set.of(modelId));
+		}
+
+		@Override
+		public String exchangeRealtimeSdp(String modelId, String offerSdp, String token) {
+			throw new BusinessException("REALTIME_DOWN", "realtime unavailable");
+		}
+	}
+
+	private static final class SuccessfulRealtimeProvider extends RealtimeProvider {
+		private SuccessfulRealtimeProvider(String modelId, ProviderType providerType) {
+			super(providerType, Set.of(modelId));
+		}
+
+		@Override
+		public String exchangeRealtimeSdp(String modelId, String offerSdp, String token) {
+			return "realtime-answer";
+		}
+	}
+
 	private static final class StubQwenLlmProvider extends LlmProvider {
 		private int calls;
 		private BusinessException failure;
+		private String token;
 
 		private StubQwenLlmProvider() {
 			super("qwen", Set.of(AiProviderRegistry.QWEN_LLM_PLUS));
@@ -535,6 +1100,7 @@ class AiProviderRegistryTest {
 		@Override
 		public String executeLlmTask(String prompt, String token) {
 			calls++;
+			this.token = token;
 			if (failure != null) {
 				throw failure;
 			}
@@ -544,6 +1110,7 @@ class AiProviderRegistryTest {
 
 	private static final class StubDeepSeekLlmProvider extends LlmProvider {
 		private int calls;
+		private BusinessException failure;
 
 		private StubDeepSeekLlmProvider() {
 			super("deepseek", Set.of(AiProviderRegistry.DEEPSEEK_CHAT));
@@ -552,6 +1119,9 @@ class AiProviderRegistryTest {
 		@Override
 		public String executeLlmTask(String prompt, String token) {
 			calls++;
+			if (failure != null) {
+				throw failure;
+			}
 			return "deepseek";
 		}
 	}
@@ -624,6 +1194,17 @@ class AiProviderRegistryTest {
 		}
 	}
 
+	private static final class FailingScoringProvider extends ScoringProvider {
+		private FailingScoringProvider(String modelId) {
+			super("scoring-provider-" + modelId, Set.of(modelId));
+		}
+
+		@Override
+		public String evaluatePronunciation(String text, byte[] audio, String token) {
+			throw new BusinessException("SCORING_DOWN", "scoring unavailable");
+		}
+	}
+
 	private static final class StubAliyunTtsProvider extends TtsProvider {
 		private StubAliyunTtsProvider() {
 			super("aliyun", Set.of(AiProviderRegistry.ALIYUN_TTS));
@@ -632,8 +1213,16 @@ class AiProviderRegistryTest {
 	}
 
 	private static final class StubQwenTtsProvider extends TtsProvider {
+		private int calls;
+
 		private StubQwenTtsProvider() {
 			super("qwen", Set.of(AiProviderRegistry.QWEN_TTS));
+		}
+
+		@Override
+		public byte[] generateSpeechAudio(String text, String token) {
+			calls++;
+			return new byte[] {1, 2};
 		}
 	}
 
@@ -674,9 +1263,33 @@ class AiProviderRegistryTest {
 		}
 	}
 
+	private static final class FailingTtsProvider extends TtsProvider {
+		private FailingTtsProvider(String modelId) {
+			super(modelId, Set.of(modelId));
+		}
+
+		@Override
+		public byte[] generateSpeechAudio(String text, String token) {
+			throw new BusinessException("TTS_DOWN", "tts unavailable");
+		}
+	}
+
+	private static final class SuccessfulTtsProvider extends TtsProvider {
+		private SuccessfulTtsProvider(String modelId) {
+			super(modelId, Set.of(modelId));
+		}
+
+		@Override
+		public AiProviderResponse<byte[]> generateSpeechAudioMeasured(String text, String token) {
+			return new AiProviderResponse<>(
+					new byte[] {3, 4}, "tts-success-request", ProviderUsage.tts(text, new byte[] {3, 4}));
+		}
+	}
+
 	private static final class StubTranscriptionProvider extends TranscriptionProvider {
 
 		private static final String MODEL_ID = "stub-asr";
+		private int calls;
 
 		private StubTranscriptionProvider() {
 			super("qwen", Set.of(MODEL_ID));
@@ -684,7 +1297,36 @@ class AiProviderRegistryTest {
 
 		@Override
 		public String convertAudioToText(byte[] audio, String token) {
+			calls++;
 			return "transcript";
+		}
+	}
+
+	private static final class FailingTranscriptionProvider extends TranscriptionProvider {
+		private FailingTranscriptionProvider(String modelId) {
+			super(modelId, Set.of(modelId));
+		}
+
+		@Override
+		public String convertAudioToText(byte[] audio, String token) {
+			throw new BusinessException("ASR_DOWN", "transcription unavailable");
+		}
+	}
+
+	private static final class AlternativeTranscriptionProvider extends TranscriptionProvider {
+		private AlternativeTranscriptionProvider(String modelId) {
+			super(modelId, Set.of(modelId));
+		}
+
+		@Override
+		public String convertAudioToText(byte[] audio, String token) {
+			return "backup-transcript";
+		}
+	}
+
+	private static final class SharedModelTtsProvider extends TtsProvider {
+		private SharedModelTtsProvider() {
+			super("shared", Set.of("shared-model"));
 		}
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/provider/config/JdbcEncryptedAiProviderCredentialStoreTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/provider/config/JdbcEncryptedAiProviderCredentialStoreTest.java
@@ -91,6 +91,78 @@ class JdbcEncryptedAiProviderCredentialStoreTest {
 				.isEqualTo("AI_CREDENTIAL_MASTER_KEY_REQUIRED");
 	}
 
+	@Test
+	void usesFallbacksWhenTheMasterKeyIsMissing() {
+		var store = store(database("credential-fallback-no-key"), "");
+
+		assertThat(store.credentialOrFallback("qwen", "fallback")).isEqualTo("fallback");
+		assertThat(store.credentialsOrFallback("qwen", Map.of("apiKey", "fallback")))
+				.containsEntry("apiKey", "fallback");
+		assertThat(store.status("qwen")).satisfies(status -> {
+			assertThat(status.configured()).isFalse();
+			assertThat(status.writable()).isFalse();
+			assertThat(status.fingerprint()).isNull();
+		});
+	}
+
+	@Test
+	void reportsMissingRowsAndDatabaseFailuresAsUnconfiguredOrFallback() {
+		var store = store(database("credential-missing-row"), key());
+		assertThat(store.status("deepseek").configured()).isFalse();
+		assertThat(store.credentialsOrFallback("deepseek", Map.of("apiKey", "fallback")))
+				.containsEntry("apiKey", "fallback");
+
+		var brokenJdbc = org.mockito.Mockito.mock(JdbcTemplate.class);
+		org.mockito.Mockito.when(brokenJdbc.query(org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.any(org.springframework.jdbc.core.RowMapper.class),
+				org.mockito.ArgumentMatchers.any(Object[].class)))
+				.thenThrow(new org.springframework.dao.DataAccessResourceFailureException("database down"));
+		var broken = store(brokenJdbc, key());
+		assertThat(broken.credentialsOrFallback("qwen", Map.of("apiKey", "fallback")))
+				.containsEntry("apiKey", "fallback");
+		assertThat(broken.status("qwen").configured()).isFalse();
+	}
+
+	@Test
+	void validatesProviderFieldsBlankUnknownAndOversizedChanges() {
+		var store = store(database("credential-validation"), key());
+		assertThatThrownBy(() -> store.replace("qwen", Map.of("unsupported", "value")))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_CREDENTIAL_FIELD_INVALID");
+		assertThatThrownBy(() -> store.replace("qwen", Map.of("apiKey", " ")))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_CREDENTIAL_INVALID");
+		assertThatThrownBy(() -> store.replace("qwen", Map.of("apiKey", "x".repeat(4097))))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_CREDENTIAL_INVALID");
+	}
+
+	@Test
+	void rejectsEmptyChangesUnknownProvidersInvalidMasterKeysAndBadCiphertext() {
+		var store = store(database("credential-invalid-inputs"), key());
+		assertThatThrownBy(() -> store.replace("qwen", Map.of()))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_CREDENTIAL_INVALID");
+		assertThatThrownBy(() -> store.replace("not-a-provider", Map.of("apiKey", "secret")))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_PROVIDER_CREDENTIAL_SCHEMA_MISSING");
+		assertThatThrownBy(() -> store(database("credential-bad-key"), "not-base64"))
+				.isInstanceOf(IllegalStateException.class);
+
+		JdbcTemplate jdbc = database("credential-bad-cipher");
+		jdbc.update("update ai_providers set secret_ciphertext='not-valid-ciphertext' where provider_id='qwen'");
+		var corrupted = store(jdbc, key());
+		assertThatThrownBy(() -> corrupted.credentialsOrFallback("qwen", Map.of()))
+				.isInstanceOf(BusinessException.class)
+				.extracting(exception -> ((BusinessException) exception).code())
+				.isEqualTo("AI_CREDENTIAL_DECRYPTION_FAILED");
+	}
+
 	private static JdbcEncryptedAiProviderCredentialStore store(JdbcTemplate jdbc, String key) {
 		return new JdbcEncryptedAiProviderCredentialStore(jdbc, new ObjectMapper(), key);
 	}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/provider/usage/JdbcAiInvocationLedgerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/provider/usage/JdbcAiInvocationLedgerTest.java
@@ -8,6 +8,8 @@ import com.unispeaking.provider.ProviderUsage;
 import com.unispeaking.provider.config.AiModelConfiguration;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.UUID;
+import org.mockito.Mockito;
 import org.junit.jupiter.api.Test;
 
 class JdbcAiInvocationLedgerTest {
@@ -40,5 +42,47 @@ class JdbcAiInvocationLedgerTest {
 				"SUCCEEDED", null, false, null);
 
 		assertThat(JdbcAiInvocationLedger.estimateCost(attempt)).isEqualByComparingTo("0.00500000");
+	}
+
+	@Test
+	void defaultsMissingUsageAndPricingToZeroAndSupportsEachBillingUnit() {
+		AiInvocationContext context = AiInvocationContext.create(
+				"not-a-uuid", " session-1 ", " billing ");
+		AiModelConfiguration base = new AiModelConfiguration(
+				"m", "p", "Model", AiCapability.LLM, true, "TOKENS",
+				new BigDecimal("2"), new BigDecimal("3"), new BigDecimal("5"),
+				new BigDecimal("7"), new BigDecimal("11"), new BigDecimal("13"), "CNY");
+		AiInvocationAttempt noUsage = new AiInvocationAttempt(null, context, 1,
+				AiCapability.LLM, base, null, Instant.EPOCH, Instant.EPOCH, 0,
+				null, "FAILED", "ERR", true, null);
+		assertThat(noUsage.invocationId()).isNotNull();
+		assertThat(noUsage.usage().source()).isEqualTo("NONE");
+		assertThat(JdbcAiInvocationLedger.estimateCost(noUsage)).isEqualByComparingTo("0.00000000");
+
+		for (String unit : new String[] {"CHARACTERS", "AUDIO_MINUTES", "REQUESTS", "UNKNOWN"}) {
+			AiModelConfiguration model = new AiModelConfiguration("m", "p", "Model",
+					AiCapability.LLM, true, unit, BigDecimal.ONE, BigDecimal.ONE,
+					BigDecimal.ONE, BigDecimal.ONE, BigDecimal.ONE, new BigDecimal("2"), "CNY");
+			AiInvocationAttempt attempt = new AiInvocationAttempt(UUID.randomUUID(), context, 1,
+					AiCapability.LLM, model, null, Instant.EPOCH, Instant.EPOCH, 0,
+					new ProviderUsage(1, 2, 3, 4, 60, 120, "provider"), "OK", null, false, null);
+			assertThat(JdbcAiInvocationLedger.estimateCost(attempt)).isNotNull();
+		}
+	}
+
+	@Test
+	void recordSwallowsMeteringFailures() throws Exception {
+		var jdbc = Mockito.mock(org.springframework.jdbc.core.JdbcTemplate.class);
+		var mapper = Mockito.mock(tools.jackson.databind.ObjectMapper.class);
+		Mockito.when(mapper.writeValueAsString(Mockito.any())).thenReturn("{}");
+		Mockito.doThrow(new IllegalStateException("db down")).when(jdbc)
+				.update(Mockito.anyString(), Mockito.any(Object[].class));
+		AiModelConfiguration model = new AiModelConfiguration("m", "p", "Model",
+				AiCapability.LLM, true, "REQUESTS", BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO, BigDecimal.ZERO,
+				new BigDecimal("1"), "CNY");
+		AiInvocationAttempt attempt = new AiInvocationAttempt(null,
+				AiInvocationContext.anonymous("test"), 1, AiCapability.LLM, model, null,
+				Instant.EPOCH, Instant.EPOCH, 0, null, "OK", null, false, null);
+		new JdbcAiInvocationLedger(jdbc, mapper).record(attempt);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/AuthServiceImplTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/AuthServiceImplTest.java
@@ -1,12 +1,17 @@
 package com.unispeaking.service.auth;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.domain.dto.auth.ChangePasswordRequest;
 import com.unispeaking.domain.dto.auth.LoginRequest;
 import com.unispeaking.domain.dto.auth.RegisterRequest;
 import com.unispeaking.domain.po.profile.UserProfile;
@@ -18,6 +23,7 @@ import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.infrastructure.persistence.repository.user.UserAccountRepository;
 import com.unispeaking.infrastructure.persistence.repository.user.UserProfileRepository;
 import com.unispeaking.service.auth.impl.AuthServiceImpl;
+import com.unispeaking.service.auth.RefreshTokenService;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
@@ -28,6 +34,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.oauth2.jwt.Jwt;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationToken;
@@ -43,6 +51,8 @@ class AuthServiceImplTest {
 	private PasswordEncoder passwordEncoder;
 	@Mock
 	private JwtTokenService jwtTokenService;
+	@Mock
+	private RefreshTokenService refreshTokenService;
 
 	@AfterEach
 	void clearSecurityContext() {
@@ -68,6 +78,22 @@ class AuthServiceImplTest {
 	}
 
 	@Test
+	void mapsDuplicateUsernameToStableBusinessError() {
+		AuthServiceImpl service = service();
+		when(passwordEncoder.encode("secret12")).thenReturn("bcrypt-hash");
+		doThrow(new DuplicateKeyException("duplicate username"))
+				.when(userAccountRepository).create(any(UserAccount.class));
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> service.register(new RegisterRequest(
+						" Learner@Example.com ", "secret12", " Alice ")));
+
+		assertEquals("USERNAME_ALREADY_EXISTS", exception.code());
+		verify(userProfileRepository, never()).save(any(UserProfile.class));
+	}
+
+	@Test
 	void rejectsWrongPassword() {
 		AuthServiceImpl service = service();
 		UserAccount user = user();
@@ -80,6 +106,135 @@ class AuthServiceImplTest {
 				() -> service.login(new LoginRequest("learner@example.com", "wrong-password")));
 
 		assertEquals("INVALID_CREDENTIALS", exception.code());
+	}
+
+	@Test
+	void rejectsMissingAndInactiveUsersDuringLogin() {
+		AuthServiceImpl service = service();
+		when(userAccountRepository.findByUsername("missing@example.com"))
+				.thenReturn(Optional.empty());
+		BusinessException missing = assertThrows(
+				BusinessException.class,
+				() -> service.login(new LoginRequest(" MISSING@example.com ", "secret")));
+		assertEquals("INVALID_CREDENTIALS", missing.code());
+
+		UserAccount inactive = new UserAccount(
+				user().id(), "learner@example.com", "bcrypt-hash", null,
+				UserRole.USER, UserStatus.DISABLED, 0, null,
+				Instant.parse("2026-07-28T00:00:00Z"),
+				Instant.parse("2026-07-28T00:00:00Z"));
+		when(userAccountRepository.findByUsername("learner@example.com"))
+				.thenReturn(Optional.of(inactive));
+		when(passwordEncoder.matches("secret", inactive.passwordHash())).thenReturn(true);
+
+		BusinessException notActive = assertThrows(
+				BusinessException.class,
+				() -> service.login(new LoginRequest("learner@example.com", "secret")));
+		assertEquals("USER_NOT_ACTIVE", notActive.code());
+		verify(userAccountRepository, never()).updateLastLoginAt(any(), any());
+	}
+
+	@Test
+	void logsInActiveUserAndUpdatesLastLogin() {
+		AuthServiceImpl service = service();
+		UserAccount user = user();
+		when(userAccountRepository.findByUsername(user.username()))
+				.thenReturn(Optional.of(user));
+		when(passwordEncoder.matches("secret", user.passwordHash())).thenReturn(true);
+		when(jwtTokenService.issue(any(UserAccount.class)))
+				.thenReturn(new IssuedJwt("login-token", Instant.parse("2026-07-29T00:00:00Z")));
+
+		var response = service.login(new LoginRequest(" LEARNER@EXAMPLE.COM ", "secret"));
+
+		assertEquals("login-token", response.accessToken());
+		verify(userAccountRepository).updateLastLoginAt(eq(user.id()), any(Instant.class));
+	}
+
+	@Test
+	void currentUserRequiresAuthenticationAndReturnsValidatedAccount() {
+		AuthServiceImpl service = service();
+		BusinessException unauthenticated = assertThrows(
+				BusinessException.class, service::currentUser);
+		assertEquals("AUTHENTICATION_REQUIRED", unauthenticated.code());
+
+		UserAccount user = user();
+		when(userAccountRepository.findById(user.id())).thenReturn(Optional.of(user));
+		setAuthentication(user);
+		assertEquals(user.username(), service.currentUser().username());
+	}
+
+	@Test
+	void rejectsMalformedMissingAndRevokedJwtClaims() {
+		AuthServiceImpl service = service();
+		setAuthentication("not-a-uuid", 0L);
+		BusinessException malformed = assertThrows(
+				BusinessException.class, service::currentUser);
+		assertEquals("INVALID_ACCESS_TOKEN", malformed.code());
+
+		UserAccount user = user();
+		when(userAccountRepository.findById(user.id())).thenReturn(Optional.empty());
+		setAuthentication(user);
+		BusinessException missing = assertThrows(
+				BusinessException.class, service::currentUser);
+		assertEquals("USER_NOT_FOUND", missing.code());
+
+		when(userAccountRepository.findById(user.id())).thenReturn(Optional.of(user));
+		setAuthentication(user, 99L);
+		BusinessException revoked = assertThrows(
+				BusinessException.class, service::currentUser);
+		assertEquals("ACCESS_TOKEN_REVOKED", revoked.code());
+	}
+
+	@Test
+	void currentUserIdOrNullRejectsNonJwtPrincipals() {
+		AuthServiceImpl service = service();
+		SecurityContextHolder.getContext().setAuthentication(
+				new UsernamePasswordAuthenticationToken("user", "credentials"));
+		assertNull(service.currentUserIdOrNull());
+	}
+
+	@Test
+	void changesPasswordAndRevokesRefreshTokensWhenChecksPass() {
+		AuthServiceImpl service = service(refreshTokenService);
+		UserAccount user = user();
+		when(userAccountRepository.findById(user.id())).thenReturn(Optional.of(user));
+		setAuthentication(user);
+		when(passwordEncoder.matches("old", user.passwordHash())).thenReturn(true);
+		when(passwordEncoder.matches("new", user.passwordHash())).thenReturn(false);
+		when(passwordEncoder.encode("new")).thenReturn("new-hash");
+		when(userAccountRepository.updatePasswordAndAuthVersion(
+				eq(user.id()), eq(user.authVersion()), eq("new-hash"))).thenReturn(true);
+
+		assertNotNull(service.changePassword(new ChangePasswordRequest("old", "new")));
+		verify(refreshTokenService).revokeAll(user.id());
+	}
+
+	@Test
+	void rejectsPasswordValidationAndOptimisticLockFailures() {
+		UserAccount user = user();
+		when(userAccountRepository.findById(user.id())).thenReturn(Optional.of(user));
+		setAuthentication(user);
+		when(passwordEncoder.matches("bad", user.passwordHash())).thenReturn(false);
+		BusinessException invalid = assertThrows(
+				BusinessException.class,
+				() -> service().changePassword(new ChangePasswordRequest("bad", "new")));
+		assertEquals("CURRENT_PASSWORD_INVALID", invalid.code());
+
+		when(passwordEncoder.matches("old", user.passwordHash())).thenReturn(true);
+		BusinessException same = assertThrows(
+				BusinessException.class,
+				() -> service().changePassword(new ChangePasswordRequest("old", "old")));
+		assertEquals("NEW_PASSWORD_SAME_AS_CURRENT", same.code());
+
+		when(passwordEncoder.matches("new", user.passwordHash())).thenReturn(false);
+		when(passwordEncoder.encode("new")).thenReturn("new-hash");
+		when(userAccountRepository.updatePasswordAndAuthVersion(
+				eq(user.id()), eq((long) user.authVersion()), eq("new-hash")))
+				.thenReturn(false);
+		BusinessException conflict = assertThrows(
+				BusinessException.class,
+				() -> service().changePassword(new ChangePasswordRequest("old", "new")));
+		assertEquals("PASSWORD_UPDATE_CONFLICT", conflict.code());
 	}
 
 	@Test
@@ -130,22 +285,35 @@ class AuthServiceImplTest {
 	}
 
 	private void setAuthentication(UserAccount user) {
+		setAuthentication(user.id().toString(), user.authVersion());
+	}
+
+	private void setAuthentication(UserAccount user, Number authVersion) {
+		setAuthentication(user.id().toString(), authVersion);
+	}
+
+	private void setAuthentication(String subject, Number authVersion) {
 		Jwt jwt = new Jwt(
 				"token",
 				Instant.parse("2026-07-28T00:00:00Z"),
 				Instant.parse("2026-07-29T00:00:00Z"),
 				Map.of("alg", "HS256"),
-				Map.of("sub", user.id().toString(), "auth_version", user.authVersion()));
+				Map.of("sub", subject, "auth_version", authVersion));
 		SecurityContextHolder.getContext()
 				.setAuthentication(new JwtAuthenticationToken(jwt, java.util.List.of()));
 	}
 
 	private AuthServiceImpl service() {
+		return service(null);
+	}
+
+	private AuthServiceImpl service(RefreshTokenService refreshTokens) {
 		return new AuthServiceImpl(
 				userAccountRepository,
 				userProfileRepository,
 				passwordEncoder,
-				jwtTokenService);
+				jwtTokenService,
+				refreshTokens);
 	}
 
 	private UserAccount user() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/EmailAuthServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/EmailAuthServiceTest.java
@@ -6,14 +6,20 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.unispeaking.common.email.VerificationEmailSender;
 import com.unispeaking.common.exception.EmailAuthException;
 import com.unispeaking.infrastructure.persistence.repository.auth.InMemoryEmailAuthStore;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
 
 class EmailAuthServiceTest {
@@ -53,11 +59,89 @@ class EmailAuthServiceTest {
     }
 
     @Test
+    void mobileChallengeNormalizesEmailAndRegistrationTrimsNickname() {
+        var challenge = service.issueMobileChallenge(" Person@Example.com ");
+
+        var user = service.register(
+                "PERSON@example.com", "correct-horse-battery-staple", challenge.challengeId(),
+                emailSender.lastCode(), "  Sunny  ");
+
+        assertThat(user.email()).isEqualTo("person@example.com");
+    }
+
+    @Test
+    void registrationRejectsWeakPasswordsBeforeReadingChallenge() {
+        for (String password : Arrays.asList(null, "", "too-short")) {
+            assertThatThrownBy(() -> service.register(
+                    "person@example.com", password, UUID.randomUUID(), "123456"))
+                    .isInstanceOf(EmailAuthException.class)
+                    .hasMessage("WEAK_PASSWORD");
+        }
+    }
+
+    @Test
+    void registrationRejectsMissingExpiredMismatchedAndIncorrectChallenges() {
+        var challenge = service.issueChallenge("person@example.com", "verified-human");
+
+        assertThatThrownBy(() -> service.register(
+                "person@example.com", "correct-password", UUID.randomUUID(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+        assertThatThrownBy(() -> service.register(
+                "other@example.com", "correct-password", challenge.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+        assertThatThrownBy(() -> service.register(
+                "person@example.com", "correct-password", challenge.challengeId(), "000000"))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+
+        var expiredService = newService(Duration.ofSeconds(-1), Duration.ofHours(8), new InMemoryEmailAuthStore(), null);
+        var expired = expiredService.issueMobileChallenge("person@example.com");
+        assertThatThrownBy(() -> expiredService.register(
+                "person@example.com", "correct-password", expired.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+    }
+
+    @Test
+    void registrationMapsAChallengeConsumptionRaceAndDuplicateIdentity() {
+        var store = Mockito.mock(EmailAuthStore.class);
+        var challengeId = UUID.randomUUID();
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        var code = "123456";
+        var challenge = validChallenge(challengeId, "person@example.com", code, now);
+        Mockito.when(store.findChallenge(challengeId)).thenReturn(Optional.of(challenge));
+        Mockito.when(store.consumeChallenge(challengeId, now)).thenReturn(false);
+        var mockedStoreService = newService(Duration.ofMinutes(10), Duration.ofHours(8), store, null);
+
+        assertThatThrownBy(() -> mockedStoreService.register(
+                "person@example.com", "correct-password", challengeId, code))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+
+        var firstChallenge = service.issueChallenge("person@example.com", "verified-human");
+        service.register("person@example.com", "correct-password", firstChallenge.challengeId(), emailSender.lastCode());
+        var duplicateChallenge = service.issueChallenge("person@example.com", "verified-human");
+        assertThatThrownBy(() -> service.register(
+                "person@example.com", "another-password", duplicateChallenge.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("IDENTITY_ALREADY_BOUND");
+    }
+
+    @Test
     void incorrectPasswordDoesNotCreateSession() {
         var challenge = service.issueChallenge("person@example.com", "verified-human");
         service.register("person@example.com", "correct-password", challenge.challengeId(), emailSender.lastCode());
 
         assertThatThrownBy(() -> service.login("person@example.com", "wrong-password"))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("INVALID_CREDENTIALS");
+    }
+
+    @Test
+    void loginRejectsAnUnknownEmail() {
+        assertThatThrownBy(() -> service.login("unknown@example.com", "correct-password"))
                 .isInstanceOf(EmailAuthException.class)
                 .hasMessage("INVALID_CREDENTIALS");
     }
@@ -106,6 +190,131 @@ class EmailAuthServiceTest {
                 emailSender.lastCode()))
                 .isInstanceOf(EmailAuthException.class)
                 .hasMessage("CHALLENGE_INVALID");
+    }
+
+    @Test
+    void resetPasswordRejectsPasswordBoundsAndUnknownIdentity() {
+        for (String password : Arrays.asList(null, "", "too-short", "a".repeat(201))) {
+            var challenge = service.issueChallenge("person@example.com", "verified-human");
+            assertThatThrownBy(() -> service.resetPassword(
+                    "person@example.com", password, challenge.challengeId(), emailSender.lastCode()))
+                    .isInstanceOf(EmailAuthException.class)
+                    .hasMessage("WEAK_PASSWORD");
+        }
+
+        var challenge = service.issueChallenge("person@example.com", "verified-human");
+        assertThatThrownBy(() -> service.resetPassword(
+                "person@example.com", "correct-new-password", challenge.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("IDENTITY_NOT_FOUND");
+    }
+
+    @Test
+    void resetPasswordRejectsExpiredAndMismatchedChallenges() {
+        var expiredService = newService(Duration.ofSeconds(-1), Duration.ofHours(8), new InMemoryEmailAuthStore(), null);
+        var expired = expiredService.issueMobileChallenge("person@example.com");
+        assertThatThrownBy(() -> expiredService.resetPassword(
+                "person@example.com", "correct-new-password", expired.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+
+        var challenge = service.issueChallenge("person@example.com", "verified-human");
+        assertThatThrownBy(() -> service.resetPassword(
+                "other@example.com", "correct-new-password", challenge.challengeId(), emailSender.lastCode()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+        assertThatThrownBy(() -> service.resetPassword(
+                "person@example.com", "correct-new-password", challenge.challengeId(), "000000"))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("CHALLENGE_INVALID");
+    }
+
+    @Test
+    void resetPasswordRevokesRefreshTokensWhenConfigured() {
+        var store = Mockito.mock(EmailAuthStore.class);
+        var refreshTokens = Mockito.mock(RefreshTokenService.class);
+        var challengeId = UUID.randomUUID();
+        var userId = UUID.randomUUID();
+        var now = Instant.parse("2026-08-06T08:00:00Z");
+        var challenge = validChallenge(challengeId, "person@example.com", "123456", now);
+        var user = new EmailAuthStore.UserRecord(userId, "person@example.com", "old-hash");
+        Mockito.when(store.findChallenge(challengeId)).thenReturn(Optional.of(challenge));
+        Mockito.when(store.consumeChallenge(challengeId, now)).thenReturn(true);
+        Mockito.when(store.findUserByEmail("person@example.com")).thenReturn(Optional.of(user));
+        var configuredService = newService(Duration.ofMinutes(10), Duration.ofHours(8), store, refreshTokens);
+
+        configuredService.resetPassword("PERSON@example.com", "correct-new-password", challengeId, "123456");
+
+        Mockito.verify(refreshTokens).revokeAll(userId);
+    }
+
+    @Test
+    void currentUserRejectsMissingExpiredRevokedAndDeletedSessions() {
+        assertThatThrownBy(() -> service.currentUser("missing-token"))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("UNAUTHENTICATED");
+
+        var challenge = service.issueChallenge("person@example.com", "verified-human");
+        service.register("person@example.com", "correct-password", challenge.challengeId(), emailSender.lastCode());
+        var login = service.login("person@example.com", "correct-password");
+        service.logout(login.rawToken());
+        assertThatThrownBy(() -> service.currentUser(login.rawToken()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("UNAUTHENTICATED");
+
+        var expiredService = newService(Duration.ofMinutes(10), Duration.ofSeconds(-1),
+                new InMemoryEmailAuthStore(), null);
+        var expiredChallenge = expiredService.issueMobileChallenge("expired@example.com");
+        expiredService.register("expired@example.com", "correct-password", expiredChallenge.challengeId(), emailSender.lastCode());
+        var expiredLogin = expiredService.login("expired@example.com", "correct-password");
+        assertThatThrownBy(() -> expiredService.currentUser(expiredLogin.rawToken()))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("UNAUTHENTICATED");
+
+        var store = Mockito.mock(EmailAuthStore.class);
+        var userId = UUID.randomUUID();
+        Mockito.when(store.findSession(Mockito.anyString())).thenReturn(Optional.of(new EmailAuthStore.SessionRecord(
+                "digest", userId, Instant.parse("2026-08-06T07:00:00Z"),
+                Instant.parse("2026-08-06T07:00:00Z"), Instant.parse("2026-08-06T09:00:00Z"), null)));
+        Mockito.when(store.findUserById(userId)).thenReturn(Optional.empty());
+        var deletedUserService = newService(Duration.ofMinutes(10), Duration.ofHours(8), store, null);
+        assertThatThrownBy(() -> deletedUserService.currentUser("some-token"))
+                .isInstanceOf(EmailAuthException.class)
+                .hasMessage("UNAUTHENTICATED");
+    }
+
+    @Test
+    void rejectsBlankAndMalformedEmails() {
+        for (String email : Arrays.asList(null, "   ", "invalid", "@example.com", "person@")) {
+            assertThatThrownBy(() -> service.issueMobileChallenge(email))
+                    .isInstanceOf(EmailAuthException.class)
+                    .hasMessage("INVALID_EMAIL");
+        }
+    }
+
+    private EmailAuthService newService(
+            Duration challengeTtl, Duration sessionTtl, EmailAuthStore store, RefreshTokenService refreshTokens) {
+        return new EmailAuthService(
+                emailSender,
+                token -> "verified-human".equals(token),
+                Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8(),
+                Clock.fixed(Instant.parse("2026-08-06T08:00:00Z"), ZoneOffset.UTC),
+                challengeTtl,
+                sessionTtl,
+                store,
+                refreshTokens);
+    }
+
+    private static EmailAuthStore.ChallengeRecord validChallenge(
+            UUID id, String email, String code, Instant now) {
+        try {
+            return new EmailAuthStore.ChallengeRecord(
+                    id, email,
+                    MessageDigest.getInstance("SHA-256").digest(code.getBytes(StandardCharsets.UTF_8)),
+                    now.plusSeconds(600), null);
+        } catch (Exception exception) {
+            throw new AssertionError(exception);
+        }
     }
 
     private static final class CapturingEmailSender implements VerificationEmailSender {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/RefreshTokenServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/RefreshTokenServiceTest.java
@@ -1,0 +1,173 @@
+package com.unispeaking.service.auth;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.domain.po.auth.UserAccount;
+import com.unispeaking.domain.po.auth.UserRole;
+import com.unispeaking.domain.po.auth.UserStatus;
+import com.unispeaking.domain.vo.auth.IssuedJwt;
+import com.unispeaking.infrastructure.config.JwtProperties;
+import com.unispeaking.infrastructure.persistence.repository.auth.AuthRefreshTokenRepository;
+import com.unispeaking.infrastructure.persistence.repository.user.UserAccountRepository;
+import java.time.Instant;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class RefreshTokenServiceTest {
+	@Test
+	void rejectsUnknownExpiredRevokedAndInactiveTokens() {
+		AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+		UserAccountRepository users = mock(UserAccountRepository.class);
+		RefreshTokenService service = new RefreshTokenService(repository, users, mock(JwtTokenService.class), properties());
+		when(repository.find(any())).thenReturn(null);
+		assertInvalid(() -> service.refresh("unknown"));
+	}
+
+	@Test
+	void rejectsExpiredRevokedAndIdleExpiredRecords() {
+		Instant now = Instant.now();
+		for (AuthRefreshTokenRepository.Record record : new AuthRefreshTokenRepository.Record[] {
+				new AuthRefreshTokenRepository.Record("d", UUID.randomUUID(), now, now,
+						now.plusSeconds(60), now.minusSeconds(1)),
+				new AuthRefreshTokenRepository.Record("d", UUID.randomUUID(), now, now,
+						now.minusSeconds(1), null),
+				new AuthRefreshTokenRepository.Record("d", UUID.randomUUID(), now,
+						now.minus(Duration.ofDays(8)), now.plusSeconds(60), null) }) {
+			AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+			when(repository.find(anyString())).thenReturn(record);
+			RefreshTokenService service = new RefreshTokenService(repository,
+					mock(UserAccountRepository.class), mock(JwtTokenService.class), properties());
+			assertInvalid(() -> service.refresh("raw"));
+			verify(repository, never()).consume(anyString(), any(), any());
+		}
+	}
+
+	@Test
+	void refreshesActiveTokenAndRotatesTheDigest() {
+		AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+		UserAccountRepository users = mock(UserAccountRepository.class);
+		JwtTokenService jwt = mock(JwtTokenService.class);
+		UUID id = UUID.randomUUID();
+		Instant now = Instant.now();
+		when(repository.find(any())).thenReturn(new AuthRefreshTokenRepository.Record(
+				"digest", id, now.minusSeconds(1), now.minusSeconds(1), now.plusSeconds(3600), null));
+		when(repository.consume(any(), any(), any())).thenReturn(1);
+		when(users.findById(id)).thenReturn(Optional.of(user(id, UserStatus.ACTIVE)));
+		when(jwt.issue(any())).thenReturn(new IssuedJwt("access", now.plusSeconds(600)));
+		RefreshTokenService.Result result = new RefreshTokenService(repository, users, jwt, properties()).refresh("raw");
+		assertEquals("access", result.access().accessToken());
+		org.mockito.Mockito.verify(repository).consume(any(), any(), any());
+	}
+
+	@Test
+	void rejectsDisabledUsersAndFailedAtomicConsume() {
+		AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+		UserAccountRepository users = mock(UserAccountRepository.class);
+		UUID id = UUID.randomUUID();
+		Instant now = Instant.now();
+		when(repository.find(any())).thenReturn(new AuthRefreshTokenRepository.Record("d", id, now, now, now.plusSeconds(60), null));
+		when(users.findById(id)).thenReturn(Optional.of(user(id, UserStatus.DISABLED)));
+		RefreshTokenService service = new RefreshTokenService(repository, users, mock(JwtTokenService.class), properties());
+		assertInvalid(() -> service.refresh("raw"));
+		when(users.findById(id)).thenReturn(Optional.of(user(id, UserStatus.ACTIVE)));
+		when(repository.consume(any(), any(), any())).thenReturn(0);
+		assertInvalid(() -> service.refresh("raw"));
+	}
+
+	@Test
+	void rejectsWhenUserCannotBeFoundAndRotatesForMobileClients() {
+		AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+		UserAccountRepository users = mock(UserAccountRepository.class);
+		JwtTokenService jwt = mock(JwtTokenService.class);
+		UUID id = UUID.randomUUID();
+		Instant now = Instant.now();
+		AuthRefreshTokenRepository.Record record = new AuthRefreshTokenRepository.Record(
+				"d", id, now.minusSeconds(10), now.minusSeconds(10), now.plusSeconds(600), null);
+		when(repository.find(anyString())).thenReturn(record);
+		when(users.findById(id)).thenReturn(Optional.empty());
+		RefreshTokenService service = new RefreshTokenService(repository, users, jwt, properties());
+		assertInvalid(() -> service.refresh("raw"));
+
+		when(users.findById(id)).thenReturn(Optional.of(user(id, UserStatus.ACTIVE)));
+		when(repository.consume(anyString(), any(), any())).thenReturn(1);
+		when(jwt.issue(any())).thenReturn(new IssuedJwt("mobile-access", now.plusSeconds(300)));
+		RefreshTokenService.MobileResult result = service.refreshMobile("raw");
+		assertEquals("mobile-access", result.access().accessToken());
+		assertTrue(result.refreshToken() != null && !result.refreshToken().isBlank());
+		assertEquals(record.expiresAt(), result.refreshTokenExpiresAt());
+		verify(repository).insert(anyString(), org.mockito.ArgumentMatchers.eq(id), any(),
+				org.mockito.ArgumentMatchers.eq(record.expiresAt()));
+	}
+
+	@Test
+	void issuesTokensForIdsAndUsersAndSupportsRevokeAndCleanupOperations() {
+		AuthRefreshTokenRepository repository = mock(AuthRefreshTokenRepository.class);
+		UUID id = UUID.randomUUID();
+		RefreshTokenService service = new RefreshTokenService(repository,
+				mock(UserAccountRepository.class), mock(JwtTokenService.class), properties());
+
+		RefreshTokenService.Issued issued = service.issue(id);
+		assertTrue(issued.token().length() > 40);
+		assertTrue(issued.expiresAt().isAfter(Instant.now()));
+		verify(repository).insert(anyString(), org.mockito.ArgumentMatchers.eq(id), any(), any());
+		service.issue(user(id, UserStatus.ACTIVE));
+		verify(repository, org.mockito.Mockito.times(2)).insert(anyString(),
+				org.mockito.ArgumentMatchers.eq(id), any(), any());
+
+		service.revoke(null);
+		service.revoke("  ");
+		verify(repository, never()).revoke(anyString(), any());
+		service.revoke("raw-token");
+		verify(repository).revoke(anyString(), any());
+		service.revokeAll(id);
+		verify(repository).revokeAll(org.mockito.ArgumentMatchers.eq(id), any());
+		when(repository.deleteExpired(any())).thenReturn(4);
+		assertEquals(4, service.cleanup());
+		verify(repository).deleteExpired(any());
+	}
+
+	@Test
+	void rejectsInvalidRefreshTtlConfiguration() {
+		JwtProperties idleZero = properties();
+		idleZero.setRefreshIdleTtl(java.time.Duration.ZERO);
+		assertThrows(IllegalStateException.class, () -> new RefreshTokenService(
+				mock(AuthRefreshTokenRepository.class), mock(UserAccountRepository.class),
+				mock(JwtTokenService.class), idleZero));
+
+		JwtProperties idleTooLong = properties();
+		idleTooLong.setRefreshIdleTtl(java.time.Duration.ofDays(31));
+		assertThrows(IllegalStateException.class, () -> new RefreshTokenService(
+				mock(AuthRefreshTokenRepository.class), mock(UserAccountRepository.class),
+				mock(JwtTokenService.class), idleTooLong));
+
+		JwtProperties absoluteZero = properties();
+		absoluteZero.setRefreshAbsoluteTtl(java.time.Duration.ZERO);
+		assertThrows(IllegalStateException.class, () -> new RefreshTokenService(
+				mock(AuthRefreshTokenRepository.class), mock(UserAccountRepository.class),
+				mock(JwtTokenService.class), absoluteZero));
+	}
+
+	private static void assertInvalid(org.junit.jupiter.api.function.Executable action) {
+		assertEquals("REFRESH_TOKEN_INVALID", assertThrows(BusinessException.class, action).code());
+	}
+	private static JwtProperties properties() {
+		JwtProperties p = new JwtProperties();
+		p.setRefreshIdleTtl(java.time.Duration.ofDays(7));
+		p.setRefreshAbsoluteTtl(java.time.Duration.ofDays(30));
+		return p;
+	}
+	private static UserAccount user(UUID id, UserStatus status) {
+		return new UserAccount(id, "user@example.com", "hash", "User", UserRole.USER, status, 0, null, Instant.now(), Instant.now());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/impl/JwtTokenServiceImplTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/auth/impl/JwtTokenServiceImplTest.java
@@ -1,0 +1,63 @@
+package com.unispeaking.service.auth.impl;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.domain.po.auth.UserAccount;
+import com.unispeaking.domain.po.auth.UserRole;
+import com.unispeaking.domain.po.auth.UserStatus;
+import com.unispeaking.domain.vo.auth.IssuedJwt;
+import com.unispeaking.infrastructure.config.JwtProperties;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtClaimsSet;
+import org.springframework.security.oauth2.jwt.JwtEncoder;
+import org.springframework.security.oauth2.jwt.JwtEncoderParameters;
+
+class JwtTokenServiceImplTest {
+    @Test
+    void issuesHs256TokenWithUserClaimsAndConfiguredExpiry() {
+        JwtEncoder encoder = mock(JwtEncoder.class);
+        Jwt encoded = mock(Jwt.class);
+        when(encoded.getTokenValue()).thenReturn("signed-access-token");
+        when(encoder.encode(any(JwtEncoderParameters.class))).thenReturn(encoded);
+
+        JwtProperties properties = new JwtProperties();
+        properties.setIssuer("test-issuer");
+        properties.setAccessTokenTtl(Duration.ofMinutes(20));
+        UUID id = UUID.randomUUID();
+        UserAccount user = new UserAccount(id, "alice@example.com", "hash", "Alice",
+                UserRole.ADMIN, UserStatus.ACTIVE, 7, Instant.now().minusSeconds(30),
+                Instant.now().minusSeconds(3600), Instant.now());
+        JwtTokenServiceImpl service = new JwtTokenServiceImpl(encoder, properties);
+
+        Instant before = Instant.now();
+        IssuedJwt result = service.issue(user);
+        Instant after = Instant.now();
+
+        assertEquals("signed-access-token", result.token());
+        assertTrue(!result.expiresAt().isBefore(before.plus(properties.getAccessTokenTtl())));
+        assertTrue(!result.expiresAt().isAfter(after.plus(properties.getAccessTokenTtl())));
+
+        ArgumentCaptor<JwtEncoderParameters> captor = ArgumentCaptor.forClass(JwtEncoderParameters.class);
+        verify(encoder).encode(captor.capture());
+        JwtClaimsSet claims = captor.getValue().getClaims();
+        assertEquals("test-issuer", claims.getClaimAsString("iss"));
+        assertEquals(id.toString(), claims.getSubject());
+        assertEquals("alice@example.com", claims.getClaimAsString("username"));
+        assertEquals("ADMIN", claims.getClaimAsString("role"));
+        assertEquals(Long.valueOf(7L), claims.getClaim("auth_version"));
+        assertNotNull(claims.getIssuedAt());
+        assertEquals(result.expiresAt(), claims.getExpiresAt());
+        assertEquals("HS256", captor.getValue().getJwsHeader().getAlgorithm().getName());
+    }
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/CustomEvaluationServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/CustomEvaluationServiceTest.java
@@ -1,0 +1,143 @@
+package com.unispeaking.service.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.component.evaluation.EvaluationProcessor;
+import com.unispeaking.component.session.SessionLifecycleManager;
+import com.unispeaking.domain.dto.evaluation.CustomEvaluationDetail;
+import com.unispeaking.domain.dto.evaluation.DialogueEvaluationResult;
+import com.unispeaking.domain.dto.evaluation.DialogueReportResult;
+import com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationCommand;
+import com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationResult;
+import com.unispeaking.domain.dto.evaluation.SentenceEvaluationResponse;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.dto.session.SessionDetail;
+import com.unispeaking.domain.vo.scene.SceneType;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class CustomEvaluationServiceTest {
+
+	private static final String SCENE_ID = "custom-1";
+
+	@Test
+	void delegatesTurnSentenceAndDialogueOperations() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomEvaluationService service = new CustomEvaluationService(delegate, lifecycle);
+		DialogueTurnEvaluationCommand command =
+				new DialogueTurnEvaluationCommand("session-1", 1, null, "hello");
+		DialogueTurnEvaluationResult turn = new DialogueTurnEvaluationResult(
+				1, "hello", score("80"), score("81"), score("82"), score("83"),
+				score("84"), score("85"), "反馈", "Hello there", List.of());
+		SentenceEvaluationResponse sentence = new SentenceEvaluationResponse(
+				score("90"), true, List.of());
+		DialogueEvaluationResult dialogue = new DialogueEvaluationResult(
+				List.of(new Message(0, "hello", null)), List.of(turn));
+		when(delegate.evaluateDialogueTurn(command)).thenReturn(turn);
+		when(delegate.evaluateSentenceReading("sentence-1", new byte[] {1, 2}))
+				.thenReturn(sentence);
+		when(delegate.getDialogueEvaluation("session-1")).thenReturn(dialogue);
+
+		assertSame(turn, service.evaluateTurn(command));
+		assertSame(sentence, service.evaluateSentence("sentence-1", new byte[] {1, 2}));
+		assertSame(dialogue, service.getDialogueEvaluation("session-1"));
+		verify(delegate).evaluateDialogueTurn(command);
+		verify(delegate).evaluateSentenceReading(eq("sentence-1"), any(byte[].class));
+		verify(delegate).getDialogueEvaluation("session-1");
+		verifyNoInteractions(lifecycle);
+	}
+
+	@Test
+	void generatesReportFromTheLatestSessionForScene() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomEvaluationService service = new CustomEvaluationService(delegate, lifecycle);
+		SessionDetail oldSession = session("old-session", List.of(new Message(0, "old", null)));
+		SessionDetail latestSession = session("latest-session", List.of(
+				new Message(0, "question", null), new Message(1, "answer", null)));
+		when(lifecycle.getBySceneId(SCENE_ID)).thenReturn(List.of(oldSession, latestSession));
+		DialogueReportResult report = report();
+		when(delegate.generateDialogueReport("latest-session", latestSession.dialogue()))
+				.thenReturn(report);
+
+		assertSame(report, service.generateReport(SCENE_ID));
+		verify(delegate).generateDialogueReport("latest-session", latestSession.dialogue());
+	}
+
+	@Test
+	void getsEvaluationUsingLatestSessionAndBuildsReportAndDialogue() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomEvaluationService service = new CustomEvaluationService(delegate, lifecycle);
+		SessionDetail latestSession = session("latest-session", List.of(new Message(1, "answer", null)));
+		when(lifecycle.getBySceneId(SCENE_ID)).thenReturn(List.of(latestSession));
+		DialogueReportResult report = report();
+		DialogueEvaluationResult dialogue = new DialogueEvaluationResult(latestSession.dialogue(), List.of());
+		when(delegate.generateDialogueReport("latest-session", latestSession.dialogue())).thenReturn(report);
+		when(delegate.getDialogueEvaluation("latest-session")).thenReturn(dialogue);
+
+		CustomEvaluationDetail result = service.getEvaluation(SCENE_ID);
+
+		assertSame(report, result.report());
+		assertSame(dialogue, result.dialogue());
+		verify(delegate).getDialogueEvaluation("latest-session");
+		verify(delegate).generateDialogueReport("latest-session", latestSession.dialogue());
+	}
+
+	@Test
+	void rejectsReportAndEvaluationWhenSceneHasNoSessions() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomEvaluationService service = new CustomEvaluationService(delegate, lifecycle);
+		when(lifecycle.getBySceneId(SCENE_ID)).thenReturn(List.of());
+
+		BusinessException reportFailure = assertThrows(
+				BusinessException.class, () -> service.generateReport(SCENE_ID));
+		BusinessException detailFailure = assertThrows(
+				BusinessException.class, () -> service.getEvaluation(SCENE_ID));
+
+		assertEquals("SESSION_NOT_FOUND", reportFailure.code());
+		assertEquals("SESSION_NOT_FOUND", detailFailure.code());
+		verifyNoInteractions(delegate);
+	}
+
+	@Test
+	void propagatesDelegateFailuresWithoutReplacingThem() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomEvaluationService service = new CustomEvaluationService(delegate, lifecycle);
+		SessionDetail latestSession = session("latest-session", List.of());
+		when(lifecycle.getBySceneId(SCENE_ID)).thenReturn(List.of(latestSession));
+		IllegalStateException failure = new IllegalStateException("provider failed");
+		when(delegate.generateDialogueReport("latest-session", latestSession.dialogue()))
+				.thenThrow(failure);
+
+		assertSame(failure, assertThrows(
+				IllegalStateException.class, () -> service.generateReport(SCENE_ID)));
+	}
+
+	private SessionDetail session(String id, List<Message> dialogue) {
+		return new SessionDetail(id, SCENE_ID, SceneType.CUSTOM_SCENE, "DIALOGUE", dialogue);
+	}
+
+	private DialogueReportResult report() {
+		return new DialogueReportResult(
+				score("80"), score("81"), score("82"), score("83"), score("84"),
+				score("83"), "summary", List.of("strength"), List.of("improvement"));
+	}
+
+	private BigDecimal score(String value) {
+		return new BigDecimal(value);
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/EvaluationProcessorReadPathTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/EvaluationProcessorReadPathTest.java
@@ -1,0 +1,1775 @@
+package com.unispeaking.service.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.evaluation.model.EndingTone;
+import com.unispeaking.common.evaluation.model.IeltsTextAssessment;
+import com.unispeaking.common.evaluation.model.ConversationLanguageAssessment;
+import com.unispeaking.common.evaluation.model.PronunciationAssessmentResult;
+import com.unispeaking.common.evaluation.model.PronunciationPhonemeResult;
+import com.unispeaking.common.evaluation.model.PronunciationWordResult;
+import com.unispeaking.common.evaluation.model.TurnLanguageFeedback;
+import com.unispeaking.common.evaluation.model.WordReadStatus;
+import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
+import com.unispeaking.common.exception.evaluation.EvaluationException;
+import com.unispeaking.component.evaluation.EvaluationProcessor;
+import com.unispeaking.component.recording.RecordingStore;
+import com.unispeaking.component.session.ActiveSessionRegistry;
+import com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationCommand;
+import com.unispeaking.domain.dto.evaluation.SpeechEvaluationCommand;
+import com.unispeaking.domain.dto.scene.LearningContentItem;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.po.scene.CustomSceneDefinition;
+import com.unispeaking.domain.po.scene.IeltsPracticeRecord;
+import com.unispeaking.domain.po.scene.IeltsTopic;
+import com.unispeaking.domain.po.session.CustomSceneSession;
+import com.unispeaking.domain.po.session.PracticeSessionRecord;
+import com.unispeaking.domain.vo.scene.IeltsContent;
+import com.unispeaking.domain.vo.scene.IeltsContentQuestion;
+import com.unispeaking.domain.vo.scene.IeltsMode;
+import com.unispeaking.domain.vo.scene.IeltsPart;
+import com.unispeaking.domain.vo.scene.RecommendedExpression;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.SessionStatus;
+import com.unispeaking.infrastructure.config.ObjectStorageProperties;
+import com.unispeaking.infrastructure.evaluation.client.EvaluationLlmClient;
+import com.unispeaking.infrastructure.evaluation.client.IeltsEvaluationLlmClient;
+import com.unispeaking.infrastructure.evaluation.client.PronunciationAssessmentClient;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.CustomTurnEvaluation;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.IeltsPartEvaluationEntity;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.IeltsEvaluationEntity;
+import com.unispeaking.infrastructure.persistence.entity.evaluation.PronunciationWordDetail;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.IeltsEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.SceneSentenceReadingRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.SessionEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.TurnEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.IeltsPracticeRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.IeltsRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
+import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
+import com.unispeaking.provider.ObjectStorageProvider;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.service.scene.IeltsSceneFlowService;
+import java.math.BigDecimal;
+import java.lang.reflect.Method;
+import java.lang.reflect.InvocationTargetException;
+import java.time.Instant;
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class EvaluationProcessorReadPathTest {
+
+	private final PronunciationAssessmentClient pronunciationClient =
+			mock(PronunciationAssessmentClient.class);
+	private final EvaluationLlmClient llmClient = mock(EvaluationLlmClient.class);
+	private final ActiveSessionRegistry activeSessions = mock(ActiveSessionRegistry.class);
+	private final SceneRepository sceneRepository = mock(SceneRepository.class);
+	private final SessionMessageRepository messageRepository =
+			mock(SessionMessageRepository.class);
+	private final TurnEvaluationRepository turnRepository =
+			mock(TurnEvaluationRepository.class);
+	private final SessionEvaluationRepository reportRepository =
+			mock(SessionEvaluationRepository.class);
+	private final SceneSentenceReadingRepository sentenceRepository =
+			mock(SceneSentenceReadingRepository.class);
+	private final IeltsPracticeRepository practiceRepository =
+			mock(IeltsPracticeRepository.class);
+	private final IeltsRepository ieltsRepository = mock(IeltsRepository.class);
+	private final IeltsSceneFlowService sceneFlowService =
+			mock(IeltsSceneFlowService.class);
+	private final PracticeSessionRepository practiceSessionRepository =
+			mock(PracticeSessionRepository.class);
+	private final IeltsEvaluationRepository ieltsEvaluationRepository =
+			mock(IeltsEvaluationRepository.class);
+	private final IeltsEvaluationLlmClient ieltsLlmClient =
+			mock(IeltsEvaluationLlmClient.class);
+	private final ObjectStorageProvider objectStorage =
+			mock(ObjectStorageProvider.class);
+	private final ObjectStorageProperties objectStorageProperties =
+			new ObjectStorageProperties();
+	private final RecordingStore recordingStore = mock(RecordingStore.class);
+	private final AuthService authService = mock(AuthService.class);
+	private EvaluationProcessor processor;
+
+	@BeforeEach
+	void setUp() {
+		processor = new EvaluationProcessor(
+				pronunciationClient, llmClient, activeSessions, sceneRepository,
+				messageRepository, turnRepository, reportRepository,
+				sentenceRepository, practiceRepository,
+				ieltsRepository, sceneFlowService,
+				practiceSessionRepository, ieltsEvaluationRepository,
+				ieltsLlmClient, authService,
+				objectStorage, objectStorageProperties,
+				recordingStore);
+	}
+
+	@Test
+	void rejectsIeltsEvaluationWhenRequestedSessionIsNotCompletedIeltsSession() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_1)));
+		when(practiceSessionRepository.findBySceneId("ielts-1")).thenReturn(List.of(
+				practiceSession("custom-session", userId, "ielts-1",
+						SceneType.CUSTOM_SCENE, SessionStatus.COMPLETED),
+				practiceSession("active-ielts", userId, "ielts-1",
+						SceneType.IELTS_SCENE, SessionStatus.ACTIVE)));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.generateIeltsEvaluation("ielts-1", "active-ielts"));
+
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, exception.errorCode());
+		verify(ieltsEvaluationRepository, never()).findPart(any());
+	}
+
+	@Test
+	void returnsCompletedDiagnosticPartFromCacheWithoutReevaluating() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_2)));
+		when(practiceSessionRepository.findBySceneId("ielts-1")).thenReturn(List.of(
+				practiceSession("session-1", userId, "ielts-1",
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		IeltsPartEvaluationEntity cached = cachedPart(
+				"ielts-1", "session-1", IeltsPart.PART_2);
+		when(ieltsEvaluationRepository.findPart("session-1"))
+				.thenReturn(Optional.of(cached));
+
+		var result = processor.generateIeltsEvaluation("ielts-1", "session-1");
+
+		assertEquals(IeltsPart.PART_2, result.part());
+		assertEquals("DIAGNOSTIC", result.assessmentType());
+		assertEquals(new BigDecimal("7.0"), result.fluencyCoherenceScore());
+		assertEquals(List.of("能够展开"), result.strengths());
+		assertEquals(List.of("增加细节"), result.improvements());
+		assertEquals(List.of("A clearer answer."), result.recommendedExpressions());
+		verify(ieltsLlmClient, never()).assessPart(any(), any(), any(), any());
+		verify(ieltsEvaluationRepository, never()).savePart(any(), any(), any());
+	}
+
+	@Test
+	void aggregatesFinalMockWithPerPartFallbackWhenTextProviderFails() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-mock-1";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(
+						ieltsId, userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+						"topic-1", "topic-2", "topic-3",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		List<PracticeSessionRecord> sessions = List.of(
+				practiceSession("session-1", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("session-2", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("session-3", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(sessions);
+		when(ieltsEvaluationRepository.findFinal(ieltsId)).thenReturn(Optional.empty());
+		when(ieltsEvaluationRepository.findPart(any())).thenReturn(Optional.empty());
+		when(ieltsLlmClient.assessPart(any(), any(), any(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_CALL_FAILED));
+		for (PracticeSessionRecord session : sessions) {
+			when(messageRepository.findMessages(session.sessionId())).thenReturn(List.of(
+					new Message(0, "Tell me about this topic.", null),
+					new Message(1, "I can explain this topic with several details.", null)));
+			when(turnRepository.findAll(session.sessionId())).thenReturn(List.of(
+					scorableTurn(ieltsId, session.sessionId())));
+		}
+
+		var result = processor.generateIeltsEvaluation(ieltsId, "session-3");
+
+		assertEquals("FINAL", result.assessmentType());
+		assertEquals(3, result.partEvaluations().size());
+		assertEquals(new BigDecimal("7.0"),
+				result.partEvaluations().getFirst().fluencyCoherenceScore());
+		assertEquals(new BigDecimal("7.0"),
+				result.partEvaluations().getFirst().pronunciationScore());
+		assertTrue(result.partEvaluations().getFirst().summary()
+				.contains("临时诊断分"));
+		assertEquals(List.of("A more natural expression."),
+				result.recommendedExpressions());
+		verify(ieltsEvaluationRepository).saveFinal(eq(ieltsId), eq(result));
+		verify(practiceRepository).incrementCompletedCount(userId);
+	}
+
+	@Test
+	void keepsPartEvaluationUnavailableWhenFallbackHasNoScorableTurns() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-mock-empty";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(
+						ieltsId, userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+						null, null, null, new IeltsContent(List.of(), List.of(), List.of()))));
+		List<PracticeSessionRecord> sessions = List.of(
+				practiceSession("empty-1", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("empty-2", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("empty-3", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(sessions);
+		when(ieltsEvaluationRepository.findFinal(ieltsId)).thenReturn(Optional.empty());
+		when(ieltsEvaluationRepository.findPart(any())).thenReturn(Optional.empty());
+		when(ieltsLlmClient.assessPart(any(), any(), any(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_CALL_FAILED));
+		for (PracticeSessionRecord session : sessions) {
+			when(messageRepository.findMessages(session.sessionId())).thenReturn(List.of(
+					new Message(1, "I answered this question.", null)));
+			when(turnRepository.findAll(session.sessionId())).thenReturn(List.of());
+		}
+
+		var result = processor.generateIeltsEvaluation(ieltsId, "empty-3");
+
+		assertEquals(3, result.partEvaluations().size());
+		assertTrue(result.partEvaluations().stream()
+				.allMatch(part -> part.fluencyCoherenceScore() == null
+						&& part.pronunciationScore() == null));
+		assertTrue(result.fluencyCoherenceReason().contains("均缺少有效"));
+	}
+
+	@Test
+	void resolvesIeltsPartFromSceneFlowWhenPracticeAndSessionHaveNoPartMetadata() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-flow";
+		String sessionId = "ielts-flow-session";
+		CustomSceneSession session = session(sessionId, ieltsId, userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(
+						ieltsId, userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+						null, null, null, new IeltsContent(List.of(), List.of(), List.of()))));
+		when(activeSessions.findById(sessionId)).thenReturn(Optional.of(session));
+		when(sceneFlowService.current(ieltsId))
+				.thenReturn(com.unispeaking.domain.vo.scene.IeltsStage.PART2);
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of());
+		when(turnRepository.findBefore(sessionId, 1)).thenReturn(List.of());
+		when(pronunciationClient.evaluate(any(), any()))
+				.thenReturn(completeAssessment());
+		when(llmClient.assessTurn(any())).thenReturn(new TurnLanguageFeedback(
+				"反馈", "Try a more precise expression."));
+
+		var result = processor.evaluateIeltsTurn(ieltsId,
+				new DialogueTurnEvaluationCommand(
+						sessionId, 1, canonicalWav(),
+						"I would like to explain this topic in several detailed sentences."));
+
+		assertEquals("反馈", result.feedbackSummary());
+		verify(llmClient).assessTurn(any());
+	}
+
+	@Test
+	void evaluatesOwnedSentenceAndPersistsAttempt() {
+		byte[] audio = canonicalWav();
+		LearningContentItem sentence = new LearningContentItem(
+				"sentence-1", "The project improved our response time.", "项目提升了响应速度", null);
+		when(sentenceRepository.findSceneIdBySentenceId("sentence-1"))
+				.thenReturn(Optional.of("scene-1"));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", sentence)));
+		when(pronunciationClient.evaluate(sentence.englishText(), audio))
+				.thenReturn(new PronunciationAssessmentResult(
+						new BigDecimal("80"), null, null, null, null, null,
+						EndingTone.UNKNOWN, List.of()));
+
+		var response = processor.evaluateSentenceReading("sentence-1", audio);
+
+		assertEquals(new BigDecimal("80"), response.overallScore());
+		assertTrue(response.passed());
+		assertTrue(response.words().isEmpty());
+		verify(sentenceRepository).saveAttempt("scene-1", sentence,
+				new PronunciationAssessmentResult(
+						new BigDecimal("80"), null, null, null, null, null,
+						EndingTone.UNKNOWN, List.of()));
+	}
+
+	@Test
+	void rejectsSentenceOutsideCurrentUsersSceneBeforeCallingProvider() {
+		when(sentenceRepository.findSceneIdBySentenceId("sentence-1"))
+				.thenReturn(Optional.of("scene-1"));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-2", null)));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateSentenceReading("sentence-1", canonicalWav()));
+
+		assertEquals(EvaluationErrorCode.SENTENCE_NOT_FOUND, exception.errorCode());
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void returnsPersistedDialogueAndMapsTurnScoresForOwnedScene() {
+		when(messageRepository.findSceneId("session-1")).thenReturn(Optional.of("scene-1"));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(messageRepository.findMessages("session-1"))
+				.thenReturn(List.of(new Message(1, "I improved the service latency.", null)));
+		when(turnRepository.findAll("session-1")).thenReturn(List.of(turn()));
+
+		var result = processor.getDialogueEvaluation("session-1");
+
+		assertEquals(1, result.dialogue().size());
+		assertEquals(1, result.turnEvaluation().size());
+		assertEquals("I improved the service latency.",
+				result.turnEvaluation().getFirst().transcript());
+		assertEquals(new BigDecimal("82"), result.turnEvaluation().getFirst().overallScore());
+	}
+
+	@Test
+	void rejectsDialogueReadWhenNoPersistedSceneCanBeFound() {
+		when(messageRepository.findSceneId("missing")).thenReturn(Optional.empty());
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.getDialogueEvaluation("missing"));
+
+		assertEquals(EvaluationErrorCode.RESULT_NOT_FOUND, exception.errorCode());
+	}
+
+	@Test
+	void rejectsDialogueReadWhenOwnedSceneHasNeitherMessagesNorTurns() {
+		when(messageRepository.findSceneId("session-1")).thenReturn(Optional.of("scene-1"));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(messageRepository.findMessages("session-1")).thenReturn(List.of());
+		when(turnRepository.findAll("session-1")).thenReturn(List.of());
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.getDialogueEvaluation("session-1"));
+
+		assertEquals(EvaluationErrorCode.RESULT_NOT_FOUND, exception.errorCode());
+	}
+
+	@Test
+	void persistsUnavailableResultWhenOwnedDialogueHasNoAudio() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				"session-1", 1, null,
+				"I designed the cache to reduce repeated database reads."));
+
+		assertEquals(1, result.turnNo());
+		assertFalse(result.feedbackSummary().isBlank());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(pronunciationClient, never()).evaluate(any(), any());
+		verify(llmClient, never()).assessTurn(any());
+	}
+
+	@Test
+	void mapsInvalidDialogueAudioToDurableUnavailableResult() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				"session-1", 1, new byte[]{1, 2, 3},
+				"I designed the cache to reduce repeated database reads."));
+
+		assertEquals("本轮评分暂不可用，已保留对话内容", result.feedbackSummary());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void persistsTooShortDialogueWithoutCallingSpeechOrLanguageProviders() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				"session-1", 1, canonicalWav(), "Hello"));
+
+		assertEquals(1, result.turnNo());
+		assertFalse(result.feedbackSummary().isBlank());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(pronunciationClient, never()).evaluate(any(), any());
+		verify(llmClient, never()).assessTurn(any());
+	}
+
+	@Test
+	void rejectsDialogueTurnWhenRuntimeSessionIsMissing() {
+		when(activeSessions.findById("missing")).thenReturn(Optional.empty());
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+						"missing", 1, null,
+						"I designed the cache to reduce repeated database reads.")));
+
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, exception.errorCode());
+		verify(turnRepository, never()).upsert(any());
+	}
+
+	@Test
+	void rejectsUnknownSentenceBeforeResolvingSceneOwnership() {
+		when(sentenceRepository.findSceneIdBySentenceId("missing"))
+				.thenReturn(Optional.empty());
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateSentenceReading("missing", canonicalWav()));
+
+		assertEquals(EvaluationErrorCode.SENTENCE_NOT_FOUND, exception.errorCode());
+		verify(sceneRepository, never()).findCustomDefinitionById(any());
+	}
+
+	@Test
+	void preservesIeltsTurnWhenRecordingAttachmentFailsAndCleansStoredAudio() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-1";
+		CustomSceneSession session = session("session-ielts", ieltsId, userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById("session-ielts")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.PART_PRACTICE,
+						IeltsPart.PART_1, "topic-1",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		byte[] audio = canonicalWav();
+		when(recordingStore.store("session-ielts", 1, audio))
+				.thenReturn("https://audio.example/session-ielts.wav");
+		org.mockito.Mockito.doThrow(new IllegalStateException("write failed"))
+				.when(messageRepository).attachLearnerAudioUrl(
+						"session-ielts", 1,
+						"https://audio.example/session-ielts.wav");
+
+		var result = processor.evaluateIeltsTurn(ieltsId,
+				new DialogueTurnEvaluationCommand("session-ielts", 1, audio, "Hello"));
+
+		assertEquals(1, result.turnNo());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(recordingStore).store("session-ielts", 1, audio);
+		verify(recordingStore).delete("session-ielts", 1);
+	}
+
+	@Test
+	void returnsFullDialogueTurnFeedbackAndPersistsDetailedPronunciation() {
+		byte[] audio = canonicalWav();
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(messageRepository.findMessages("session-1")).thenReturn(List.of(
+				new Message(0, "Please describe your database optimization work.", null)));
+		when(turnRepository.findBefore("session-1", 1)).thenReturn(List.of());
+		when(pronunciationClient.evaluate(
+				"I added an index and reduced repeated database reads.", audio))
+				.thenReturn(completeAssessment());
+		when(llmClient.assessTurn(any())).thenReturn(new TurnLanguageFeedback(
+				"表达清晰，可以补充量化结果。", "I reduced database reads by adding an index."));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				"session-1", 1, audio,
+				"I added an index and reduced repeated database reads."));
+
+		assertEquals(new BigDecimal("86"), result.overallScore());
+		assertEquals("表达清晰，可以补充量化结果。", result.feedbackSummary());
+		assertEquals(1, result.words().size());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+	}
+
+	@Test
+	void generatesDialogueReportFromStoredSpeechAndLanguageAssessment() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(reportRepository.find("session-1")).thenReturn(Optional.empty());
+		List<Message> dialogue = List.of(
+				new Message(0, "What did you improve?", null),
+				new Message(1, "I added an index and reduced repeated database reads.", null));
+		when(turnRepository.findAll("session-1")).thenReturn(List.of(turn()));
+		when(llmClient.assessDialogue(dialogue)).thenReturn(
+				new ConversationLanguageAssessment(new BigDecimal("88"),
+						new BigDecimal("84"), new BigDecimal("86"), "报告已生成",
+						List.of("结构清晰"), List.of("补充量化结果")));
+
+		var report = processor.generateDialogueReport("session-1", dialogue);
+
+		assertEquals("报告已生成", report.summary());
+		assertEquals(new BigDecimal("88.0"), report.grammarScore());
+		assertEquals(new BigDecimal("84.0"), report.vocabularyScore());
+		assertTrue(report.finalScore().compareTo(BigDecimal.ZERO) > 0);
+		verify(reportRepository).save(eq("scene-1"), eq("session-1"), eq(report));
+	}
+
+	@Test
+	void mapsRecoverableIeltsTurnFailureToUnavailableResult() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-1";
+		CustomSceneSession session = session("session-ielts", ieltsId, userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById("session-ielts")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.PART_PRACTICE,
+						IeltsPart.PART_1, "topic-1",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+
+		var result = processor.evaluateIeltsTurn(ieltsId,
+				new DialogueTurnEvaluationCommand("session-ielts", 1,
+						new byte[]{1, 2, 3},
+						"I added an index and reduced repeated database reads."));
+
+		assertEquals("本轮评分暂不可用，已保留对话内容", result.feedbackSummary());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void evaluatesSpeechAndTrimsReferenceBeforeCallingProvider() {
+		when(pronunciationClient.evaluate(eq("hello world"), any()))
+				.thenReturn(completeAssessment());
+
+		var result = processor.evaluateSpeech(
+				new SpeechEvaluationCommand("  hello world  ", canonicalWav()));
+
+		assertTrue(result.accuracyScore().compareTo(BigDecimal.ZERO) > 0);
+		assertTrue(result.fluencyScore().compareTo(BigDecimal.ZERO) > 0);
+		verify(pronunciationClient).evaluate(eq("hello world"), any());
+	}
+
+	@Test
+	void rejectsSpeechRequestsBeforeProviderForMissingReferenceOrInvalidAudio() {
+		EvaluationException missing = assertThrows(EvaluationException.class,
+				() -> processor.evaluateSpeech(new SpeechEvaluationCommand(" ", canonicalWav())));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, missing.errorCode());
+
+		EvaluationException invalidAudio = assertThrows(EvaluationException.class,
+				() -> processor.evaluateSpeech(new SpeechEvaluationCommand("hello", new byte[]{1, 2})));
+		assertEquals(EvaluationErrorCode.AUDIO_UNSUPPORTED, invalidAudio.errorCode());
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void returnsCachedDialogueReportWithoutCallingProvidersOrSavingAgain() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		var cached = new com.unispeaking.domain.dto.evaluation.DialogueReportResult(
+				new BigDecimal("80"), new BigDecimal("81"), new BigDecimal("82"),
+				new BigDecimal("83"), new BigDecimal("84"), new BigDecimal("83"),
+				"cached", List.of(), List.of());
+		when(reportRepository.find("session-1")).thenReturn(Optional.of(cached));
+
+		var result = processor.generateDialogueReport("session-1", List.of(
+				new Message(1, "already evaluated", null)));
+
+		assertEquals(cached, result);
+		verify(llmClient, never()).assessDialogue(any());
+		verify(reportRepository, never()).save(any(), any(), any());
+	}
+
+	@Test
+	void persistsUnavailableReportWhenNoScorableTurnsExist() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(reportRepository.find("session-1")).thenReturn(Optional.empty());
+		when(turnRepository.findAll("session-1")).thenReturn(List.of());
+		List<Message> dialogue = List.of(new Message(1, "short", null));
+
+		var result = processor.generateDialogueReport("session-1", dialogue);
+
+		assertFalse(result.summary().isBlank());
+		verify(reportRepository).save(eq("scene-1"), eq("session-1"), eq(result));
+		verify(llmClient, never()).assessDialogue(any());
+	}
+
+	@Test
+	void fallsBackToPersistedTurnScoresWhenLanguageProviderIsUnavailable() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		when(reportRepository.find("session-1")).thenReturn(Optional.empty());
+		when(turnRepository.findAll("session-1")).thenReturn(List.of(turn()));
+		List<Message> dialogue = List.of(
+				new Message(0, "What improved?", null),
+				new Message(1, "I improved latency.", null));
+		when(llmClient.assessDialogue(dialogue))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_CALL_FAILED));
+
+		var result = processor.generateDialogueReport("session-1", dialogue);
+
+		assertTrue(result.summary().contains("语言模型文字报告暂不可用"));
+		assertTrue(result.finalScore().compareTo(BigDecimal.ZERO) > 0);
+		verify(reportRepository).save(eq("scene-1"), eq("session-1"), eq(result));
+	}
+
+	@Test
+	void validatesDialogueBeforeLookingUpRuntimeSession() {
+		EvaluationException invalid = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport("session-1", List.of()));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, invalid.errorCode());
+		verify(activeSessions).findById(any());
+	}
+
+	@Test
+	void rejectsNullOrNonPositiveIeltsTurnCommandsBeforeSessionLookup() {
+		EvaluationException nullCommand = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1", null));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, nullCommand.errorCode());
+		EvaluationException invalidTurn = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1",
+						new DialogueTurnEvaluationCommand("session-1", 0, null, "hello")));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, invalidTurn.errorCode());
+		verify(activeSessions, never()).findById(any());
+	}
+
+	@Test
+	void evaluatesAndCachesPartPracticeWithPartTwoCueCard() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-part-two";
+		String sessionId = "part-two-session";
+		IeltsContent content = new IeltsContent(
+				List.of(),
+				List.of(new IeltsContentQuestion(
+						"Describe a useful object.",
+						List.of("what it is", "why it is useful"),
+						List.of())),
+				List.of());
+		IeltsPracticeRecord practice = new IeltsPracticeRecord(
+				ieltsId, userId, IeltsMode.PART_PRACTICE, IeltsPart.PART_2,
+				"topic-2", content);
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(practice));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(List.of(
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.empty());
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of(
+				new Message(0, "Describe a useful object.", null),
+				new Message(1, "This laptop helps me study every day.", null)));
+		when(turnRepository.findAll(sessionId)).thenReturn(List.of(scorableTurn(ieltsId, sessionId)));
+		IeltsTextAssessment assessment = new IeltsTextAssessment(
+				IeltsPart.PART_2, new BigDecimal("7.0"), new BigDecimal("6.5"),
+				new BigDecimal("6.0"), "流利", "词汇", "语法", "分析完成",
+				List.of("展开自然"), List.of("补充例子"), "HIGH");
+		when(ieltsLlmClient.assessPart(any(), any(), any(), any()))
+				.thenReturn(assessment);
+
+		var result = processor.generateIeltsEvaluation(ieltsId, sessionId);
+
+		assertAll(
+				() -> assertEquals(IeltsPart.PART_2, result.part()),
+				() -> assertEquals(new BigDecimal("7.0"), result.fluencyCoherenceScore()),
+				() -> assertEquals(new BigDecimal("7.0"), result.pronunciationScore()),
+				() -> assertTrue(result.summary().contains("分析完成")));
+		verify(ieltsEvaluationRepository).savePart(ieltsId, sessionId, result);
+		verify(practiceRepository).incrementCompletedCount(userId);
+	}
+
+	@Test
+	void derivesPartFromCompletedSessionOrderWhenPracticeHasNoSelectedPart() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-derived-part";
+		String sessionId = "derived-part-session";
+		IeltsContent content = new IeltsContent(
+				List.of(),
+				List.of(new IeltsContentQuestion(
+						"Describe a useful object.", List.of(), List.of())),
+				List.of());
+		IeltsPracticeRecord practice = new IeltsPracticeRecord(
+				ieltsId, userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+				"topic-1", "topic-2", "topic-3", content);
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(practice));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(List.of(
+				practiceSession("first-session", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.empty());
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of(
+				new Message(1, "This laptop helps me study every day.", null)));
+		when(turnRepository.findAll(sessionId)).thenReturn(List.of());
+		when(ieltsLlmClient.assessPart(eq(IeltsPart.PART_2), any(), eq("Describe a useful object."), eq(null)))
+				.thenReturn(new IeltsTextAssessment(
+						IeltsPart.PART_2, new BigDecimal("6.5"), new BigDecimal("6.0"),
+						new BigDecimal("6.0"), "流利", "词汇", "语法", "按顺序推导",
+						List.of(), List.of(), "LOW"));
+
+		var result = processor.generateIeltsEvaluation(ieltsId, sessionId);
+
+		assertEquals(IeltsPart.PART_2, result.part());
+		verify(ieltsLlmClient).assessPart(
+				eq(IeltsPart.PART_2), any(), eq("Describe a useful object."), eq(null));
+	}
+
+	@Test
+	void formatsPartTwoCueCardWithoutCuePoints() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-empty-cue-points";
+		String sessionId = "empty-cue-session";
+		IeltsPracticeRecord practice = new IeltsPracticeRecord(
+				ieltsId, userId, IeltsMode.PART_PRACTICE, IeltsPart.PART_2,
+				"topic-2", new IeltsContent(
+						List.of(),
+						List.of(new IeltsContentQuestion(
+								"Talk about a memorable meal.", List.of(), List.of())),
+						List.of()));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(practice));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(List.of(
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.empty());
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of(
+				new Message(0, "Talk about a memorable meal.", null),
+				new Message(1, "I remember a family dinner last summer.", null)));
+		when(turnRepository.findAll(sessionId)).thenReturn(List.of());
+		when(ieltsLlmClient.assessPart(
+				eq(IeltsPart.PART_2), any(), eq("Talk about a memorable meal."), eq(null)))
+				.thenReturn(new IeltsTextAssessment(
+						IeltsPart.PART_2, new BigDecimal("6.5"), new BigDecimal("6.0"),
+						new BigDecimal("6.0"), "流利", "词汇", "语法", "无提示点",
+						List.of(), List.of(), "LOW"));
+
+		var result = processor.generateIeltsEvaluation(ieltsId, sessionId);
+
+		assertTrue(result.summary().startsWith("无提示点"));
+	}
+
+	@Test
+	void rejectsIeltsPartWithoutCandidateAnswerBeforeCallingTextProvider() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-no-answer";
+		String sessionId = "no-answer-session";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				partPractice(ieltsId, userId, IeltsPart.PART_1)));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(List.of(
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.empty());
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of(
+				new Message(0, "Please answer this question.", null)));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.generateIeltsEvaluation(ieltsId, sessionId));
+
+		assertEquals(EvaluationErrorCode.NO_SCORABLE_UTTERANCES, exception.errorCode());
+		verify(ieltsLlmClient, never()).assessPart(any(), any(), any(), any());
+	}
+
+	@Test
+	void preservesIeltsTranscriptWhenAudioIsMissing() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("missing-audio-ielts", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_1)));
+
+		var result = processor.evaluateIeltsTurn("ielts-1",
+				new DialogueTurnEvaluationCommand(
+						session.getId(), 1, null,
+						"I would like to explain this topic in several detailed sentences."));
+
+		assertEquals("本轮评分暂不可用，已保留对话内容", result.feedbackSummary());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void propagatesNonRecoverableIeltsPronunciationFailure() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("nonrecoverable-ielts", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_1)));
+		when(pronunciationClient.evaluate(any(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.INVALID_REQUEST));
+		when(recordingStore.store(eq(session.getId()), eq(1), any()))
+				.thenReturn("https://audio.example/nonrecoverable.wav");
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1",
+						new DialogueTurnEvaluationCommand(
+								session.getId(), 1, canonicalWav(),
+								"I would like to explain this topic in several detailed sentences.")));
+
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, exception.errorCode());
+		verify(turnRepository, never()).upsert(any());
+	}
+
+	@Test
+	void rejectsIeltsTurnWhenLegacySessionFlowIsAlreadyCompleted() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("completed-flow-ielts", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				new IeltsPracticeRecord(
+						"ielts-1", userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+						null, null, null, new IeltsContent(List.of(), List.of(), List.of()))));
+		when(pronunciationClient.evaluate(any(), any())).thenReturn(completeAssessment());
+		when(sceneFlowService.current("ielts-1"))
+				.thenReturn(com.unispeaking.domain.vo.scene.IeltsStage.COMPLETED);
+		when(recordingStore.store(eq(session.getId()), eq(1), any()))
+				.thenReturn("https://audio.example/completed.wav");
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1",
+						new DialogueTurnEvaluationCommand(
+								session.getId(), 1, canonicalWav(),
+								"I would like to explain this topic in several detailed sentences.")));
+
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, exception.errorCode());
+		verify(pronunciationClient).evaluate(any(), any());
+	}
+
+	@Test
+	void ignoresIncompleteCachedPartAndReevaluatesIt() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-incomplete-cache";
+		String sessionId = "incomplete-cache-session";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				partPractice(ieltsId, userId, IeltsPart.PART_1)));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(List.of(
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		IeltsPartEvaluationEntity incomplete = cachedPart(ieltsId, sessionId, IeltsPart.PART_1);
+		incomplete.setEvaluationStatus("FAILED");
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.of(incomplete));
+		when(messageRepository.findMessages(sessionId)).thenReturn(List.of(
+				new Message(1, "I enjoy reading books.", null)));
+		when(turnRepository.findAll(sessionId)).thenReturn(List.of());
+		when(ieltsLlmClient.assessPart(any(), any(), eq(null), eq(null)))
+				.thenReturn(new IeltsTextAssessment(
+						IeltsPart.PART_1, new BigDecimal("6.5"), new BigDecimal("6.0"),
+						new BigDecimal("6.0"), "流利", "词汇", "语法", "重新评估",
+						List.of(), List.of(), "MEDIUM"));
+
+		var result = processor.generateIeltsEvaluation(ieltsId, sessionId);
+
+		assertTrue(result.summary().startsWith("重新评估"));
+		verify(ieltsLlmClient).assessPart(any(), any(), eq(null), eq(null));
+		verify(ieltsEvaluationRepository).savePart(ieltsId, sessionId, result);
+	}
+
+	@Test
+	void returnsCompletedCachedFinalMockEvaluationAndMapsPartResults() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "ielts-cached-final";
+		List<PracticeSessionRecord> sessions = List.of(
+				practiceSession("cached-1", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("cached-2", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("cached-3", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.MOCK_TEST, null, null,
+						"RANDOM", "topic-1", "topic-2", "topic-3",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(sessions);
+		IeltsEvaluationEntity cached = cachedFinal(ieltsId);
+		when(ieltsEvaluationRepository.findFinal(ieltsId)).thenReturn(Optional.of(cached));
+		when(ieltsEvaluationRepository.findParts(ieltsId)).thenReturn(List.of(
+				cachedPart(ieltsId, "cached-1", IeltsPart.PART_1)));
+
+		var result = processor.generateIeltsEvaluation(ieltsId, "cached-3");
+
+		assertAll(
+				() -> assertEquals("FINAL", result.assessmentType()),
+				() -> assertEquals(new BigDecimal("7.0"), result.overallBandScore()),
+				() -> assertEquals(1, result.partEvaluations().size()),
+				() -> assertEquals(List.of("优势"), result.strengths()),
+				() -> assertEquals(List.of("改进"), result.improvements()),
+				() -> assertEquals(List.of("Use detail."), result.recommendedExpressions()));
+		verify(ieltsEvaluationRepository, never()).saveFinal(any(), any());
+		verify(ieltsLlmClient, never()).assessPart(any(), any(), any(), any());
+	}
+
+	@Test
+	void buildsIeltsHistoryWithMockAndPartRecordsAndSignedRecordingFallback() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String mockId = "history-mock";
+		String partId = "history-part";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceSessionRepository.findCompletedByUserAndSceneType(
+				eq(userId), eq(SceneType.IELTS_SCENE))).thenReturn(List.of(
+				practiceSession("history-mock-1", userId, mockId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("history-mock-2", userId, mockId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("history-mock-3", userId, mockId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("history-part-1", userId, partId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		IeltsPracticeRecord mockPractice = new IeltsPracticeRecord(
+				mockId, userId, IeltsMode.MOCK_TEST, null, null, "RANDOM",
+				"topic-1", "topic-2", "topic-missing", new IeltsContent(List.of(), List.of(), List.of()));
+		IeltsPracticeRecord partPractice = partPractice(partId, userId, IeltsPart.PART_1);
+		when(practiceRepository.findPractice(mockId)).thenReturn(Optional.of(mockPractice));
+		when(practiceRepository.findPractice(partId)).thenReturn(Optional.of(partPractice));
+		when(ieltsRepository.findTopicsByIds(any())).thenReturn(List.of(
+				new IeltsTopic("topic-1", "Work", null, null, null, null),
+				new IeltsTopic("topic-2", "Travel", null, null, null, null)));
+		when(ieltsEvaluationRepository.findFinal(mockId)).thenReturn(Optional.of(cachedFinal(mockId)));
+		when(ieltsEvaluationRepository.findParts(mockId)).thenReturn(List.of(
+				cachedPart(mockId, "history-mock-1", IeltsPart.PART_1)));
+		when(ieltsEvaluationRepository.findPart("history-part-1"))
+				.thenReturn(Optional.of(cachedPart(partId, "history-part-1", IeltsPart.PART_1)));
+		when(messageRepository.findAudioUrls(any())).thenReturn(List.of());
+		when(objectStorage.available()).thenReturn(true);
+		when(messageRepository.findAudioObjectKeys(any())).thenReturn(List.of("audio/key.wav"));
+		when(objectStorage.signGetUrl(eq("audio/key.wav"), any()))
+				.thenReturn(URI.create("https://cdn.example/audio.wav"));
+
+		var history = processor.getIeltsEvaluationHistory();
+
+		assertEquals(2, history.size());
+		assertAll(
+				() -> assertEquals("FINAL", history.get(0).assessmentType()),
+				() -> assertEquals("DIAGNOSTIC", history.get(1).assessmentType()),
+				() -> assertEquals("Work", history.get(0).topicTitles().get(IeltsPart.PART_1)),
+				() -> assertEquals("topic-missing", history.get(0).topicTitles().get(IeltsPart.PART_3)),
+				() -> assertEquals(
+						List.of("https://cdn.example/audio.wav",
+								"https://cdn.example/audio.wav",
+								"https://cdn.example/audio.wav"),
+						history.get(0).recordingUrls()));
+	}
+
+	@Test
+	void handlesUnavailableStorageAndSigningFailuresWhenReadingHistory() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "history-storage";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceSessionRepository.findCompletedByUserAndSceneType(eq(userId), eq(SceneType.IELTS_SCENE)))
+				.thenReturn(List.of(practiceSession("storage-session", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				partPractice(ieltsId, userId, IeltsPart.PART_1)));
+		when(ieltsRepository.findTopicsByIds(any())).thenReturn(List.of());
+		when(ieltsEvaluationRepository.findPart("storage-session"))
+				.thenReturn(Optional.of(cachedPart(ieltsId, "storage-session", IeltsPart.PART_1)));
+		when(messageRepository.findAudioUrls("storage-session")).thenReturn(List.of());
+		when(objectStorage.available()).thenReturn(true);
+		when(messageRepository.findAudioObjectKeys("storage-session"))
+				.thenReturn(List.of("bad-key", "good-key"));
+		when(objectStorage.signGetUrl(eq("bad-key"), any()))
+				.thenThrow(new IllegalStateException("sign failed"));
+		when(objectStorage.signGetUrl(eq("good-key"), any()))
+				.thenReturn(URI.create("https://cdn.example/good.wav"));
+
+		var history = processor.getIeltsEvaluationHistory();
+
+		assertEquals(List.of("https://cdn.example/good.wav"), history.getFirst().recordingUrls());
+	}
+
+	@Test
+	void storesAndAttachesValidIeltsRecordingAfterUnavailableScoring() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("session-ielts", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById("session-ielts")).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				new IeltsPracticeRecord("ielts-1", userId, IeltsMode.PART_PRACTICE,
+						IeltsPart.PART_1, "topic-1", new IeltsContent(List.of(), List.of(), List.of()))));
+		byte[] audio = canonicalWav();
+		when(recordingStore.store("session-ielts", 1, audio)).thenReturn("https://audio.example/turn.wav");
+
+		var result = processor.evaluateIeltsTurn("ielts-1",
+				new DialogueTurnEvaluationCommand("session-ielts", 1, audio, "Hello"));
+
+		assertEquals(1, result.turnNo());
+		verify(recordingStore).store("session-ielts", 1, audio);
+		verify(messageRepository).attachLearnerAudioUrl("session-ielts", 1, "https://audio.example/turn.wav");
+		verify(recordingStore, never()).delete(any(), anyInt());
+	}
+
+	@Test
+	void rejectsBlankTranscriptAndInvalidTurnNumberBeforeProvider() {
+		EvaluationException blank = assertThrows(EvaluationException.class,
+				() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+						"session-1", 1, null, "  ")));
+		assertEquals(EvaluationErrorCode.TRANSCRIPT_REQUIRED, blank.errorCode());
+		EvaluationException zero = assertThrows(EvaluationException.class,
+				() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+						"session-1", 0, null, "hello")));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, zero.errorCode());
+		verify(activeSessions, never()).findById(any());
+	}
+
+	@Test
+	void rejectsNullAndMalformedDialogueMessagesBeforeReadingOrScoring() {
+		CustomSceneSession session = session("invalid-dialogue", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+
+		EvaluationException nullOwner = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport(session.getId(), List.of(
+						new Message(null, "answer", null))));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, nullOwner.errorCode());
+
+		EvaluationException nullContent = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport(session.getId(), List.of(
+						new Message(1, null, null))));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, nullContent.errorCode());
+
+		EvaluationException blankContent = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport(session.getId(), List.of(
+						new Message(1, "  ", null))));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, blankContent.errorCode());
+		verify(reportRepository, never()).find(any());
+	}
+
+	@Test
+	void persistsUnavailableCustomTurnWhenPronunciationProviderFails() {
+		CustomSceneSession session = session("custom-provider-failure", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(pronunciationClient.evaluate(any(), any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.PROVIDER_CALL_FAILED));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				session.getId(), 1, canonicalWav(),
+				"I can explain this complete answer with several details."));
+
+		assertEquals("本轮评分暂不可用，已保留对话内容", result.feedbackSummary());
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(llmClient, never()).assessTurn(any());
+	}
+
+	@Test
+	void propagatesNonRecoverableCustomFeedbackFailureWithoutPersistingResult() {
+		CustomSceneSession session = session("custom-feedback-failure", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(pronunciationClient.evaluate(any(), any())).thenReturn(completeAssessment());
+		when(llmClient.assessTurn(any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.INVALID_REQUEST));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+						session.getId(), 1, canonicalWav(),
+						"I can explain this complete answer with several details.")));
+
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, exception.errorCode());
+		verify(turnRepository, never()).upsert(any(CustomTurnEvaluation.class));
+	}
+
+	@Test
+	void buildsCustomPromptHistoryAndRejectsMissingSceneDefinition() {
+		CustomSceneSession session = session("custom-history", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(messageRepository.findMessages(session.getId())).thenReturn(List.of(
+				new Message(0, "Earlier question", null),
+				new Message(1, "Earlier answer with enough words", null),
+				new Message(0, "Current question", null)));
+		when(turnRepository.findBefore(session.getId(), 2)).thenReturn(List.of(
+				scorableTurn("scene-1", session.getId())));
+		when(pronunciationClient.evaluate(any(), any())).thenReturn(completeAssessment());
+		when(llmClient.assessTurn(any())).thenReturn(new TurnLanguageFeedback(
+				"历史上下文已构造", "Use a more precise expression."));
+
+		var result = processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+				session.getId(), 2, canonicalWav(),
+				"I can explain the current question with enough detail."));
+
+		assertEquals("历史上下文已构造", result.feedbackSummary());
+		verify(llmClient).assessTurn(any());
+
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.empty());
+		EvaluationException missingScene = assertThrows(EvaluationException.class,
+				() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+						session.getId(), 3, canonicalWav(),
+						"I can explain another complete answer with details.")));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, missingScene.errorCode());
+	}
+
+	@Test
+	void rejectsIeltsBlankTranscriptAndNonRecoverableLanguageFeedbackFailure() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("ielts-nonrecoverable", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		session.setIeltsPart(IeltsPart.PART_1);
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_1)));
+
+		EvaluationException blank = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1",
+						new DialogueTurnEvaluationCommand(session.getId(), 1, null, " ")));
+		assertEquals(EvaluationErrorCode.TRANSCRIPT_REQUIRED, blank.errorCode());
+
+		when(pronunciationClient.evaluate(any(), any())).thenReturn(completeAssessment());
+		when(messageRepository.findMessages(session.getId())).thenReturn(List.of(
+				new Message(0, "What do you do?", null)));
+		when(llmClient.assessTurn(any()))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.INVALID_REQUEST));
+
+		EvaluationException providerFailure = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-1",
+						new DialogueTurnEvaluationCommand(session.getId(), 2,
+								canonicalWav(),
+								"I work in software and can explain my responsibilities.")));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, providerFailure.errorCode());
+		verify(turnRepository, never()).upsert(any(CustomTurnEvaluation.class));
+	}
+
+	@Test
+	void rejectsUnownedOrMissingIeltsPracticeBeforeEvaluation() {
+		UUID owner = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		UUID other = UUID.fromString("22222222-2222-4222-8222-222222222222");
+		when(authService.requireUserId(null)).thenReturn(owner.toString());
+		when(practiceRepository.findPractice("missing-ielts")).thenReturn(Optional.empty());
+		EvaluationException missing = assertThrows(EvaluationException.class,
+				() -> processor.generateIeltsEvaluation("missing-ielts", "session-1"));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, missing.errorCode());
+
+		when(practiceRepository.findPractice("other-ielts")).thenReturn(Optional.of(
+				partPractice("other-ielts", other, IeltsPart.PART_1)));
+		EvaluationException unowned = assertThrows(EvaluationException.class,
+				() -> processor.generateIeltsEvaluation("other-ielts", "session-1"));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, unowned.errorCode());
+		verify(practiceSessionRepository, never()).findBySceneId(any());
+	}
+
+	@Test
+	void backfillsMissingCustomTurnBeforeGeneratingProviderIndependentReport() {
+		CustomSceneSession session = session("backfill-success", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(reportRepository.find(session.getId())).thenReturn(Optional.empty());
+		when(turnRepository.findAll(session.getId())).thenReturn(List.of(turn()));
+		List<Message> dialogue = List.of(
+				new Message(0, "Question", null),
+				new Message(1, "First complete answer with details", null),
+				new Message(0, "Follow-up", null),
+				new Message(1, "Second complete answer with details", null));
+		when(llmClient.assessDialogue(dialogue))
+				.thenThrow(new EvaluationException(EvaluationErrorCode.RESULT_INCOMPLETE));
+
+		var result = processor.generateDialogueReport(session.getId(), dialogue);
+
+		assertTrue(result.summary().contains("语言模型文字报告暂不可用"));
+		verify(turnRepository).upsert(any(CustomTurnEvaluation.class));
+		verify(reportRepository).save(eq("scene-1"), eq(session.getId()), eq(result));
+	}
+
+	@Test
+	void rejectsDialogueReportWithInvalidMessageShapeAfterSessionLookup() {
+		CustomSceneSession session = session("session-1", "scene-1", "user-1");
+		when(activeSessions.findById("session-1")).thenReturn(Optional.of(session));
+		NullPointerException nullMessage = assertThrows(NullPointerException.class,
+				() -> processor.generateDialogueReport("session-1", java.util.Arrays.asList((Message) null)));
+		assertTrue(nullMessage.getMessage() == null || nullMessage.getMessage().isBlank());
+		EvaluationException noLearner = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport("session-1", List.of(
+						new Message(0, "examiner only", null))));
+		assertEquals(EvaluationErrorCode.NO_SCORABLE_UTTERANCES, noLearner.errorCode());
+	}
+
+	@Test
+	void skipsIncompleteOrMissingIeltsHistoryEntriesAndReturnsLatestMockScore() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String incompleteMock = "history-incomplete-mock";
+		String missingPractice = "history-missing-practice";
+		String completedMock = "history-completed-mock";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceSessionRepository.findCompletedByUserAndSceneType(
+				eq(userId), eq(SceneType.IELTS_SCENE))).thenReturn(List.of(
+				practiceSession("incomplete-1", userId, incompleteMock,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("missing-1", userId, missingPractice,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("completed-1", userId, completedMock,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("completed-2", userId, completedMock,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("completed-3", userId, completedMock,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(practiceRepository.findPractice(incompleteMock)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(incompleteMock, userId, IeltsMode.MOCK_TEST,
+						null, null, "RANDOM", null, null, null,
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		when(practiceRepository.findPractice(missingPractice)).thenReturn(Optional.empty());
+		when(practiceRepository.findPractice(completedMock)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(completedMock, userId, IeltsMode.MOCK_TEST,
+						null, null, "RANDOM", null, null, null,
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		when(ieltsRepository.findTopicsByIds(any())).thenReturn(List.of());
+		when(ieltsEvaluationRepository.findFinal(completedMock))
+				.thenReturn(Optional.of(cachedFinal(completedMock)));
+		when(ieltsEvaluationRepository.findParts(completedMock)).thenReturn(List.of());
+		when(messageRepository.findAudioUrls(any())).thenReturn(List.of());
+		when(objectStorage.available()).thenReturn(false);
+
+		assertEquals(new BigDecimal("7.0"), processor.getLatestIeltsEstimatedScore());
+		assertEquals(1, processor.getIeltsEvaluationHistory().size());
+	}
+
+	@Test
+	void skipsPartHistoryWithoutEvaluationAndMapsNullArraysAndStoredAudioUrls() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "history-null-fields";
+		String sessionId = "history-null-session";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceSessionRepository.findCompletedByUserAndSceneType(
+				eq(userId), eq(SceneType.IELTS_SCENE))).thenReturn(List.of(
+				practiceSession(sessionId, userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED)));
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				partPractice(ieltsId, userId, IeltsPart.PART_1)));
+		when(ieltsRepository.findTopicsByIds(any())).thenReturn(List.of());
+		when(ieltsEvaluationRepository.findPart(sessionId)).thenReturn(Optional.of(
+				cachedPartWithNullLists(ieltsId, sessionId, IeltsPart.PART_1)));
+		when(messageRepository.findAudioUrls(sessionId)).thenReturn(
+				List.of("https://stored.example/audio.wav"));
+
+		var history = processor.getIeltsEvaluationHistory();
+
+		assertEquals(1, history.size());
+		assertEquals(List.of(), history.getFirst().strengths());
+		assertEquals(List.of(), history.getFirst().improvements());
+		assertEquals(List.of(), history.getFirst().recommendedExpressions());
+		assertEquals(List.of("https://stored.example/audio.wav"),
+				history.getFirst().recordingUrls());
+	}
+
+	@Test
+	void reevaluatesIncompleteFinalCacheAndUsesPartScoresForFinalAverage() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String ieltsId = "incomplete-final-cache";
+		List<PracticeSessionRecord> sessions = List.of(
+				practiceSession("final-cache-1", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("final-cache-2", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED),
+				practiceSession("final-cache-3", userId, ieltsId,
+						SceneType.IELTS_SCENE, SessionStatus.COMPLETED));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.MOCK_TEST,
+						null, null, "RANDOM", null, null, null,
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		when(practiceSessionRepository.findBySceneId(ieltsId)).thenReturn(sessions);
+		IeltsEvaluationEntity incomplete = cachedFinal(ieltsId);
+		incomplete.setEvaluationStatus("FAILED");
+		when(ieltsEvaluationRepository.findFinal(ieltsId)).thenReturn(Optional.of(incomplete));
+		when(ieltsEvaluationRepository.findPart(any())).thenReturn(Optional.empty());
+		when(ieltsLlmClient.assessPart(any(), any(), any(), any()))
+				.thenReturn(new IeltsTextAssessment(
+					IeltsPart.PART_1, new BigDecimal("6.5"), new BigDecimal("6.0"),
+					new BigDecimal("5.5"), "流利", "词汇", "语法", "已完成",
+					List.of("strength"), List.of("improvement"), "MEDIUM"));
+		for (PracticeSessionRecord session : sessions) {
+			when(messageRepository.findMessages(session.sessionId())).thenReturn(List.of(
+					new Message(0, "Question", null),
+					new Message(1, "I can answer this question in detail.", null)));
+			when(turnRepository.findAll(session.sessionId())).thenReturn(List.of());
+		}
+
+		var result = processor.generateIeltsEvaluation(ieltsId, "final-cache-3");
+
+		assertEquals("FINAL", result.assessmentType());
+		assertEquals(new BigDecimal("6.0"), result.overallBandScore());
+		verify(ieltsEvaluationRepository).saveFinal(ieltsId, result);
+		verify(practiceRepository).incrementCompletedCount(userId);
+	}
+
+	@Test
+	void coversIeltsTurnTooShortFeedbackFailureAndRecommendedPromptContext() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("ielts-prompt", "ielts-prompt", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		session.setIeltsPart(IeltsPart.PART_3);
+		IeltsContent content = new IeltsContent(List.of(), List.of(), List.of(
+				new IeltsContentQuestion("Why?", List.of(), List.of(
+						new RecommendedExpression("phrase", "in the long run",
+								"长期来看", "use for future effects")))));
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-prompt")).thenReturn(Optional.of(
+				new IeltsPracticeRecord("ielts-prompt", userId, IeltsMode.MOCK_TEST,
+						null, null, "RANDOM", null, null, null, content)));
+		var tooShort = processor.evaluateIeltsTurn("ielts-prompt",
+				new DialogueTurnEvaluationCommand(session.getId(), 1, null, "Hello"));
+		assertEquals(1, tooShort.turnNo());
+
+		when(messageRepository.findMessages(session.getId())).thenReturn(List.of(
+				new Message(0, "Why?", null),
+				new Message(0, "Follow-up", null),
+				new Message(1, "I think it matters in the long run.", null)));
+		when(turnRepository.findBefore(session.getId(), 2)).thenReturn(List.of(
+				scorableTurn("ielts-prompt", session.getId())));
+		when(pronunciationClient.evaluate(any(), any())).thenReturn(completeAssessment());
+		when(llmClient.assessTurn(any())).thenThrow(
+				new EvaluationException(EvaluationErrorCode.PROVIDER_RESPONSE_INVALID));
+		when(recordingStore.store(eq(session.getId()), eq(2), any()))
+				.thenReturn("https://audio.example/prompt.wav");
+
+		var result = processor.evaluateIeltsTurn("ielts-prompt",
+				new DialogueTurnEvaluationCommand(session.getId(), 2, canonicalWav(),
+						"I think it matters in the long run."));
+
+		assertEquals("本轮发音评分已完成，语言反馈暂不可用。", result.feedbackSummary());
+		verify(turnRepository, org.mockito.Mockito.times(2)).upsert(any(CustomTurnEvaluation.class));
+	}
+
+	@Test
+	void rejectsIeltsSessionWhenPracticeOrRuntimeOwnershipDoesNotMatch() {
+		UUID owner = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		UUID other = UUID.fromString("22222222-2222-4222-8222-222222222222");
+		CustomSceneSession session = session("owned-check", "ielts-owned", other.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(authService.requireUserId(null)).thenReturn(owner.toString());
+		when(practiceRepository.findPractice("ielts-owned")).thenReturn(Optional.of(
+				partPractice("ielts-owned", other, IeltsPart.PART_1)));
+		when(activeSessions.findById("owned-check")).thenReturn(Optional.of(session));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.evaluateIeltsTurn("ielts-owned",
+						new DialogueTurnEvaluationCommand("owned-check", 1, null,
+								"A complete answer with several words.")));
+
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND, exception.errorCode());
+		verify(pronunciationClient, never()).evaluate(any(), any());
+	}
+
+	@Test
+	void handlesCustomReportBackfillAndRejectsNonRecoverableReportFailure() {
+		CustomSceneSession session = session("backfill-report", "scene-1", "user-1");
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(reportRepository.find(session.getId())).thenReturn(Optional.empty());
+		when(turnRepository.findAll(session.getId())).thenReturn(List.of(turn()));
+		List<Message> dialogue = List.of(
+				new Message(0, "Question", null),
+				new Message(1, "I answered with enough detail.", null));
+		when(llmClient.assessDialogue(dialogue)).thenThrow(
+				new EvaluationException(EvaluationErrorCode.INVALID_REQUEST));
+
+		EvaluationException exception = assertThrows(EvaluationException.class,
+				() -> processor.generateDialogueReport(session.getId(), dialogue));
+
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST, exception.errorCode());
+		verify(turnRepository, never()).upsert(any(CustomTurnEvaluation.class));
+		verify(reportRepository, never()).save(any(), any(), any());
+	}
+
+	@Test
+	void coversSentenceNotFoundInsideSceneAndRecordingValidationFailures() {
+		LearningContentItem otherSentence = new LearningContentItem(
+				"other", "The other sentence.", "其他", null);
+		when(sentenceRepository.findSceneIdBySentenceId("missing-in-scene"))
+				.thenReturn(Optional.of("scene-1"));
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", otherSentence)));
+
+		EvaluationException missing = assertThrows(EvaluationException.class,
+				() -> processor.evaluateSentenceReading("missing-in-scene", canonicalWav()));
+		assertEquals(EvaluationErrorCode.SENTENCE_NOT_FOUND, missing.errorCode());
+
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession session = session("record-invalid", "ielts-1", userId.toString());
+		session.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById(session.getId())).thenReturn(Optional.of(session));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceRepository.findPractice("ielts-1")).thenReturn(Optional.of(
+				partPractice("ielts-1", userId, IeltsPart.PART_1)));
+		var result = processor.evaluateIeltsTurn("ielts-1",
+				new DialogueTurnEvaluationCommand(session.getId(), 1,
+						new byte[]{1, 2, 3}, "A complete answer with several words."));
+		assertEquals(1, result.turnNo());
+		verify(recordingStore, never()).store(any(), anyInt(), any());
+	}
+
+	@Test
+	void invokesPureBandAndValidationBranchesThroughReflectionForStableContract() throws Exception {
+		Method overall = EvaluationProcessor.class.getDeclaredMethod(
+				"overallBand", IeltsTextAssessment.class, BigDecimal.class);
+		overall.setAccessible(true);
+		BigDecimal band = (BigDecimal) overall.invoke(processor,
+				new IeltsTextAssessment(IeltsPart.PART_1,
+						new BigDecimal("7.0"), new BigDecimal("6.5"),
+						new BigDecimal("6.0"), "f", "l", "g", "s",
+						List.of(), List.of(), "HIGH"),
+				new BigDecimal("7.5"));
+		assertEquals(new BigDecimal("7.0"), band);
+
+		Method partByIndex = EvaluationProcessor.class.getDeclaredMethod("partByIndex", int.class);
+		partByIndex.setAccessible(true);
+		var invalid = assertThrows(java.lang.reflect.InvocationTargetException.class,
+				() -> partByIndex.invoke(processor, 99));
+		assertEquals(EvaluationErrorCode.INVALID_REQUEST,
+				((EvaluationException) invalid.getCause()).errorCode());
+
+		Method pronunciationBand = EvaluationProcessor.class.getDeclaredMethod(
+				"pronunciationBand", List.class);
+		pronunciationBand.setAccessible(true);
+		var emptyPronunciation = assertThrows(InvocationTargetException.class,
+				() -> pronunciationBand.invoke(processor, List.of()));
+		assertEquals(EvaluationErrorCode.NO_SCORABLE_UTTERANCES,
+				((EvaluationException) emptyPronunciation.getCause()).errorCode());
+
+		Method meanAvailable = EvaluationProcessor.class.getDeclaredMethod(
+				"meanAvailable", BigDecimal[].class);
+		meanAvailable.setAccessible(true);
+		assertEquals(new BigDecimal("0.0"), meanAvailable.invoke(processor,
+				(Object) new BigDecimal[]{null}));
+		assertEquals(new BigDecimal("50.0"), meanAvailable.invoke(processor,
+				(Object) new BigDecimal[]{new BigDecimal("-5"),
+						new BigDecimal("105")}));
+
+		Method firstScore = EvaluationProcessor.class.getDeclaredMethod(
+				"firstScore", BigDecimal.class, BigDecimal.class);
+		firstScore.setAccessible(true);
+		assertEquals(new BigDecimal("4"), firstScore.invoke(processor,
+				null, new BigDecimal("4")));
+
+		Method findAiText = EvaluationProcessor.class.getDeclaredMethod(
+				"findAiText", List.class, int.class);
+		findAiText.setAccessible(true);
+		List<Message> messages = List.of(
+				new Message(0, "Question", null),
+				new Message(1, "Answer", null));
+		assertEquals("Question", findAiText.invoke(processor, messages, 1));
+		assertNull(findAiText.invoke(processor, messages, 2));
+
+		Method validateDialogue = EvaluationProcessor.class.getDeclaredMethod(
+				"validateDialogue", List.class);
+		validateDialogue.setAccessible(true);
+		assertInvocationError(validateDialogue, null, EvaluationErrorCode.INVALID_REQUEST);
+		assertInvocationError(validateDialogue, List.of(), EvaluationErrorCode.INVALID_REQUEST);
+		assertInvocationError(validateDialogue,
+				List.of(new Message(2, "invalid owner", null)),
+				EvaluationErrorCode.INVALID_REQUEST);
+		assertInvocationError(validateDialogue,
+				List.of(new Message(0, "examiner only", null)),
+				EvaluationErrorCode.NO_SCORABLE_UTTERANCES);
+
+		Method requireComplete = EvaluationProcessor.class.getDeclaredMethod(
+				"requireCompleteLearnerTurns", List.class, List.class);
+		requireComplete.setAccessible(true);
+		List<Message> learnerDialogue = List.of(new Message(1, "answer", null));
+		assertInvocationError(requireComplete, learnerDialogue, List.of(),
+				EvaluationErrorCode.RESULT_INCOMPLETE);
+		assertInvocationError(requireComplete, learnerDialogue,
+				List.of(new CustomTurnEvaluation("scene", "session", 2,
+						"answer", null, null, null, null, null, null, "saved", "", List.of())),
+				EvaluationErrorCode.RESULT_INCOMPLETE);
+	}
+
+	@Test
+	void coversHistorySkipsLatestFilteringAndIncompleteEvaluationRows() {
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		String mockId = "history-null-final";
+		String partId = "history-null-part";
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		when(practiceSessionRepository.findCompletedByUserAndSceneType(
+				eq(userId), eq(SceneType.IELTS_SCENE))).thenReturn(List.of(
+				practiceSession("mock-1", userId, mockId, SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED),
+				practiceSession("mock-2", userId, mockId, SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED),
+				practiceSession("mock-3", userId, mockId, SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED),
+				practiceSession("part-1", userId, partId, SceneType.IELTS_SCENE,
+						SessionStatus.COMPLETED)));
+		when(practiceRepository.findPractice(mockId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(mockId, userId, IeltsMode.MOCK_TEST, null, null,
+						"RANDOM", null, null, null, new IeltsContent(List.of(), List.of(), List.of()))));
+		when(practiceRepository.findPractice(partId)).thenReturn(Optional.of(
+				partPractice(partId, userId, IeltsPart.PART_1)));
+		when(ieltsRepository.findTopicsByIds(any())).thenReturn(List.of());
+		when(ieltsEvaluationRepository.findFinal(mockId)).thenReturn(Optional.empty());
+		when(ieltsEvaluationRepository.findPart("part-1")).thenReturn(Optional.empty());
+
+		assertTrue(processor.getIeltsEvaluationHistory().isEmpty());
+		assertNull(processor.getLatestIeltsEstimatedScore());
+	}
+
+	@Test
+	void coversOwnershipGuardsAndCustomRuntimeShapeChecks() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(sentenceRepository.findSceneIdBySentenceId("missing-scene"))
+				.thenReturn(Optional.of("scene-missing"));
+		when(sceneRepository.findCustomDefinitionById("scene-missing"))
+				.thenReturn(Optional.empty());
+		assertEquals(EvaluationErrorCode.SENTENCE_NOT_FOUND,
+				assertThrows(EvaluationException.class,
+						() -> processor.evaluateSentenceReading("missing-scene", canonicalWav()))
+						.errorCode());
+
+		CustomSceneSession wrongType = session("wrong-type", "scene-1", "user-1");
+		wrongType.setSceneType(SceneType.IELTS_SCENE);
+		when(activeSessions.findById("wrong-type")).thenReturn(Optional.of(wrongType));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND,
+				assertThrows(EvaluationException.class,
+						() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+								"wrong-type", 1, null, "A complete answer here")))
+						.errorCode());
+
+		CustomSceneSession blankScene = session("blank-scene", "", "user-1");
+		when(activeSessions.findById("blank-scene")).thenReturn(Optional.of(blankScene));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND,
+				assertThrows(EvaluationException.class,
+						() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+								"blank-scene", 1, null, "A complete answer here")))
+						.errorCode());
+
+		when(activeSessions.findById("blank-id")).thenReturn(Optional.of(
+				session("blank-id", "scene-1", "user-1")));
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND,
+				assertThrows(EvaluationException.class,
+						() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+								"", 1, null, "A complete answer here")))
+						.errorCode());
+
+		UUID userId = UUID.fromString("11111111-1111-4111-8111-111111111111");
+		CustomSceneSession mismatched = session("mismatch", "scene-1", "user-2");
+		when(activeSessions.findById("mismatch")).thenReturn(Optional.of(mismatched));
+		when(sceneRepository.findCustomDefinitionById("scene-1"))
+				.thenReturn(Optional.of(scene("scene-1", "user-1", null)));
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		// The different user is intentionally checked after the scene lookup.
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		assertEquals(EvaluationErrorCode.SESSION_NOT_FOUND,
+				assertThrows(EvaluationException.class,
+						() -> processor.evaluateDialogueTurn(new DialogueTurnEvaluationCommand(
+								"mismatch", 1, null, "A complete answer here")))
+						.errorCode());
+	}
+
+	private void assertInvocationError(
+			Method method,
+			Object argument,
+			EvaluationErrorCode expected) {
+		InvocationTargetException exception = assertThrows(
+				InvocationTargetException.class,
+				() -> method.invoke(processor, new Object[]{argument}));
+		assertEquals(expected, ((EvaluationException) exception.getCause()).errorCode());
+	}
+
+	private void assertInvocationError(
+			Method method,
+			Object first,
+			Object second,
+			EvaluationErrorCode expected) {
+		InvocationTargetException exception = assertThrows(
+				InvocationTargetException.class,
+				() -> method.invoke(processor, first, second));
+		assertEquals(expected, ((EvaluationException) exception.getCause()).errorCode());
+	}
+
+	private CustomSceneDefinition scene(
+			String sceneId,
+			String userId,
+			LearningContentItem sentence) {
+		return new CustomSceneDefinition(sceneId, userId, "场景", "标签", "背景",
+				"AI", "用户", "目标", null, null, List.of(), List.of(),
+				sentence == null ? List.of() : List.of(sentence));
+	}
+
+	private CustomSceneSession session(String sessionId, String sceneId, String userId) {
+		CustomSceneSession session = new CustomSceneSession(sessionId, userId);
+		session.setSceneId(sceneId);
+		session.setSceneType(SceneType.CUSTOM_SCENE);
+		return session;
+	}
+
+	private CustomTurnEvaluation turn() {
+		return new CustomTurnEvaluation("scene-1", "session-1", 1,
+				"I improved the service latency.", new BigDecimal("82"),
+				new BigDecimal("81"), new BigDecimal("80"), new BigDecimal("83"),
+				new BigDecimal("84"), new BigDecimal("85"), "表达清晰",
+				"I improved service latency.", List.of(new PronunciationWordDetail(
+						0, "improved", new BigDecimal("84"), List.of(
+								new PronunciationWordDetail.Phoneme(0, "ih", "ih",
+										new BigDecimal("84"), 0, 20)))));
+	}
+
+	private IeltsPracticeRecord partPractice(
+			String ieltsId,
+			UUID userId,
+			IeltsPart part) {
+		return new IeltsPracticeRecord(
+				ieltsId,
+				userId,
+				IeltsMode.PART_PRACTICE,
+				part,
+				"topic-" + part.name(),
+				new IeltsContent(List.of(), List.of(), List.of()));
+	}
+
+	private PracticeSessionRecord practiceSession(
+			String sessionId,
+			UUID userId,
+			String sceneId,
+			SceneType sceneType,
+			SessionStatus status) {
+		Instant startedAt = Instant.parse("2026-08-21T08:00:00Z");
+		return new PracticeSessionRecord(
+				sessionId,
+				userId,
+				sceneId,
+				sceneType,
+				status,
+				startedAt,
+				startedAt.plusSeconds(60));
+	}
+
+	private IeltsPartEvaluationEntity cachedPart(
+			String ieltsId,
+			String sessionId,
+			IeltsPart part) {
+		IeltsPartEvaluationEntity entity = new IeltsPartEvaluationEntity();
+		entity.setIeltsId(ieltsId);
+		entity.setSessionId(sessionId);
+		entity.setPart(part.name());
+		entity.setFluencyCoherenceScore(new BigDecimal("7.0"));
+		entity.setLexicalResourceScore(new BigDecimal("6.5"));
+		entity.setGrammaticalRangeAccuracyScore(new BigDecimal("6.0"));
+		entity.setPronunciationScore(new BigDecimal("7.5"));
+		entity.setSummary("缓存的单 Part 评分");
+		entity.setStrengths(new String[]{"能够展开"});
+		entity.setImprovements(new String[]{"增加细节"});
+		entity.setRecommendedExpressions(new String[]{"A clearer answer."});
+		entity.setFluencyCoherenceReason("表达基本连贯");
+		entity.setLexicalResourceReason("词汇够用");
+		entity.setGrammaticalRangeAccuracyReason("句式基本准确");
+		entity.setPronunciationReason("发音清楚");
+		entity.setEvaluationStatus("COMPLETED");
+		return entity;
+	}
+
+	private IeltsPartEvaluationEntity cachedPartWithNullLists(
+			String ieltsId,
+			String sessionId,
+			IeltsPart part) {
+		IeltsPartEvaluationEntity entity = cachedPart(ieltsId, sessionId, part);
+		entity.setStrengths(null);
+		entity.setImprovements(null);
+		entity.setRecommendedExpressions(null);
+		return entity;
+	}
+
+	private IeltsEvaluationEntity cachedFinal(String ieltsId) {
+		IeltsEvaluationEntity entity = new IeltsEvaluationEntity();
+		entity.setIeltsId(ieltsId);
+		entity.setOverallBandScore(new BigDecimal("7.0"));
+		entity.setFluencyCoherenceScore(new BigDecimal("7.0"));
+		entity.setLexicalResourceScore(new BigDecimal("6.5"));
+		entity.setGrammaticalRangeAccuracyScore(new BigDecimal("6.5"));
+		entity.setPronunciationScore(new BigDecimal("7.5"));
+		entity.setSummary("模考缓存结果");
+		entity.setStrengths(new String[]{"优势"});
+		entity.setImprovements(new String[]{"改进"});
+		entity.setRecommendedExpressions(new String[]{"Use detail."});
+		entity.setFluencyCoherenceReason("流利");
+		entity.setLexicalResourceReason("词汇");
+		entity.setGrammaticalRangeAccuracyReason("语法");
+		entity.setPronunciationReason("发音");
+		entity.setEvaluationStatus("COMPLETED");
+		return entity;
+	}
+
+	private CustomTurnEvaluation scorableTurn(
+			String sceneId,
+			String sessionId) {
+		return new CustomTurnEvaluation(
+				sceneId,
+				sessionId,
+				1,
+				"I can explain this topic with several details.",
+				new BigDecimal("82"),
+				new BigDecimal("78"),
+				new BigDecimal("76"),
+				new BigDecimal("85"),
+				new BigDecimal("80"),
+				new BigDecimal("79"),
+				"表达清楚",
+				"A more natural expression.",
+				List.of());
+	}
+
+	private PronunciationAssessmentResult completeAssessment() {
+		return new PronunciationAssessmentResult(
+				new BigDecimal("86"), new BigDecimal("82"), new BigDecimal("80"),
+				new BigDecimal("88"), new BigDecimal("84"), new BigDecimal("85"),
+				EndingTone.FALL, List.of(new PronunciationWordResult(0, "index",
+						WordReadStatus.NORMAL, new BigDecimal("84"), new BigDecimal("84"),
+						null, List.of(new PronunciationPhonemeResult(0, "ih", "ih",
+								new BigDecimal("84"), 0, 20)))));
+	}
+
+	private byte[] canonicalWav() {
+		byte[] wav = new byte[46];
+		writeAscii(wav, 0, "RIFF");
+		writeInt(wav, 4, wav.length - 8);
+		writeAscii(wav, 8, "WAVE");
+		writeAscii(wav, 12, "fmt ");
+		writeInt(wav, 16, 16);
+		writeShort(wav, 20, 1);
+		writeShort(wav, 22, 1);
+		writeInt(wav, 24, 16_000);
+		writeInt(wav, 28, 32_000);
+		writeShort(wav, 32, 2);
+		writeShort(wav, 34, 16);
+		writeAscii(wav, 36, "data");
+		writeInt(wav, 40, 2);
+		return wav;
+	}
+
+	private void writeAscii(byte[] target, int offset, String value) {
+		byte[] bytes = value.getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+		System.arraycopy(bytes, 0, target, offset, bytes.length);
+	}
+
+	private void writeShort(byte[] target, int offset, int value) {
+		target[offset] = (byte) value;
+		target[offset + 1] = (byte) (value >>> 8);
+	}
+
+	private void writeInt(byte[] target, int offset, int value) {
+		target[offset] = (byte) value;
+		target[offset + 1] = (byte) (value >>> 8);
+		target[offset + 2] = (byte) (value >>> 16);
+		target[offset + 3] = (byte) (value >>> 24);
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/EvaluationServiceReportTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/EvaluationServiceReportTest.java
@@ -1,9 +1,11 @@
 package com.unispeaking.service.evaluation;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.unispeaking.domain.dto.session.Message;
@@ -33,6 +35,42 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 class EvaluationServiceReportTest {
+
+	@Test
+	void returnsPersistedReportWithoutReevaluatingTheDialogue() {
+		String sessionId = "scene_cached_report";
+		CustomSceneSession session = new CustomSceneSession(sessionId, "user_1");
+		session.setSceneId("custom_2001");
+		session.setSceneType(SceneType.CUSTOM_SCENE);
+		ActiveSessionRegistry runtimeStore = mock(ActiveSessionRegistry.class);
+		when(runtimeStore.findById(sessionId)).thenReturn(Optional.of(session));
+		SessionEvaluationRepository reportRepository =
+				mock(SessionEvaluationRepository.class);
+		var savedReport = new com.unispeaking.domain.dto.evaluation.DialogueReportResult(
+				new BigDecimal("81"), new BigDecimal("82"), new BigDecimal("83"),
+				new BigDecimal("84"), new BigDecimal("85"), new BigDecimal("83"),
+				"已缓存的报告", List.of("表达清晰"), List.of("补充细节"));
+		when(reportRepository.find(sessionId)).thenReturn(Optional.of(savedReport));
+		TurnEvaluationRepository turnRepository = mock(TurnEvaluationRepository.class);
+		EvaluationLlmClient llmClient = mock(EvaluationLlmClient.class);
+
+		EvaluationProcessor service = new EvaluationProcessor(
+				mock(PronunciationAssessmentClient.class), llmClient, runtimeStore,
+				mock(SceneRepository.class), mock(SessionMessageRepository.class), turnRepository,
+				reportRepository, mock(SceneSentenceReadingRepository.class),
+				mock(IeltsPracticeRepository.class),
+				mock(com.unispeaking.infrastructure.persistence.repository.scene.IeltsRepository.class),
+				mock(IeltsSceneFlowService.class), mock(PracticeSessionRepository.class),
+				mock(IeltsEvaluationRepository.class), mock(IeltsEvaluationLlmClient.class),
+				mock(AuthService.class), mock(com.unispeaking.provider.ObjectStorageProvider.class),
+				new com.unispeaking.infrastructure.config.ObjectStorageProperties(),
+				mock(com.unispeaking.component.recording.RecordingStore.class));
+
+		assertSame(savedReport, service.generateDialogueReport(sessionId, List.of(
+				new Message(0, "How can I help you?", null),
+				new Message(1, "I would like a coffee, please.", null))));
+		verifyNoInteractions(turnRepository, llmClient);
+	}
 
 	@Test
 	void allZeroSpeechResultIsNotAggregatedIntoAZeroScoreReport() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/IeltsEvaluationServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/IeltsEvaluationServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.mock;
 
 import com.unispeaking.common.evaluation.model.EndingTone;
 import com.unispeaking.common.evaluation.model.IeltsTextAssessment;
@@ -18,8 +19,12 @@ import com.unispeaking.common.evaluation.model.PronunciationWordResult;
 import com.unispeaking.common.evaluation.model.WordReadStatus;
 import com.unispeaking.common.exception.evaluation.EvaluationErrorCode;
 import com.unispeaking.common.exception.evaluation.EvaluationException;
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.domain.dto.evaluation.IeltsEvaluationResult;
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.component.session.ActiveSessionRegistry;
 import com.unispeaking.domain.dto.evaluation.DialogueTurnEvaluationCommand;
+import com.unispeaking.domain.dto.evaluation.IeltsEvaluationResult;
 import com.unispeaking.domain.dto.session.Message;
 import com.unispeaking.domain.po.scene.IeltsPracticeRecord;
 import com.unispeaking.domain.po.session.CustomSceneSession;
@@ -44,6 +49,11 @@ import com.unispeaking.infrastructure.persistence.repository.session.PracticeSes
 import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
 import com.unispeaking.service.auth.AuthService;
 import com.unispeaking.component.evaluation.EvaluationProcessor;
+import com.unispeaking.component.session.SessionLifecycleManager;
+import com.unispeaking.domain.dto.evaluation.IeltsEvaluationDetail;
+import com.unispeaking.domain.dto.evaluation.IeltsEvaluationReport;
+import com.unispeaking.domain.dto.session.SessionDetail;
+import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.service.scene.IeltsSceneFlowService;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -56,6 +66,174 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
 class IeltsEvaluationServiceTest {
+
+	@Test
+	void delegatesTurnReportDetailAndHistoryOperations() {
+		EvaluationProcessor delegate = mock(EvaluationProcessor.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsEvaluationService service = new IeltsEvaluationService(delegate, lifecycle);
+		IeltsEvaluationResult result = new IeltsEvaluationResult(
+				IeltsPart.PART_2,
+				"DIAGNOSTIC",
+				new BigDecimal("7.0"),
+				new BigDecimal("7.5"),
+				new BigDecimal("6.5"),
+				new BigDecimal("7.0"),
+				new BigDecimal("7.0"),
+				"summary",
+				List.of("strength"),
+				List.of("improvement"),
+				List.of(),
+				List.of());
+		when(lifecycle.getSession("session-1")).thenReturn(new SessionDetail(
+				"session-1", "scene-1", SceneType.IELTS_SCENE, "PART2", List.of()));
+		when(delegate.evaluateIeltsTurn(eq("scene-1"), any())).thenReturn(null);
+		when(lifecycle.getBySceneId("scene-1")).thenReturn(List.of(
+				new SessionDetail("session-1", "scene-1", SceneType.IELTS_SCENE,
+						"PART2", List.of())));
+		when(delegate.generateIeltsEvaluation("scene-1", "session-1")).thenReturn(result);
+		when(delegate.getLatestIeltsEstimatedScore()).thenReturn(new BigDecimal("6.5"));
+		when(delegate.getIeltsEvaluationHistory()).thenReturn(List.of());
+
+		assertEquals(null, service.evaluateTurn(new DialogueTurnEvaluationCommand(
+				"session-1", 1, null, "answer")));
+		IeltsEvaluationReport report = service.generateReport("scene-1");
+		assertEquals(new BigDecimal("7.0"), report.bandScore());
+		IeltsEvaluationDetail detail = service.getEvaluation("scene-1");
+		assertEquals("summary", detail.result().summary());
+		assertEquals(new BigDecimal("6.5"), service.getLatestEstimatedScore());
+		assertEquals(List.of(), service.getHistory());
+	}
+
+	@Test
+	void rejectsReportAndDetailWhenSceneHasNoSessions() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		when(lifecycle.getBySceneId("missing-scene")).thenReturn(List.of());
+		IeltsEvaluationService service = new IeltsEvaluationService(
+				mock(EvaluationProcessor.class), lifecycle);
+
+		BusinessException exception = org.junit.jupiter.api.Assertions.assertThrows(
+				BusinessException.class, () -> service.generateReport("missing-scene"));
+		assertEquals("SESSION_NOT_FOUND", exception.code());
+		org.junit.jupiter.api.Assertions.assertThrows(
+				BusinessException.class, () -> service.getEvaluation("missing-scene"));
+	}
+
+	@Test
+	void returnsCompletedMockEvaluationFromCacheWithoutCallingProvidersOrIncrementing() {
+		UUID userId = UUID.fromString("3d8f80be-6390-4db9-a6cf-c10a0145d4c3");
+		String ieltsId = "ielts_mock_cached";
+		List<PracticeSessionRecord> sessions = List.of(
+				session("cached-p1", userId, ieltsId, 0),
+				session("cached-p2", userId, ieltsId, 1),
+				session("cached-p3", userId, ieltsId, 2));
+		IeltsPracticeRepository practiceRepository = mock(IeltsPracticeRepository.class);
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.MOCK_TEST,
+						null, null, "RANDOM", "topic-p1", "topic-p2", "topic-p3",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		PracticeSessionRepository sessionRepository = mock(PracticeSessionRepository.class);
+		when(sessionRepository.findBySceneId(ieltsId)).thenReturn(sessions);
+		IeltsEvaluationEntity cached = new IeltsEvaluationEntity();
+		cached.setEvaluationId("final_cached");
+		cached.setIeltsId(ieltsId);
+		cached.setEvaluationStatus("COMPLETED");
+		cached.setOverallBandScore(new BigDecimal("7.5"));
+		cached.setFluencyCoherenceScore(new BigDecimal("7.0"));
+		cached.setLexicalResourceScore(new BigDecimal("7.5"));
+		cached.setGrammaticalRangeAccuracyScore(new BigDecimal("7.0"));
+		cached.setPronunciationScore(new BigDecimal("8.0"));
+		cached.setSummary("已缓存的完整模考报告");
+		IeltsEvaluationRepository evaluationRepository = mock(IeltsEvaluationRepository.class);
+		when(evaluationRepository.findFinal(ieltsId)).thenReturn(Optional.of(cached));
+		when(evaluationRepository.findParts(ieltsId)).thenReturn(List.of(
+				savedPart(ieltsId, "cached-p1",
+						com.unispeaking.domain.vo.scene.IeltsPart.PART_1, "7.5")));
+		AuthService authService = mock(AuthService.class);
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		IeltsEvaluationLlmClient ieltsLlmClient = mock(IeltsEvaluationLlmClient.class);
+
+		EvaluationProcessor processor = new EvaluationProcessor(
+				mock(PronunciationAssessmentClient.class), mock(EvaluationLlmClient.class),
+				mock(ActiveSessionRegistry.class), mock(SceneRepository.class),
+				mock(SessionMessageRepository.class), mock(TurnEvaluationRepository.class),
+				mock(SessionEvaluationRepository.class), mock(SceneSentenceReadingRepository.class),
+				practiceRepository,
+				mock(com.unispeaking.infrastructure.persistence.repository.scene.IeltsRepository.class),
+				mock(IeltsSceneFlowService.class), sessionRepository, evaluationRepository,
+				ieltsLlmClient, authService,
+				mock(com.unispeaking.provider.ObjectStorageProvider.class),
+				new com.unispeaking.infrastructure.config.ObjectStorageProperties(),
+				mock(com.unispeaking.component.recording.RecordingStore.class));
+
+		var result = processor.generateIeltsEvaluation(ieltsId, "cached-p3");
+
+		assertEquals("FINAL", result.assessmentType());
+		assertEquals(new BigDecimal("7.5"), result.overallBandScore());
+		assertEquals(1, result.partEvaluations().size());
+		verify(ieltsLlmClient, never()).assessPart(
+				org.mockito.ArgumentMatchers.any(),
+				org.mockito.ArgumentMatchers.anyString(),
+				org.mockito.ArgumentMatchers.nullable(String.class),
+				org.mockito.ArgumentMatchers.anyString());
+		verify(evaluationRepository, never()).saveFinal(
+				eq(ieltsId), org.mockito.ArgumentMatchers.any());
+		verify(practiceRepository, never()).incrementCompletedCount(userId);
+	}
+
+	@Test
+	void returnsDiagnosticHistoryWithStoredRecordingAndFallbackTopicTitle() {
+		UUID userId = UUID.fromString("3d8f80be-6390-4db9-a6cf-c10a0145d4c3");
+		String ieltsId = "ielts_part_history";
+		PracticeSessionRecord completedSession = session(
+				"history-session", userId, ieltsId, 0);
+		IeltsPracticeRepository practiceRepository = mock(IeltsPracticeRepository.class);
+		when(practiceRepository.findPractice(ieltsId)).thenReturn(Optional.of(
+				new IeltsPracticeRecord(ieltsId, userId, IeltsMode.PART_PRACTICE,
+						com.unispeaking.domain.vo.scene.IeltsPart.PART_2, "missing-topic",
+						new IeltsContent(List.of(), List.of(), List.of()))));
+		PracticeSessionRepository sessionRepository = mock(PracticeSessionRepository.class);
+		when(sessionRepository.findCompletedByUserAndSceneType(
+				userId, SceneType.IELTS_SCENE)).thenReturn(List.of(completedSession));
+		IeltsPartEvaluationEntity part = savedPart(ieltsId, "history-session",
+				com.unispeaking.domain.vo.scene.IeltsPart.PART_2, "6.5");
+		part.setStrengths(null);
+		part.setImprovements(null);
+		part.setRecommendedExpressions(null);
+		IeltsEvaluationRepository evaluationRepository = mock(IeltsEvaluationRepository.class);
+		when(evaluationRepository.findPart("history-session")).thenReturn(Optional.of(part));
+		SessionMessageRepository messageRepository = mock(SessionMessageRepository.class);
+		when(messageRepository.findAudioUrls("history-session")).thenReturn(List.of(
+				"https://recordings.example/history-session.wav"));
+		AuthService authService = mock(AuthService.class);
+		when(authService.requireUserId(null)).thenReturn(userId.toString());
+		var topicRepository = mock(
+				com.unispeaking.infrastructure.persistence.repository.scene.IeltsRepository.class);
+		when(topicRepository.findTopicsByIds(any())).thenReturn(List.of());
+
+		EvaluationProcessor processor = new EvaluationProcessor(
+				mock(PronunciationAssessmentClient.class), mock(EvaluationLlmClient.class),
+				mock(ActiveSessionRegistry.class), mock(SceneRepository.class),
+				messageRepository, mock(TurnEvaluationRepository.class),
+				mock(SessionEvaluationRepository.class), mock(SceneSentenceReadingRepository.class),
+				practiceRepository, topicRepository, mock(IeltsSceneFlowService.class),
+				sessionRepository, evaluationRepository, mock(IeltsEvaluationLlmClient.class),
+				authService, mock(com.unispeaking.provider.ObjectStorageProvider.class),
+				new com.unispeaking.infrastructure.config.ObjectStorageProperties(),
+				mock(com.unispeaking.component.recording.RecordingStore.class));
+
+		var history = processor.getIeltsEvaluationHistory();
+
+		assertEquals(1, history.size());
+		assertEquals("DIAGNOSTIC", history.getFirst().assessmentType());
+		assertEquals(com.unispeaking.domain.vo.scene.IeltsPart.PART_2,
+				history.getFirst().part());
+		assertEquals("missing-topic", history.getFirst().topicTitles().get(
+				com.unispeaking.domain.vo.scene.IeltsPart.PART_2));
+		assertEquals(List.of("https://recordings.example/history-session.wav"),
+				history.getFirst().recordingUrls());
+		assertEquals(List.of(), history.getFirst().strengths());
+	}
 
 	@Test
 	void preservesPronunciationWhenIeltsLanguageFeedbackProviderFails() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/profile/impl/ProfileOverviewServiceImplTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/profile/impl/ProfileOverviewServiceImplTest.java
@@ -1,6 +1,8 @@
 package com.unispeaking.service.profile.impl;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -25,6 +27,8 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import com.unispeaking.common.exception.BusinessException;
+import java.net.URI;
 
 class ProfileOverviewServiceImplTest {
 
@@ -88,5 +92,50 @@ class ProfileOverviewServiceImplTest {
 		assertEquals(7, overview.statistics().lastSevenDays().size());
 		assertEquals(300,
 				overview.statistics().lastSevenDays().getLast().practiceSeconds());
+	}
+
+	@Test
+	void rejectsFutureAndMalformedMonthsAndUnknownUsers() {
+		UserAccountRepository accounts = mock(UserAccountRepository.class);
+		UUID id = UUID.randomUUID();
+		when(accounts.findById(id)).thenReturn(Optional.empty());
+		ProfileOverviewServiceImpl service = new ProfileOverviewServiceImpl(accounts,
+				mock(SceneRepository.class), mock(SessionEvaluationRepository.class),
+				mock(PracticeSessionRepository.class), mock(ObjectStorageProvider.class),
+				new ObjectStorageProperties(), ZoneId.of("UTC"), Clock.fixed(Instant.parse("2026-08-03T00:00:00Z"), ZoneId.of("UTC")));
+		assertEquals("USER_NOT_FOUND", assertThrows(BusinessException.class,
+				() -> service.getOverview(id.toString(), null)).code());
+
+		when(accounts.findById(id)).thenReturn(Optional.of(new UserAccount(id, "user@example.com", "hash", null,
+				UserRole.USER, UserStatus.ACTIVE, 0, null, Instant.now(), Instant.now())));
+		assertEquals("PROFILE_MONTH_INVALID", assertThrows(BusinessException.class,
+				() -> service.getOverview(id.toString(), "2026/08")).code());
+		assertEquals("PROFILE_MONTH_INVALID", assertThrows(BusinessException.class,
+				() -> service.getOverview(id.toString(), "2026-09")).code());
+	}
+
+	@Test
+	void fallsBackToEmailNameAndSignsAvatarWhenStorageIsAvailable() {
+		ZoneId zone = ZoneId.of("UTC");
+		Instant now = Instant.parse("2026-08-03T00:00:00Z");
+		UUID id = UUID.randomUUID();
+		UserAccountRepository accounts = mock(UserAccountRepository.class);
+		SceneRepository scenes = mock(SceneRepository.class);
+		SessionEvaluationRepository evaluations = mock(SessionEvaluationRepository.class);
+		PracticeSessionRepository sessions = mock(PracticeSessionRepository.class);
+		ObjectStorageProvider storage = mock(ObjectStorageProvider.class);
+		when(accounts.findById(id)).thenReturn(Optional.of(new UserAccount(id, "name@example.com", "hash", " ",
+				"avatars/name.png", UserRole.USER, UserStatus.ACTIVE, 0, null, now, now)));
+		when(scenes.findAllIdsByUserId(id.toString())).thenReturn(List.of());
+		when(scenes.countActiveByUserId(id.toString())).thenReturn(0L);
+		when(evaluations.findCreatedAtBySceneIdsBetween(any(), any(), any())).thenReturn(List.of());
+		when(sessions.findCompletedOverlapping(any(), any(), any())).thenReturn(List.of());
+		when(storage.available()).thenReturn(true);
+		when(storage.signGetUrl(any(), any())).thenReturn(URI.create("https://cdn.example/avatar.png"));
+		ProfileOverviewServiceImpl service = new ProfileOverviewServiceImpl(accounts, scenes, evaluations, sessions,
+				storage, new ObjectStorageProperties(), zone, Clock.fixed(now, zone));
+		var overview = service.getOverview(id.toString(), "2026-08");
+		assertEquals("name", overview.account().displayName());
+		assertEquals("https://cdn.example/avatar.png", overview.account().avatarUrl());
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/recording/RecordingStoreInterviewTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/recording/RecordingStoreInterviewTest.java
@@ -1,11 +1,15 @@
 package com.unispeaking.service.recording;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.unispeaking.common.exception.BusinessException;
@@ -110,6 +114,120 @@ class RecordingStoreInterviewTest {
 		assertFalse(Files.exists(stale));
 	}
 
+	@Test
+	void validatesConstructorAndStorageInputLimits() {
+	RecordingProperties blankDirectory = new RecordingProperties();
+		blankDirectory.setDirectory(" ");
+		assertThrows(IllegalArgumentException.class, () -> new RecordingStore(
+				blankDirectory, mock(PracticeSessionRepository.class),
+				mock(AuthService.class), Set.of(SceneType.INTERVIEW_SCENE),
+				"/api/interview-scenes/", RecordingStore.INTERVIEW_FILE_NAME,
+				"NOT_FOUND", "PERSISTENCE_FAILED"));
+
+		RecordingProperties invalidSize = new RecordingProperties();
+		invalidSize.setDirectory(tempDirectory.toString());
+		invalidSize.setMaxBytes(0);
+		assertThrows(IllegalArgumentException.class, () -> new RecordingStore(
+				invalidSize, mock(PracticeSessionRepository.class),
+				mock(AuthService.class), Set.of(SceneType.INTERVIEW_SCENE),
+				"/api/interview-scenes/", RecordingStore.INTERVIEW_FILE_NAME,
+				"NOT_FOUND", "PERSISTENCE_FAILED"));
+
+		RecordingStore limited = storeWithMaxBytes(3);
+		assertPersistenceFailure(() -> limited.storeTurn("session-1", 0, new byte[]{1}));
+		assertPersistenceFailure(() -> limited.storeTurn("session-1", 1, null));
+		assertPersistenceFailure(() -> limited.storeTurn("session-1", 1, new byte[]{1, 2, 3, 4}));
+		assertPersistenceFailure(() -> limited.storeAiAudio("session-1", new byte[0]));
+		assertPersistenceFailure(() -> limited.storeSessionAudio("session-1", new byte[]{1, 2, 3, 4}));
+	}
+
+	@Test
+	void rejectsUnsafeIdentifiersAndInvalidFilesWithoutTouchingOwnership() {
+		PracticeSessionRepository repository = mock(PracticeSessionRepository.class);
+		AuthService authService = mock(AuthService.class);
+		RecordingStore store = store(repository, authService);
+
+		assertPersistenceFailure("INTERVIEW_RECORDING_PERSISTENCE_FAILED",
+				() -> store.storeTurn("../escape", 1, new byte[]{1}));
+		assertPersistenceFailure("INTERVIEW_RECORDING_PERSISTENCE_FAILED",
+				() -> store.storeTurn(null, 1, new byte[]{1}));
+		assertDoesNotThrow(() -> store.delete("bad/id", 1));
+		assertPersistenceFailure("INTERVIEW_RECORDING_PERSISTENCE_FAILED",
+				() -> store.readAudio("bad/id", "turn-1.wav"));
+		assertFalse(store.hasAudio("bad/id", "turn-1.wav"));
+		assertTrue(throwsNotFound(() -> store.loadOwned(
+				"scene-1", "session-1", null)));
+		assertTrue(throwsNotFound(() -> store.loadOwned(
+				"scene-1", "session-1", "../turn-1.wav")));
+		verify(authService, never()).requireUserId(null);
+		verify(repository, never()).findBySessionId("session-1");
+	}
+
+	@Test
+	void readsSessionRecordingAndEnforcesOwnerSceneTypeAndSceneBinding() throws Exception {
+		UUID ownerId = UUID.randomUUID();
+		PracticeSessionRepository repository = mock(PracticeSessionRepository.class);
+		AuthService authService = mock(AuthService.class);
+		when(authService.requireUserId(null)).thenReturn(ownerId.toString());
+		when(repository.findBySessionId("session-1")).thenReturn(Optional.of(
+				new PracticeSessionRecord(
+					"session-1", ownerId, "scene-1", SceneType.INTERVIEW_SCENE,
+					SessionStatus.COMPLETED, Instant.now(), Instant.now())));
+		RecordingStore store = store(repository, authService);
+		store.storeSessionAudio("session-1", new byte[]{9, 8, 7});
+
+		assertArrayEquals(new byte[]{9, 8, 7}, store.loadSessionRecording(
+				"scene-1", "session-1").getInputStream().readAllBytes());
+
+		when(repository.findBySessionId("wrong-owner")).thenReturn(Optional.of(
+				new PracticeSessionRecord(
+					"wrong-owner", UUID.randomUUID(), "scene-1", SceneType.INTERVIEW_SCENE,
+					SessionStatus.COMPLETED, Instant.now(), Instant.now())));
+		assertTrue(throwsNotFound(() -> store.loadOwned(
+				"scene-1", "wrong-owner", "session.wav")));
+
+		when(repository.findBySessionId("wrong-type")).thenReturn(Optional.of(
+				new PracticeSessionRecord(
+					"wrong-type", ownerId, "scene-1", SceneType.IELTS_SCENE,
+					SessionStatus.COMPLETED, Instant.now(), Instant.now())));
+		assertTrue(throwsNotFound(() -> store.loadOwned(
+				"scene-1", "wrong-type", "session.wav")));
+	}
+
+	@Test
+	void reportsMissingAndInvalidInternalAudioAndHandlesCleanupNoOps() throws Exception {
+		RecordingStore store = store();
+		assertNull(store.readAudio("session-1", "session.wav"));
+		assertNull(store.readAudio("session-1", "not-a-recording.txt"));
+		assertFalse(store.hasAudio("session-1", null));
+		assertFalse(store.hasAudio("session-1", "../session.wav"));
+
+		store.delete("session-1", 0);
+		store.delete(null, 1);
+		store.deleteSessionAudio(null);
+		store.deleteSessionAudio("../escape");
+		store.cleanupExpired(null);
+		store.cleanupExpired(Duration.ZERO);
+		store.cleanupExpired(Duration.ofSeconds(-1));
+	}
+
+	@Test
+	void cleanupExpiredKeepsFreshFilesAndIgnoresMissingRoot() throws Exception {
+		RecordingStore store = store();
+		store.storeTurn("session-1", 1, new byte[]{1, 2});
+		Path fresh = tempDirectory.resolve("session-1/turn-1.wav");
+		store.cleanupExpired(Duration.ofDays(7));
+		assertTrue(Files.exists(fresh));
+
+		RecordingProperties missingRoot = new RecordingProperties();
+		missingRoot.setDirectory(tempDirectory.resolve("does-not-exist").toString());
+		RecordingStore missing = new RecordingStore(
+				missingRoot, mock(PracticeSessionRepository.class), mock(AuthService.class),
+				Set.of(SceneType.INTERVIEW_SCENE), "/api/interview-scenes/",
+				RecordingStore.INTERVIEW_FILE_NAME, "NOT_FOUND", "PERSISTENCE_FAILED");
+		assertDoesNotThrow(() -> missing.cleanupExpired(Duration.ofDays(1)));
+	}
+
 	private boolean throwsNotFound(Runnable runnable) {
 		try {
 			runnable.run();
@@ -122,6 +240,25 @@ class RecordingStoreInterviewTest {
 
 	private RecordingStore store() {
 		return store(mock(PracticeSessionRepository.class), mock(AuthService.class));
+	}
+
+	private RecordingStore storeWithMaxBytes(long maxBytes) {
+		RecordingProperties properties = new RecordingProperties();
+		properties.setDirectory(tempDirectory.toString());
+		properties.setMaxBytes(maxBytes);
+		return new RecordingStore(
+				properties, mock(PracticeSessionRepository.class), mock(AuthService.class),
+				Set.of(SceneType.INTERVIEW_SCENE), "/api/interview-scenes/",
+				RecordingStore.INTERVIEW_FILE_NAME, "NOT_FOUND", "PERSISTENCE_FAILED");
+	}
+
+	private void assertPersistenceFailure(Runnable action) {
+		assertPersistenceFailure("PERSISTENCE_FAILED", action);
+	}
+
+	private void assertPersistenceFailure(String code, Runnable action) {
+		BusinessException exception = assertThrows(BusinessException.class, action::run);
+		assertEquals(code, exception.code());
 	}
 
 	private RecordingStore store(

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneFlowServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneFlowServiceTest.java
@@ -1,0 +1,186 @@
+package com.unispeaking.service.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.exception.SceneNotFoundException;
+import com.unispeaking.component.session.RealtimeSessionCoordinator;
+import com.unispeaking.component.statemachine.ScenarioDialogueStateMachine;
+import com.unispeaking.domain.dto.scene.LearningContentItem;
+import com.unispeaking.domain.dto.scene.SceneGenerationResponse;
+import com.unispeaking.domain.dto.session.ScenarioDialogueStateResponse;
+import com.unispeaking.domain.po.scene.CustomSceneDefinition;
+import com.unispeaking.domain.po.session.AbstractSceneSession;
+import com.unispeaking.domain.vo.scene.CustomStage;
+import com.unispeaking.domain.vo.scene.SceneFlowStage;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class CustomSceneFlowServiceTest {
+
+	private final SceneRepository repository = mock(SceneRepository.class);
+	private final ScenarioDialogueStateMachine stateMachine = mock(ScenarioDialogueStateMachine.class);
+	private final RealtimeSessionCoordinator sessions = mock(RealtimeSessionCoordinator.class);
+	private final CustomSceneFlowService service = new CustomSceneFlowService(repository, stateMachine, sessions);
+
+	@BeforeEach
+	void provideScene() {
+		SceneGenerationResponse generated = scene("scene");
+		when(repository.findGeneratedById("scene")).thenReturn(Optional.of(generated));
+	}
+
+	@Test
+	void startRequiresPersistedSceneAndClearRemovesItsState() {
+		when(repository.findGeneratedById("missing")).thenReturn(Optional.empty());
+		assertThrows(SceneNotFoundException.class, () -> service.start("missing"));
+		assertCode("SCENE_FLOW_NOT_FOUND", () -> service.current("scene"));
+
+		assertEquals(CustomStage.WORD, service.start("scene"));
+		service.clear("scene");
+		assertCode("SCENE_FLOW_NOT_FOUND", () -> service.current("scene"));
+	}
+
+	@Test
+	void contentRejectsFutureStagesButPermitsPreviouslyUnlockedStages() {
+		service.start("scene");
+		assertCode("SCENE_FLOW_STAGE_OUT_OF_ORDER", () -> service.content("scene", SceneFlowStage.PHRASE_LEARNING));
+		assertEquals(CustomStage.PHRASE, service.next("scene"));
+		assertEquals("phrase", service.content("scene").getFirst().englishText());
+		assertEquals("word", service.content("scene", SceneFlowStage.WORD_LEARNING).getFirst().englishText());
+		assertCode("SCENE_FLOW_STAGE_INVALID", () -> service.content("scene", SceneFlowStage.IELTS_PART_1));
+	}
+
+	@Test
+	void clientCannotAdvancePastFurthestUnlockedStage() {
+		service.start("scene");
+		assertCode("SCENE_FLOW_STAGE_OUT_OF_ORDER", () -> service.next("scene", SceneFlowStage.DIALOGUE));
+
+		service.next("scene");
+		service.next("scene");
+		assertEquals(CustomStage.PHRASE, service.next("scene", SceneFlowStage.WORD_LEARNING));
+		assertEquals(CustomStage.DIALOGUE, service.next("scene", SceneFlowStage.SENTENCE_LEARNING));
+		assertTrue(!service.isCompleted("scene"));
+	}
+
+	@Test
+	void dialogueOperationsRequireTheMatchingCustomSceneSession() {
+		CustomSceneDefinition definition = definition("scene", "user");
+		when(repository.findCustomDefinitionById("scene")).thenReturn(Optional.of(definition));
+		AbstractSceneSession wrongSession = mock(AbstractSceneSession.class);
+		when(wrongSession.getSceneType()).thenReturn(SceneType.IELTS_SCENE);
+		when(sessions.requireOwnedSession("user", "session")).thenReturn(wrongSession);
+		assertCode("SESSION_ACCESS_DENIED", () -> service.getDialogueState("scene", "session"));
+
+		AbstractSceneSession matchingSession = mock(AbstractSceneSession.class);
+		when(matchingSession.getSceneType()).thenReturn(SceneType.CUSTOM_SCENE);
+		when(matchingSession.getSceneId()).thenReturn("scene");
+		when(sessions.requireOwnedSession("user", "session")).thenReturn(matchingSession);
+		ScenarioDialogueStateResponse response = mock(ScenarioDialogueStateResponse.class);
+		when(stateMachine.getState("session")).thenReturn(response);
+
+		assertEquals(response, service.getDialogueState("scene", "session"));
+		verify(stateMachine).getState("session");
+	}
+
+	@Test
+	void dialogueStartAndAdvanceDelegateOnlyAfterBindingValidation() {
+		when(repository.findCustomDefinitionById("scene")).thenReturn(Optional.of(definition("scene", "user")));
+		AbstractSceneSession matching = mock(AbstractSceneSession.class);
+		when(matching.getSceneType()).thenReturn(SceneType.CUSTOM_SCENE);
+		when(matching.getSceneId()).thenReturn("scene");
+		when(sessions.requireOwnedSession("user", "session")).thenReturn(matching);
+		ScenarioDialogueStateResponse response = mock(ScenarioDialogueStateResponse.class);
+		when(stateMachine.start("session", "scene", "{}", "goal")).thenReturn(response);
+		when(stateMachine.advance("session", 2, "hello")).thenReturn(response);
+
+		assertEquals(response, service.startDialogueState("scene", "session", "{}", "goal"));
+		assertEquals(response, service.advanceDialogueState("scene", "session", 2, "hello"));
+		verify(stateMachine).start("session", "scene", "{}", "goal");
+		verify(stateMachine).advance("session", 2, "hello");
+	}
+
+	@Test
+	void responseAndCompletionExposeLegacyStagesAndCompletionFlag() {
+		assertCode("SCENE_FLOW_NOT_FOUND", () -> service.response("scene"));
+		assertEquals(CustomStage.WORD, service.start("scene"));
+		assertEquals(SceneFlowStage.WORD_LEARNING, service.response("scene").stage());
+		service.next("scene");
+		service.next("scene");
+		service.next("scene");
+		assertEquals(CustomStage.COMPLETED, service.next("scene"));
+		assertEquals(SceneFlowStage.COMPLETED, service.response("scene").stage());
+		assertTrue(service.response("scene").completed());
+		assertTrue(service.isCompleted("scene"));
+	}
+
+	@Test
+	void completedAndDialogueContentAreEmptyAndMissingGeneratedSceneIsRejected() {
+		service.start("scene");
+		service.next("scene");
+		service.next("scene");
+		service.next("scene");
+		service.next("scene");
+		assertTrue(service.content("scene", SceneFlowStage.DIALOGUE).isEmpty());
+		assertTrue(service.content("scene", SceneFlowStage.COMPLETED).isEmpty());
+
+		when(repository.findGeneratedById("deleted")).thenReturn(Optional.empty());
+		assertCode("SCENE_FLOW_NOT_FOUND", () -> service.content("deleted"));
+	}
+
+	@Test
+	void dialogueBindingRejectsMissingDefinitionAndWrongSceneId() {
+		when(repository.findCustomDefinitionById("missing")).thenReturn(Optional.empty());
+		assertCode("SCENE_NOT_FOUND", () -> service.getDialogueState("missing", "session"));
+
+		when(repository.findCustomDefinitionById("scene")).thenReturn(Optional.of(definition("scene", "user")));
+		AbstractSceneSession wrongScene = mock(AbstractSceneSession.class);
+		when(wrongScene.getSceneType()).thenReturn(SceneType.CUSTOM_SCENE);
+		when(wrongScene.getSceneId()).thenReturn("other-scene");
+		when(sessions.requireOwnedSession("user", "session")).thenReturn(wrongScene);
+		assertCode("SESSION_ACCESS_DENIED", () -> service.startDialogueState("scene", "session", "{}", "goal"));
+	}
+
+	@Test
+	void closingReturnsNullWhenDialogueStateDoesNotExistAndClearDelegates() {
+		when(repository.findCustomDefinitionById("scene")).thenReturn(Optional.of(definition("scene", "user")));
+		AbstractSceneSession matching = mock(AbstractSceneSession.class);
+		when(matching.getSceneType()).thenReturn(SceneType.CUSTOM_SCENE);
+		when(matching.getSceneId()).thenReturn("scene");
+		when(sessions.requireOwnedSession("user", "session")).thenReturn(matching);
+		when(stateMachine.findState("session")).thenReturn(Optional.empty());
+
+		assertNull(service.beginDialogueClosing("scene", "session"));
+		service.clearDialogueState("session");
+		verify(stateMachine).remove("session");
+	}
+
+	private void assertCode(String expected, org.junit.jupiter.api.function.Executable action) {
+		assertEquals(expected, assertThrows(BusinessException.class, action).code());
+	}
+
+	private SceneGenerationResponse scene(String id) {
+		return new SceneGenerationResponse(id, List.of(item("word")), List.of(item("phrase")),
+				List.of(item("sentence")), "prompt");
+	}
+
+	private CustomSceneDefinition definition(String sceneId, String userId) {
+		return new CustomSceneDefinition(sceneId, userId, "title", "label", "background", "ai", "user",
+				"goal", "", "{}", List.of(), List.of(), List.of());
+	}
+
+	private LearningContentItem item(String english) {
+		return new LearningContentItem(english, english, "中文", "");
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneGeneratorTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneGeneratorTest.java
@@ -1,10 +1,12 @@
 package com.unispeaking.service.scene;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,6 +15,7 @@ import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import com.unispeaking.domain.po.profile.UserProfile;
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.provider.AiProviderRegistry;
 import com.unispeaking.component.scene.CustomSceneGenerator;
 import java.util.ArrayList;
@@ -213,6 +216,140 @@ class CustomSceneGeneratorTest {
 
 		assertEquals("check in", scene.phraseList().getFirst().englishText());
 		verify(registry, times(2)).executeLlmTask(anyString(), isNull());
+	}
+
+	@Test
+	void acceptsJsonFenceAndNormalizesOptionalInstruction() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.executeLlmTask(anyString(), isNull()))
+				.thenReturn("```json\n" + validResponse(5) + "\n```");
+		var service = new CustomSceneGenerator(registry, objectMapper);
+
+		var scene = service.generate(
+				"custom_fenced", "user-1", "酒店办理入住", null,
+				new UserProfile("user-1", "B", "Katerina", "zh-CN", ""));
+
+		assertEquals("保持礼貌，每次回复不超过三句话。", scene.customInstruction());
+		verify(registry).executeLlmTask(anyString(), isNull());
+	}
+
+	@Test
+	void rejectsNullBlankAndOverlongSceneInputBeforeCallingLlm() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		var service = new CustomSceneGenerator(registry, objectMapper);
+
+		for (String input : new String[] {null, " ", "x".repeat(501)}) {
+			BusinessException exception = assertThrows(BusinessException.class,
+					() -> service.generate("custom_invalid", "user-1", input, null,
+							new UserProfile("user-1", "B", "Katerina", "zh-CN", "")));
+			assertEquals("INVALID_SCENE_INPUT", exception.code());
+		}
+		verify(registry, never()).executeLlmTask(anyString(), isNull());
+	}
+
+	@Test
+	void retriesMalformedJsonDuplicateKeysTrailingTokensAndMarkdown() {
+		String base = validResponse(5);
+		String[] invalid = {
+				"not json",
+				base + " trailing",
+				"```json\n" + base + "\n``` trailing",
+				base.replaceFirst("\\{", "{\"title\":\"duplicate\",")
+		};
+		for (int index = 0; index < invalid.length; index++) {
+			final int caseIndex = index;
+			AiProviderRegistry registry = mock(AiProviderRegistry.class);
+			when(registry.executeLlmTask(anyString(), isNull()))
+					.thenReturn(invalid[index], invalid[index]);
+			var service = new CustomSceneGenerator(registry, objectMapper);
+
+			BusinessException exception = assertThrows(BusinessException.class,
+					() -> service.generate("custom_json_" + caseIndex, "user-1", "酒店办理入住", null,
+							new UserProfile("user-1", "B", "Katerina", "zh-CN", "")));
+			assertEquals("CUSTOM_SCENE_LLM_RESPONSE_INVALID", exception.code());
+			verify(registry, times(2)).executeLlmTask(anyString(), isNull());
+		}
+	}
+
+	@Test
+	void retriesWhenSuccessFactorHasInvalidBoundsTypesDuplicatesOrMissingFields() {
+		String base = validResponse(5);
+		String[] invalid = {
+				base.replace("\"estimated_minutes\":6", "\"estimated_minutes\":2"),
+				base.replace("\"minimum_user_turns\":5", "\"minimum_user_turns\":7"),
+				base.replace("\"maximum_user_turns\":10", "\"maximum_user_turns\":9"),
+				base.replace("\"completion_rule\":\"ALL_REQUIRED_OUTCOMES\"", "\"completion_rule\":\"ANY\""),
+				base.replace("\"required_outcomes\":[\"说明预订姓名\",\"确认房型和入住时间\",\"询问早餐和退房时间\"]",
+						"\"required_outcomes\":[\"说明预订姓名\",\"说明预订姓名\",\"询问早餐和退房时间\"]"),
+				base.replace("\"closing_instruction\":\"总结房间信息并祝用户入住愉快\"", "\"closing_instruction\":null")
+		};
+		assertAllRejected(invalid);
+	}
+
+	@Test
+	void retriesWhenWordsPhrasesOrSentencesViolateCountUniquenessAndReferences() {
+		String base = validResponse(5);
+		String[] invalid = {
+				validResponse(3),
+				base.replace("\"word\":\"passport\"", "\"word\":\"reservation\""),
+				base.replace("\"phrases\":[", "\"phrases\":[{"),
+				base.replace("\"sentence\":\"Could I book a room that is available?\"",
+						"\"sentence\":\"This sentence uses unrelated vocabulary.\""),
+				base.replace("\"sentences\":[", "\"sentences\":[{"),
+				base.replace("\"translation\":\"释义0\"", "\"translation\":\"\"")
+		};
+		assertAllRejected(invalid);
+	}
+
+	@Test
+	void rejectsPhraseWordCountPunctuationAndClauseShapes() {
+		String base = validResponse(5);
+		String[] invalid = {
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"check\""),
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"one two three four five six seven\""),
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"check in.\""),
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"Can I get help\""),
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"There is a room\""),
+				base.replace("\"phrase\":\"check in\"", "\"phrase\":\"The room is ready\"")
+		};
+		assertAllRejected(invalid);
+	}
+
+	@Test
+	void propagatesProviderFailuresAndReturnsLastInvalidResponseAfterTwoAttempts() {
+		AiProviderRegistry registry = mock(AiProviderRegistry.class);
+		when(registry.executeLlmTask(anyString(), isNull()))
+				.thenThrow(new IllegalStateException("provider unavailable"));
+		var service = new CustomSceneGenerator(registry, objectMapper);
+		assertThrows(IllegalStateException.class,
+				() -> service.generate("custom_provider", "user-1", "酒店办理入住", null,
+						new UserProfile("user-1", "B", "Katerina", "zh-CN", "")));
+		verify(registry).executeLlmTask(anyString(), isNull());
+
+		AiProviderRegistry invalidRegistry = mock(AiProviderRegistry.class);
+		when(invalidRegistry.executeLlmTask(anyString(), isNull()))
+				.thenReturn("{}", "{}");
+		var invalidService = new CustomSceneGenerator(invalidRegistry, objectMapper);
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> invalidService.generate("custom_invalid_final", "user-1", "酒店办理入住", null,
+						new UserProfile("user-1", "B", "Katerina", "zh-CN", "")));
+		assertEquals("CUSTOM_SCENE_LLM_RESPONSE_INVALID", exception.code());
+		verify(invalidRegistry, times(2)).executeLlmTask(anyString(), isNull());
+	}
+
+	private void assertAllRejected(String[] responses) {
+		for (int index = 0; index < responses.length; index++) {
+			final int caseIndex = index;
+			AiProviderRegistry registry = mock(AiProviderRegistry.class);
+			when(registry.executeLlmTask(anyString(), isNull()))
+					.thenReturn(responses[index], responses[index]);
+			var service = new CustomSceneGenerator(registry, objectMapper);
+			BusinessException exception = assertThrows(BusinessException.class,
+					() -> service.generate("custom_rejected_" + caseIndex, "user-1", "酒店办理入住", null,
+							new UserProfile("user-1", "B", "Katerina", "zh-CN", "")));
+			assertEquals("CUSTOM_SCENE_LLM_RESPONSE_INVALID", exception.code());
+			verify(registry, times(2)).executeLlmTask(anyString(), isNull());
+		}
 	}
 
 	private String validResponse(int wordCount) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/CustomSceneServiceTest.java
@@ -1,0 +1,128 @@
+package com.unispeaking.service.scene;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.prompt.FiveLayerPromptBuilder;
+import com.unispeaking.component.scene.CustomSceneGenerator;
+import com.unispeaking.domain.dto.scene.LearningContentItem;
+import com.unispeaking.domain.dto.scene.SceneGenerationResponse;
+import com.unispeaking.domain.po.profile.UserProfile;
+import com.unispeaking.domain.po.scene.CustomSceneDefinition;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import com.unispeaking.provider.AiProviderRegistry;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.service.profile.ProfileService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import tools.jackson.databind.ObjectMapper;
+
+class CustomSceneServiceTest {
+
+	private static final String USER_ID = "11111111-1111-4111-8111-111111111111";
+	private final AuthService authService = mock(AuthService.class);
+	private final ProfileService profileService = mock(ProfileService.class);
+	private final SceneRepository repository = mock(SceneRepository.class);
+	private final FiveLayerPromptBuilder promptBuilder = mock(FiveLayerPromptBuilder.class);
+	private final AiProviderRegistry providers = mock(AiProviderRegistry.class);
+	private final CustomSceneService service = new CustomSceneService(
+			authService, profileService, repository, promptBuilder,
+			mock(CustomSceneGenerator.class), providers, new ObjectMapper());
+
+	@BeforeEach
+	void authenticate() {
+		when(authService.requireUserId(null)).thenReturn(USER_ID);
+	}
+
+	@Test
+	void speechRequiresOwnershipAndNonBlankText() {
+		when(repository.findCustomDefinitionById("missing")).thenReturn(Optional.empty());
+		assertCode("CUSTOM_SCENE_NOT_FOUND", () -> service.synthesizeSpeech("missing", "hello", null));
+
+		CustomSceneDefinition foreign = definition("foreign", "another-user", "{}");
+		when(repository.findCustomDefinitionById("foreign")).thenReturn(Optional.of(foreign));
+		assertCode("CUSTOM_SCENE_ACCESS_DENIED", () -> service.synthesizeSpeech("foreign", "hello", null));
+
+		when(repository.findCustomDefinitionById("owned")).thenReturn(Optional.of(definition("owned", USER_ID, "{}")));
+		assertCode("TTS_TEXT_REQUIRED", () -> service.synthesizeSpeech("owned", "  ", null));
+	}
+
+	@Test
+	void speechUsesProfileVoiceAndRejectsEmptyProviderAudio() {
+		CustomSceneDefinition definition = definition("owned", USER_ID, "{}");
+		when(repository.findCustomDefinitionById("owned")).thenReturn(Optional.of(definition));
+		when(profileService.getProfile(USER_ID)).thenReturn(profile("Tina"));
+		when(providers.generateSpeechAudioBytes(AiProviderRegistry.QWEN_TTS, "hello", null, "Tina"))
+				.thenReturn(new byte[] {1, 2});
+
+		assertArrayEquals(new byte[] {1, 2}, service.synthesizeSpeech("owned", " hello ", "ignored"));
+		verify(providers).generateSpeechAudioBytes(AiProviderRegistry.QWEN_TTS, "hello", null, "Tina");
+
+		when(providers.generateSpeechAudioBytes(AiProviderRegistry.QWEN_TTS, "empty", null, "Tina"))
+				.thenReturn(new byte[0]);
+		assertCode("TTS_AUDIO_EMPTY", () -> service.synthesizeSpeech("owned", "empty", null));
+	}
+
+	@Test
+	void translationNormalizesTextAndValidatesProviderOutput() {
+		when(repository.findCustomDefinitionById("owned")).thenReturn(Optional.of(definition("owned", USER_ID, "{}")));
+		assertCode("TRANSLATION_TEXT_REQUIRED", () -> service.translate("owned", " "));
+		assertCode("TRANSLATION_TEXT_TOO_LONG", () -> service.translate("owned", "x".repeat(4001)));
+		when(providers.executeLlmTask(any(String.class), eq(null))).thenReturn("  你好，世界。  ");
+
+		var result = service.translate("owned", "  Hello, world.  ");
+
+		assertEquals("Hello, world.", result.sourceText());
+		assertEquals("你好，世界。", result.translatedText());
+		assertEquals("zh-CN", result.targetLanguage());
+		when(providers.executeLlmTask(any(String.class), eq(null))).thenReturn(" ");
+		assertCode("TRANSLATION_EMPTY", () -> service.translate("owned", "hello"));
+	}
+
+	@Test
+	void generatedSceneAndDialogueRequireOwnedPersistedData() {
+		CustomSceneDefinition definition = definition("owned", USER_ID, "{not-json}");
+		when(repository.findCustomDefinitionById("owned")).thenReturn(Optional.of(definition));
+		when(repository.findGeneratedById("owned")).thenReturn(Optional.empty());
+		assertCode("CUSTOM_SCENE_NOT_FOUND", () -> service.getGeneratedScene("owned"));
+
+		SceneGenerationResponse generated = new SceneGenerationResponse(
+				"owned", List.of(item("word")), List.of(), List.of(), "");
+		when(repository.findGeneratedById("owned")).thenReturn(Optional.of(generated));
+		when(profileService.getProfile(USER_ID)).thenReturn(profile("Tina"));
+		when(promptBuilder.compose(any(), any(), eq(SceneType.CUSTOM_SCENE), eq(definition.title()), eq(""),
+				any(), any(), any(), eq(definition))).thenReturn(List.of("rebuilt prompt"));
+
+		var context = service.prepareDialogue("owned");
+
+		assertEquals("rebuilt prompt", context.prompt());
+		assertEquals("owned", service.getGeneratedScene("owned").sceneId());
+	}
+
+	private void assertCode(String expected, org.junit.jupiter.api.function.Executable action) {
+		assertEquals(expected, assertThrows(BusinessException.class, action).code());
+	}
+
+	private CustomSceneDefinition definition(String sceneId, String userId, String factors) {
+		return new CustomSceneDefinition(sceneId, userId, "酒店入住", "旅行", "酒店", "前台", "住客",
+				"完成入住", "", factors, List.of(item("word")), List.of(), List.of());
+	}
+
+	private UserProfile profile(String voiceId) {
+		return new UserProfile(USER_ID, "B", voiceId, "NATURAL", "zh-CN", "旅行");
+	}
+
+	private LearningContentItem item(String id) {
+		return new LearningContentItem(id, "hello", "你好", "");
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/FreeChatSceneServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/FreeChatSceneServiceTest.java
@@ -1,0 +1,102 @@
+package com.unispeaking.service.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.common.prompt.FiveLayerPromptBuilder;
+import com.unispeaking.domain.dto.scene.FreeChatSceneRequest;
+import com.unispeaking.domain.dto.scene.FreeChatSceneResult;
+import com.unispeaking.domain.po.profile.UserProfile;
+import com.unispeaking.domain.vo.scene.SceneConfig;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import com.unispeaking.provider.AiProviderRegistry;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.service.profile.ProfileService;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class FreeChatSceneServiceTest {
+
+	@Test
+	void preparesFreeChatWithTrimmedPromptAndGeneratesScene() {
+		AuthService auth = mock(AuthService.class);
+		ProfileService profiles = mock(ProfileService.class);
+		SceneRepository scenes = mock(SceneRepository.class);
+		FiveLayerPromptBuilder prompts = mock(FiveLayerPromptBuilder.class);
+		AiProviderRegistry providers = mock(AiProviderRegistry.class);
+		when(auth.requireUserId(null)).thenReturn("user-1");
+		UserProfile profile = mock(UserProfile.class);
+		SceneConfig config = mock(SceneConfig.class);
+		when(profiles.getProfile("user-1")).thenReturn(profile);
+		when(scenes.findByType(SceneType.FREE_CHAT)).thenReturn(Optional.of(config));
+		when(prompts.compose(
+				profile, config, SceneType.FREE_CHAT, "hello", null,
+				List.of(), List.of(), List.of()))
+				.thenReturn(List.of("system", "hello"));
+
+		FreeChatSceneService service = new FreeChatSceneService(
+				auth, profiles, scenes, prompts, providers);
+		FreeChatSceneResult result = service.generate(new FreeChatSceneRequest("  hello  "));
+
+		assertTrue(result.sceneId().startsWith("freechat_"));
+		assertEquals("system\n\nhello", result.dialoguePrompt());
+		verify(prompts).compose(
+				profile, config, SceneType.FREE_CHAT, "hello", null,
+				List.of(), List.of(), List.of());
+	}
+
+	@Test
+	void preparesFreeChatWithNullRequestAndRejectsMissingConfiguration() {
+		AuthService auth = mock(AuthService.class);
+		SceneRepository scenes = mock(SceneRepository.class);
+		when(auth.requireUserId(null)).thenReturn("user-1");
+		when(scenes.findByType(SceneType.FREE_CHAT)).thenReturn(Optional.empty());
+		FreeChatSceneService service = new FreeChatSceneService(
+				auth, mock(ProfileService.class), scenes,
+				mock(FiveLayerPromptBuilder.class), mock(AiProviderRegistry.class));
+
+		assertThrows(RuntimeException.class, () -> service.prepare(null));
+	}
+
+	@Test
+	void translationValidatesInputAndStripsModelOutput() {
+		AuthService auth = mock(AuthService.class);
+		AiProviderRegistry providers = mock(AiProviderRegistry.class);
+		when(providers.executeLlmTask(anyString(), isNull())).thenReturn("  你好  ");
+		FreeChatSceneService service = new FreeChatSceneService(
+				auth, mock(ProfileService.class), mock(SceneRepository.class),
+				mock(FiveLayerPromptBuilder.class), providers);
+
+		assertEquals("你好", service.translate("  Hello  ").translatedText());
+		assertEquals("Hello", service.translate("  Hello  ").sourceText());
+		assertEquals("TRANSLATION_TEXT_REQUIRED", assertThrows(
+				BusinessException.class, () -> service.translate(" \t ")).code());
+		assertEquals("TRANSLATION_TEXT_REQUIRED", assertThrows(
+				BusinessException.class, () -> service.translate(null)).code());
+		assertEquals("TRANSLATION_TEXT_TOO_LONG", assertThrows(
+				BusinessException.class, () -> service.translate("x".repeat(4001))).code());
+	}
+
+	@Test
+	void translationRejectsEmptyModelOutput() {
+		AiProviderRegistry providers = mock(AiProviderRegistry.class);
+		when(providers.executeLlmTask(anyString(), isNull())).thenReturn(" \n ");
+		FreeChatSceneService service = new FreeChatSceneService(
+			mock(AuthService.class), mock(ProfileService.class), mock(SceneRepository.class),
+			mock(FiveLayerPromptBuilder.class), providers);
+
+		BusinessException exception = assertThrows(
+				BusinessException.class, () -> service.translate("Hello"));
+		assertEquals("TRANSLATION_EMPTY", exception.code());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/IeltsSceneFlowServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/IeltsSceneFlowServiceTest.java
@@ -1,0 +1,124 @@
+package com.unispeaking.service.scene;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.exception.BusinessException;
+import com.unispeaking.component.session.RealtimeSessionCoordinator;
+import com.unispeaking.component.statemachine.IeltsPart2StateMachine;
+import com.unispeaking.component.statemachine.IeltsQuestionStateMachine;
+import com.unispeaking.domain.dto.session.IeltsDialogueStateResponse;
+import com.unispeaking.domain.dto.session.IeltsPart2StateResponse;
+import com.unispeaking.domain.po.scene.IeltsPracticeRecord;
+import com.unispeaking.domain.po.session.AbstractSceneSession;
+import com.unispeaking.domain.vo.scene.IeltsContent;
+import com.unispeaking.domain.vo.scene.IeltsMode;
+import com.unispeaking.domain.vo.scene.IeltsPart;
+import com.unispeaking.domain.vo.scene.IeltsPart2Event;
+import com.unispeaking.domain.vo.scene.IeltsStage;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.infrastructure.persistence.repository.scene.IeltsPracticeRepository;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class IeltsSceneFlowServiceTest {
+
+	private final IeltsPracticeRepository practices = mock(IeltsPracticeRepository.class);
+	private final IeltsQuestionStateMachine questions = mock(IeltsQuestionStateMachine.class);
+	private final IeltsPart2StateMachine partTwo = mock(IeltsPart2StateMachine.class);
+	private final RealtimeSessionCoordinator sessions = mock(RealtimeSessionCoordinator.class);
+	private final IeltsSceneFlowService service = new IeltsSceneFlowService(
+			practices, questions, partTwo, sessions);
+	private final UUID userId = UUID.randomUUID();
+
+	@Test
+	void startRejectsMissingPracticeAndStartsPartPracticeAtItsSelectedPart() {
+		when(practices.findPractice("missing")).thenReturn(Optional.empty());
+		assertCode("IELTS_PRACTICE_NOT_FOUND", () -> service.start("missing"));
+
+		IeltsPracticeRecord partPractice = practice(
+				"part-practice", IeltsMode.PART_PRACTICE, IeltsPart.PART_3);
+		when(practices.findPractice("part-practice"))
+				.thenReturn(Optional.of(partPractice));
+		assertEquals(IeltsStage.PART3, service.start("part-practice"));
+	}
+
+	@Test
+	void mockPracticeProgressesThroughAllPartsAndExposesLegacyResponse() {
+		IeltsPracticeRecord practice = practice("mock", IeltsMode.MOCK_TEST, null);
+		when(practices.findPractice("mock")).thenReturn(Optional.of(practice));
+
+		assertEquals(IeltsStage.PART1, service.start("mock"));
+		assertEquals(IeltsStage.PART2, service.next("mock"));
+		assertEquals(com.unispeaking.domain.vo.scene.SceneFlowStage.IELTS_PART_2,
+				service.response("mock").stage());
+		assertEquals(IeltsStage.PART3, service.next("mock"));
+		assertEquals(IeltsStage.COMPLETED, service.next("mock"));
+		assertEquals(IeltsStage.COMPLETED, service.next("mock"));
+	}
+
+	@Test
+	void sessionStateRequiresMatchingIeltsBindingBeforeDelegation() {
+		IeltsPracticeRecord practice = practice("scene", IeltsMode.PART_PRACTICE, IeltsPart.PART_1);
+		when(practices.findPractice("scene")).thenReturn(Optional.of(practice));
+		AbstractSceneSession wrong = mock(AbstractSceneSession.class);
+		when(wrong.getSceneType()).thenReturn(SceneType.CUSTOM_SCENE);
+		when(sessions.requireOwnedSession(userId.toString(), "session")).thenReturn(wrong);
+		assertCode("IELTS_SESSION_MISMATCH", () -> service.getDialogueState("scene", "session"));
+
+		AbstractSceneSession matching = mock(AbstractSceneSession.class);
+		when(matching.getSceneType()).thenReturn(SceneType.IELTS_SCENE);
+		when(matching.getSceneId()).thenReturn("scene");
+		when(sessions.requireOwnedSession(userId.toString(), "session")).thenReturn(matching);
+		IeltsDialogueStateResponse dialogue = mock(IeltsDialogueStateResponse.class);
+		IeltsPart2StateResponse part2 = mock(IeltsPart2StateResponse.class);
+		when(questions.get("scene", "session")).thenReturn(dialogue);
+		when(partTwo.get("scene", "session")).thenReturn(part2);
+
+		assertEquals(dialogue, service.getDialogueState("scene", "session"));
+		assertEquals(part2, service.getPart2State("scene", "session"));
+	}
+
+	@Test
+	void startsAndAdvancesTheCorrectStateMachineForEachPart() {
+		IeltsPracticeRecord practice = practice("scene", IeltsMode.MOCK_TEST, null);
+		when(practices.findPractice("scene")).thenReturn(Optional.of(practice));
+		AbstractSceneSession matching = mock(AbstractSceneSession.class);
+		when(matching.getSceneType()).thenReturn(SceneType.IELTS_SCENE);
+		when(matching.getSceneId()).thenReturn("scene");
+		when(sessions.requireOwnedSession(userId.toString(), "session")).thenReturn(matching);
+		IeltsDialogueStateResponse dialogue = mock(IeltsDialogueStateResponse.class);
+		IeltsPart2StateResponse part2 = mock(IeltsPart2StateResponse.class);
+		when(questions.advance("scene", "session", 2, false)).thenReturn(dialogue);
+		when(partTwo.advance("scene", "session", IeltsPart2Event.LONG_TURN_TIME_LIMIT)).thenReturn(part2);
+
+		service.startSessionState("scene", "session", IeltsPart.PART_1);
+		service.startSessionState("scene", "session", IeltsPart.PART_2);
+		assertEquals(dialogue, service.advanceDialogueState("scene", "session", 2, false));
+		assertEquals(part2, service.advancePart2State("scene", "session", IeltsPart2Event.LONG_TURN_TIME_LIMIT));
+		verify(questions).start("scene", "session", IeltsPart.PART_1, practice.content().part1());
+		verify(partTwo).start("scene", "session");
+	}
+
+	@Test
+	void clearSessionStateRemovesBothMachineCaches() {
+		service.clearSessionState("session");
+		verify(questions).remove("session");
+		verify(partTwo).remove("session");
+	}
+
+	private void assertCode(String expected, org.junit.jupiter.api.function.Executable action) {
+		assertEquals(expected, assertThrows(BusinessException.class, action).code());
+	}
+
+	private IeltsPracticeRecord practice(String id, IeltsMode mode, IeltsPart part) {
+		return new IeltsPracticeRecord(id, userId, mode, part, "topic",
+				new IeltsContent(List.of(), List.of(), List.of()));
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/IeltsSceneServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/IeltsSceneServiceTest.java
@@ -12,12 +12,14 @@ import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.common.prompt.IeltsExaminerPromptBuilder;
 import com.unispeaking.common.util.search.TitleRelevanceCalculator;
 import com.unispeaking.domain.dto.scene.IeltsGenerationRequest;
+import com.unispeaking.domain.dto.scene.UpdateIeltsSettingsRequest;
 import com.unispeaking.domain.po.scene.IeltsPracticeRecord;
 import com.unispeaking.domain.po.scene.IeltsQuestion;
 import com.unispeaking.domain.po.scene.IeltsTopic;
 import com.unispeaking.domain.po.scene.IeltsUserSettings;
 import com.unispeaking.domain.vo.scene.IeltsMode;
 import com.unispeaking.domain.vo.scene.IeltsContent;
+import com.unispeaking.domain.vo.scene.IeltsContentQuestion;
 import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.domain.vo.scene.IeltsStage;
 import com.unispeaking.domain.vo.scene.IeltsTopicType;
@@ -29,6 +31,7 @@ import com.unispeaking.service.scene.IeltsSceneFlowService;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.math.BigDecimal;
 import java.util.stream.IntStream;
 import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.BeforeEach;
@@ -218,6 +221,294 @@ class IeltsSceneServiceTest {
 		verify(practiceRepository, never()).incrementCompletedCount(userId);
 	}
 
+	@Test
+	void dialogueRejectsMissingAndForeignPractices() {
+		when(practiceRepository.findPractice("missing")).thenReturn(Optional.empty());
+		BusinessException missing = assertThrows(BusinessException.class,
+				() -> service.completeDialogue("missing", userId.toString()));
+		assertEquals("IELTS_PRACTICE_NOT_FOUND", missing.code());
+
+		when(practiceRepository.findPractice("foreign"))
+				.thenReturn(Optional.of(new IeltsPracticeRecord("foreign", UUID.randomUUID(),
+						IeltsMode.PART_PRACTICE, IeltsPart.PART_1, "topic", emptyContent())));
+		BusinessException denied = assertThrows(BusinessException.class,
+				() -> service.completeDialogue("foreign", userId.toString()));
+		assertEquals("IELTS_PRACTICE_ACCESS_DENIED", denied.code());
+	}
+
+	@Test
+	void generationRejectsInvalidRequestsMissingTopicsAndEmptyQuestions() {
+		BusinessException invalid = assertThrows(BusinessException.class, () -> service.generate(null));
+		assertEquals("IELTS_GENERATION_REQUEST_INVALID", invalid.code());
+		BusinessException missingTopic = assertThrows(BusinessException.class,
+				() -> service.generate(request(IeltsPart.PART_1, "missing")));
+		assertEquals("IELTS_TOPIC_NOT_FOUND", missingTopic.code());
+
+		IeltsTopic topic = topic("empty", IeltsTopicType.PART_1_POOL);
+		when(repository.findTopicById(topic.id())).thenReturn(Optional.of(topic));
+		when(repository.findQuestions(topic.id(), IeltsPart.PART_1)).thenReturn(List.of());
+		BusinessException missingQuestions = assertThrows(BusinessException.class,
+				() -> service.generate(request(IeltsPart.PART_1, topic.id())));
+		assertEquals("IELTS_QUESTIONS_NOT_FOUND", missingQuestions.code());
+	}
+
+	@Test
+	void generationUsesDefaultVoiceAndMarksExplicitTopicSelection() {
+		IeltsTopic topic = topic("weekends", IeltsTopicType.PART_1_POOL);
+		when(practiceRepository.getOrCreateSettings(userId)).thenReturn(new IeltsUserSettings(userId, null, 0, null));
+		when(repository.findTopicById(topic.id())).thenReturn(Optional.of(topic));
+		when(repository.findQuestions(topic.id(), IeltsPart.PART_1)).thenReturn(questions(topic.id(), IeltsPart.PART_1, 1));
+
+		var result = service.generate(request(IeltsPart.PART_1, topic.id()));
+
+		assertEquals("Harvey", result.voiceId());
+		ArgumentCaptor<IeltsPracticeRecord> record = ArgumentCaptor.forClass(IeltsPracticeRecord.class);
+		verify(practiceRepository).createPractice(record.capture());
+		assertEquals("USER_SELECTED", record.getValue().topicSelectionMethod());
+		verify(practiceRepository).updateSettings(userId, null, "Harvey");
+	}
+
+	@Test
+	void settingsRejectInvalidValuesAndMapsAnExaminer() {
+		BusinessException empty = assertThrows(BusinessException.class, () -> service.updateSettings(null));
+		assertEquals("IELTS_SETTINGS_EMPTY", empty.code());
+		BusinessException invalidScore = assertThrows(BusinessException.class,
+				() -> service.updateSettings(new UpdateIeltsSettingsRequest(new BigDecimal("6.3"), null)));
+		assertEquals("IELTS_TARGET_SCORE_INVALID", invalidScore.code());
+
+		when(practiceRepository.updateSettings(userId, new BigDecimal("7.5"), "Harvey"))
+				.thenReturn(new IeltsUserSettings(userId, new BigDecimal("7.5"), 2, "Harvey"));
+		var settings = service.updateSettings(new UpdateIeltsSettingsRequest(new BigDecimal("7.5"), "daniel"));
+		assertEquals("daniel", settings.examinerId());
+		assertEquals(2, settings.todayCompletedCount());
+	}
+
+	@Test
+	void searchRejectsInvalidPagingAndBuildsCategories() {
+		BusinessException invalid = assertThrows(BusinessException.class,
+				() -> service.searchTopics(IeltsPart.PART_1, "ALL", null, 0, 10));
+		assertEquals("IELTS_PAGINATION_INVALID", invalid.code());
+		IeltsTopic person = new IeltsTopic("person", "A person", IeltsTopicType.PART_1_POOL, "PERSON", "seed", "ACTIVE");
+		IeltsTopic required = topic("required", IeltsTopicType.PART_1_POOL);
+		when(repository.findTopics(IeltsTopicType.PART_1_POOL)).thenReturn(List.of(person, required));
+		when(repository.findQuestions(List.of("person", "required"), IeltsPart.PART_1)).thenReturn(List.of());
+		when(practiceRepository.findTopicPracticeSummaries(userId, IeltsPart.PART_1, List.of("person", "required"))).thenReturn(java.util.Map.of());
+
+		var result = service.searchTopics(IeltsPart.PART_1, "ALL", null, 1, 10);
+
+		assertEquals(List.of("PERSON", "REQUIRED"), result.categories().stream().map(item -> item.code()).toList());
+		assertEquals(2, result.total());
+	}
+
+	@Test
+	void prepareDialogueRejectsCompletedFlowsAndMissingTopics() {
+		IeltsPracticeRecord practice = new IeltsPracticeRecord("completed", userId,
+				IeltsMode.PART_PRACTICE, IeltsPart.PART_1, "topic", emptyContent());
+		when(practiceRepository.findPractice("completed")).thenReturn(Optional.of(practice));
+		when(flowService.current("completed")).thenReturn(IeltsStage.COMPLETED);
+		BusinessException completed = assertThrows(BusinessException.class,
+				() -> service.prepareDialogue("completed", "Harvey"));
+		assertEquals("IELTS_FLOW_COMPLETED", completed.code());
+
+		when(flowService.current("completed")).thenReturn(IeltsStage.PART1);
+		when(repository.findTopicById("topic")).thenReturn(Optional.empty());
+		BusinessException missingTopic = assertThrows(BusinessException.class,
+				() -> service.prepareDialogue("completed", "Harvey"));
+		assertEquals("IELTS_TOPIC_NOT_FOUND", missingTopic.code());
+	}
+
+	@Test
+	void buildDialoguePromptChecksOwnershipAndUsesDefaultVoice() {
+		when(practiceRepository.findPractice("missing")).thenReturn(Optional.empty());
+		BusinessException missing = assertThrows(BusinessException.class,
+				() -> service.buildDialoguePrompt("missing", IeltsPart.PART_1));
+		assertEquals("IELTS_PRACTICE_NOT_FOUND", missing.code());
+
+		IeltsPracticeRecord foreign = new IeltsPracticeRecord("foreign", UUID.randomUUID(),
+				IeltsMode.PART_PRACTICE, IeltsPart.PART_1, "topic", emptyContent());
+		when(practiceRepository.findPractice("foreign")).thenReturn(Optional.of(foreign));
+		BusinessException denied = assertThrows(BusinessException.class,
+				() -> service.buildDialoguePrompt("foreign", IeltsPart.PART_1));
+		assertEquals("IELTS_PRACTICE_ACCESS_DENIED", denied.code());
+
+		IeltsPracticeRecord owned = new IeltsPracticeRecord("owned", userId,
+				IeltsMode.PART_PRACTICE, IeltsPart.PART_1, null,
+				new IeltsContent(List.of(new IeltsContentQuestion(
+						"What do you enjoy?", List.of(), List.of())), List.of(), List.of()));
+		when(practiceRepository.findPractice("owned")).thenReturn(Optional.of(owned));
+		when(practiceRepository.getOrCreateSettings(userId)).thenReturn(new IeltsUserSettings(userId, null, 0, null));
+		assertTrue(service.buildDialoguePrompt("owned", IeltsPart.PART_1).contains("My name is Daniel"));
+	}
+
+	@Test
+	void getSettingsAndSearchRespectCurrentUserAndFilteredCategory() {
+		when(practiceRepository.getOrCreateSettings(userId)).thenReturn(
+				new IeltsUserSettings(userId, new BigDecimal("6.5"), 3, "Mione"));
+		var settings = service.getSettings();
+		assertEquals("margaret", settings.examinerId());
+		assertEquals(3, settings.todayCompletedCount());
+
+		IeltsTopic required = topic("required", IeltsTopicType.PART_1_POOL);
+		IeltsTopic person = new IeltsTopic("person", "A person", IeltsTopicType.PART_1_POOL,
+				"PERSON", "seed", "ACTIVE");
+		when(repository.findTopics(IeltsTopicType.PART_1_POOL)).thenReturn(List.of(required, person));
+		when(repository.findQuestions(List.of("person"), IeltsPart.PART_1)).thenReturn(List.of());
+		when(practiceRepository.findTopicPracticeSummaries(userId, IeltsPart.PART_1, List.of("person")))
+				.thenReturn(java.util.Map.of());
+
+		var response = service.searchTopics(IeltsPart.PART_1, " person ", null, 2, 1);
+		assertEquals(0, response.topics().size());
+		assertEquals(1, response.total());
+		assertEquals(1, response.totalPages());
+	}
+
+	@Test
+	void prepareDialogueMapsEveryActivePartAndSynchronizesChangedVoice() {
+		IeltsPracticeRecord practice = new IeltsPracticeRecord(
+				"dialogue", userId, IeltsMode.PART_PRACTICE, IeltsPart.PART_1,
+				"part-1-topic", "USER_SELECTED", "part-1-topic", "part-2-topic",
+				"part-3-topic", dialogueContent());
+		when(practiceRepository.findPractice("dialogue")).thenReturn(Optional.of(practice));
+		when(practiceRepository.getOrCreateSettings(userId))
+				.thenReturn(new IeltsUserSettings(userId, null, 0, "Harvey"));
+		when(flowService.response("dialogue")).thenReturn(null);
+
+		for (var part : List.of(IeltsStage.PART1, IeltsStage.PART2, IeltsStage.PART3)) {
+			when(flowService.current("dialogue")).thenReturn(part);
+			String topicId = switch (part) {
+				case PART1 -> "part-1-topic";
+				case PART2 -> "part-2-topic";
+				case PART3 -> "part-3-topic";
+				case COMPLETED -> throw new AssertionError();
+			};
+			when(repository.findTopicById(topicId)).thenReturn(Optional.of(
+					topic(topicId, part == IeltsStage.PART1
+							? IeltsTopicType.PART_1_POOL : IeltsTopicType.PART_2_3_BUNDLE)));
+
+				var context = service.prepareDialogue("dialogue", "Harvey");
+
+			assertEquals(part == IeltsStage.PART1 ? IeltsPart.PART_1
+					: part == IeltsStage.PART2 ? IeltsPart.PART_2 : IeltsPart.PART_3,
+				context.activePart());
+			assertEquals("Harvey", context.voiceId());
+			if (part == IeltsStage.PART1 && practice.mode() == IeltsMode.PART_PRACTICE) {
+				assertTrue(context.topicTitle().startsWith("Topic part-1-topic"));
+			}
+		}
+
+		verify(practiceRepository, org.mockito.Mockito.never())
+				.updateSettings(userId, null, "Daniel");
+	}
+
+	@Test
+	void prepareDialogueUsesMockPartOneTopicFallbackAndDefaultTopicTitle() {
+		IeltsPracticeRecord mockPractice = new IeltsPracticeRecord(
+				"mock-dialogue", userId, IeltsMode.MOCK_TEST, null, null,
+				"RANDOM", null, null, null, dialogueContent());
+		when(practiceRepository.findPractice("mock-dialogue")).thenReturn(Optional.of(mockPractice));
+		when(practiceRepository.getOrCreateSettings(userId))
+				.thenReturn(new IeltsUserSettings(userId, null, 0, "Daniel"));
+		when(flowService.current("mock-dialogue")).thenReturn(IeltsStage.PART1);
+		when(flowService.response("mock-dialogue")).thenReturn(null);
+
+			var context = service.prepareDialogue("mock-dialogue", "Harvey");
+
+		assertEquals(IeltsPart.PART_1, context.activePart());
+		assertEquals("familiar everyday topics", context.topicTitle());
+		verify(repository, never()).findTopicById(null);
+	}
+
+	@Test
+	void prepareDialogueUsesDefaultTitleForNullTopicAndRequiresOwnedPractice() {
+		IeltsPracticeRecord practice = new IeltsPracticeRecord(
+				"untitled", userId, IeltsMode.PART_PRACTICE, IeltsPart.PART_2,
+				null, "RANDOM", null, null, null, dialogueContent());
+		when(practiceRepository.findPractice("untitled")).thenReturn(Optional.of(practice));
+		when(practiceRepository.getOrCreateSettings(userId))
+				.thenReturn(new IeltsUserSettings(userId, null, 0, "Daniel"));
+		when(flowService.current("untitled")).thenReturn(IeltsStage.PART2);
+		when(flowService.response("untitled")).thenReturn(null);
+
+			var context = service.prepareDialogue("untitled", "Harvey");
+
+		assertEquals("IELTS Speaking", context.topicTitle());
+		assertEquals(userId.toString(), context.userId());
+
+		when(authService.requireUserId(null)).thenReturn(UUID.randomUUID().toString());
+		BusinessException denied = assertThrows(BusinessException.class,
+			() -> service.prepareDialogue("untitled", "Harvey"));
+		assertEquals("IELTS_PRACTICE_ACCESS_DENIED", denied.code());
+	}
+
+	@Test
+	void searchSupportsPartTwoAndThreeAndFiltersLowRelevanceTopics() {
+		IeltsTopic partTwo = topic("part-two", IeltsTopicType.PART_2_3_BUNDLE);
+		IeltsTopic unrelated = new IeltsTopic(
+				"unrelated", "Completely unrelated", IeltsTopicType.PART_2_3_BUNDLE,
+				"OBJECT", "import", "ACTIVE");
+		when(repository.findTopics(IeltsTopicType.PART_2_3_BUNDLE))
+				.thenReturn(List.of(partTwo, unrelated));
+		when(repository.findQuestions(List.of("part-two"), IeltsPart.PART_2))
+				.thenReturn(List.of());
+		when(practiceRepository.findTopicPracticeSummaries(
+				userId, IeltsPart.PART_2, List.of("part-two")))
+				.thenReturn(java.util.Map.of());
+
+		var result = service.searchTopics(IeltsPart.PART_2, "ALL", "part-two", 1, 50);
+
+		assertEquals(1, result.total());
+		assertEquals("part-two", result.topics().getFirst().id());
+	}
+
+	@Test
+	void trainingMapsPartTwoAndPartThreeQuestionsAndRejectsEmptyPools() {
+		IeltsTopic topic = topic("bundle", IeltsTopicType.PART_2_3_BUNDLE);
+		for (IeltsPart part : List.of(IeltsPart.PART_2, IeltsPart.PART_3)) {
+			when(repository.findTopicById(topic.id())).thenReturn(Optional.of(topic));
+			when(repository.findQuestions(topic.id(), part)).thenReturn(
+					questions(topic.id(), part, 2));
+			var response = service.prepareTraining(part, topic.id());
+			assertEquals(part, response.part());
+			assertEquals(2, response.questions().size());
+		}
+
+		when(repository.findQuestions(topic.id(), IeltsPart.PART_3)).thenReturn(List.of());
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> service.prepareTraining(IeltsPart.PART_3, topic.id()));
+		assertEquals("IELTS_QUESTIONS_NOT_FOUND", exception.code());
+	}
+
+	@Test
+	void generationSupportsPartThreeAndRejectsMissingRandomCandidates() {
+		IeltsTopic topic = topic("part-three", IeltsTopicType.PART_2_3_BUNDLE);
+		when(repository.findTopicById(topic.id())).thenReturn(Optional.of(topic));
+		when(repository.findQuestions(topic.id(), IeltsPart.PART_3))
+				.thenReturn(questions(topic.id(), IeltsPart.PART_3, 1));
+
+		var result = service.generate(request(IeltsPart.PART_3, topic.id()));
+		assertEquals(IeltsPart.PART_3, result.selectedPart());
+		assertEquals(topic.id(), result.selectedTopicId());
+		verify(practiceRepository).createPractice(org.mockito.ArgumentMatchers.argThat(
+				practice -> practice.part3TopicId().equals(topic.id())));
+
+		when(repository.findTopics(IeltsTopicType.PART_2_3_BUNDLE)).thenReturn(List.of());
+		BusinessException missing = assertThrows(BusinessException.class,
+				() -> service.generate(request(IeltsPart.PART_3, null)));
+		assertEquals("IELTS_TOPIC_NOT_FOUND", missing.code());
+	}
+
+	@Test
+	void settingsMapBlankVoiceToNullAndUnknownExaminerIsRejected() {
+		when(practiceRepository.updateSettings(userId, new BigDecimal("7.0"), null))
+				.thenReturn(new IeltsUserSettings(userId, new BigDecimal("7.0"), 0, ""));
+		var response = service.updateSettings(
+				new UpdateIeltsSettingsRequest(new BigDecimal("7.0"), " "));
+		assertEquals(null, response.examinerId());
+
+		assertThrows(BusinessException.class,
+				() -> service.updateSettings(new UpdateIeltsSettingsRequest(null, "unknown")));
+	}
+
 	private IeltsPracticeRecord mockPractice(String ieltsId) {
 		return new IeltsPracticeRecord(
 				ieltsId,
@@ -226,6 +517,17 @@ class IeltsSceneServiceTest {
 				null,
 				null,
 				new IeltsContent(List.of(), List.of(), List.of()));
+	}
+
+	private IeltsContent emptyContent() {
+		return new IeltsContent(List.of(), List.of(), List.of());
+	}
+
+	private IeltsContent dialogueContent() {
+		return new IeltsContent(
+				List.of(new IeltsContentQuestion("Question 1", List.of(), List.of())),
+				List.of(new IeltsContentQuestion("Cue card", List.of("point"), List.of())),
+				List.of(new IeltsContentQuestion("Question 3", List.of(), List.of())));
 	}
 
 	private IeltsGenerationRequest request(IeltsPart part, String topicId) {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/InterviewSceneServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/scene/InterviewSceneServiceTest.java
@@ -38,6 +38,10 @@ import com.unispeaking.domain.po.scene.InterviewSceneDefinition;
 import com.unispeaking.domain.vo.evaluation.ReportStatus;
 import com.unispeaking.domain.vo.provider.AiCapability;
 import com.unispeaking.domain.vo.scene.InterviewDifficulty;
+import com.unispeaking.domain.vo.scene.InterviewTopicEvent;
+import com.unispeaking.domain.vo.scene.InterviewTopicState;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.domain.vo.session.SessionStatus;
 import com.unispeaking.infrastructure.persistence.repository.evaluation.InterviewReportRepository;
 import com.unispeaking.infrastructure.persistence.repository.scene.InterviewSceneRepository;
 import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
@@ -52,6 +56,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import tools.jackson.databind.JsonNode;
@@ -188,6 +193,147 @@ class InterviewSceneServiceTest {
 				InterviewErrorCode.INTERVIEW_CONTEXT_LLM_RESPONSE_INVALID,
 				exception.code());
 		verify(repository, never()).save(any());
+	}
+
+	@Test
+	void rejectsNullRequestBeforeCallingLlm() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> service.generate(null));
+
+		assertEquals(InterviewErrorCode.INTERVIEW_MATERIAL_INVALID, exception.code());
+		verify(providerRegistry, never()).executeLlmTaskRouted(anyString(), isNull());
+		verify(repository, never()).save(any());
+	}
+
+	@Test
+	void rejectsMaterialWithoutFinalTextOrQualifications() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		InterviewMaterial missingFinalText = new InterviewMaterial(
+				"后端开发工程师", List.of("负责服务开发"), List.of("掌握 Java"),
+				null, null, null, null, null, null, null, " ");
+		BusinessException finalTextError = assertThrows(
+				BusinessException.class,
+				() -> service.generate(request(missingFinalText, InterviewDifficulty.EASY)));
+		assertEquals(InterviewErrorCode.INTERVIEW_MATERIAL_INVALID, finalTextError.code());
+
+		InterviewMaterial missingQualifications = new InterviewMaterial(
+				"后端开发工程师", List.of("负责服务开发"), List.of(),
+				null, null, null, null, null, null, null, "后端开发工程师");
+		BusinessException qualificationsError = assertThrows(
+				BusinessException.class,
+				() -> service.generate(request(missingQualifications, InterviewDifficulty.EASY)));
+		assertEquals(InterviewErrorCode.INTERVIEW_MATERIAL_INVALID, qualificationsError.code());
+	}
+
+	@Test
+	void acceptsMinimumAndMaximumTopicCountsAndSupportedSelfIntroductionNames() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(completed(contextWithTopics(
+						"Tell me about yourself", "项目经历", "技术栈", "职业规划")))
+				.thenReturn(completed(contextWithTopics(
+						"Self-intro", "项目经历", "技术栈", "职业规划", "反问环节")));
+
+		service.generate(request(material(), InterviewDifficulty.STANDARD));
+		service.generate(request(material(), InterviewDifficulty.STANDARD));
+
+		verify(providerRegistry, times(2)).executeLlmTaskRouted(anyString(), isNull());
+		verify(repository, times(2)).save(any(InterviewSceneDefinition.class));
+	}
+
+	@Test
+	void rejectsContextJsonForMalformedFenceDuplicateKeysTrailingTokensAndInvalidTopics() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		String[] invalidResponses = {
+				"```json\n" + validContext() + "\n``` trailing",
+				"{\"candidate_overview\":\"a\",\"candidate_overview\":\"b\","
+						+ "\"role_overview\":\"role\",\"interview_topics\":[\"自我介绍\",\"项目\",\"技术\",\"规划\"]}",
+				validContext() + " trailing",
+				contextWithTopics("项目经历", "技术栈", "职业规划", "反问环节"),
+				contextWithTopics("自我介绍", "重复", "重复", "职业规划"),
+				contextWithTopics("自我介绍", "项目经历", "技术栈")
+		};
+
+		for (String invalid : invalidResponses) {
+			when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+					.thenReturn(completed(invalid), completed(invalid));
+
+			BusinessException exception = assertThrows(
+					BusinessException.class,
+					() -> service.generate(request(material(), InterviewDifficulty.EASY)));
+			assertEquals(
+					InterviewErrorCode.INTERVIEW_CONTEXT_LLM_RESPONSE_INVALID,
+					exception.code());
+		}
+
+		verify(repository, never()).save(any());
+	}
+
+	@Test
+	void rejectsContextTextThatIsBlankWrongTypeOrTooLong() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		String tooLong = "x".repeat(2001);
+		String[] invalidResponses = {
+				"null",
+				"[]",
+				"{\"candidate_overview\":\"\",\"role_overview\":\"role\","
+						+ "\"interview_topics\":[\"自我介绍\",\"项目\",\"技术\",\"规划\"]}",
+				"{\"candidate_overview\":\"" + tooLong + "\",\"role_overview\":\"role\","
+						+ "\"interview_topics\":[\"自我介绍\",\"项目\",\"技术\",\"规划\"]}"
+		};
+
+		for (String invalid : invalidResponses) {
+			when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+					.thenReturn(completed(invalid), completed(invalid));
+			assertThrows(BusinessException.class,
+					() -> service.generate(request(material(), InterviewDifficulty.EASY)));
+		}
+		verify(repository, never()).save(any());
+	}
+
+	@Test
+	void parsesStoredTopicsByFilteringBlankEntriesAndRejectsMalformedJson() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		InterviewSceneDefinition definition = definitionWithContext(
+				"interview_1", "user-1",
+				"{\"interviewTopics\":[\" 自我介绍 \",\"\",42,null,\"项目经历\"]}");
+		when(repository.findById("interview_1")).thenReturn(Optional.of(definition));
+		when(repository.findOwnedById("interview_1", "user-1"))
+				.thenReturn(Optional.of(definition));
+
+		assertEquals(List.of("自我介绍", "项目经历"), service.interviewTopics("interview_1"));
+
+		InterviewSceneDefinition malformed = definitionWithContext(
+				"interview_bad", "user-1", "{not-json");
+		when(repository.findById("interview_bad")).thenReturn(Optional.of(malformed));
+		when(repository.findOwnedById("interview_bad", "user-1"))
+				.thenReturn(Optional.of(malformed));
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> service.interviewTopics("interview_bad"));
+		assertEquals(InterviewErrorCode.INTERVIEW_REQUEST_INVALID, exception.code());
+	}
+
+	@Test
+	void propagatesQuotaAndPersistenceFailuresWithoutCallingUnrelatedDependencies() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		org.mockito.Mockito.doThrow(new BusinessException("QUOTA", "quota"))
+				.when(dailyQuotaPolicy)
+				.assertWithinQuota("user-1", SceneType.INTERVIEW_SCENE, 5);
+		BusinessException quotaException = assertThrows(BusinessException.class,
+				() -> service.generate(request(material(), InterviewDifficulty.EASY)));
+		assertEquals("QUOTA", quotaException.code());
+		verify(providerRegistry, never()).executeLlmTaskRouted(anyString(), isNull());
+
+		org.mockito.Mockito.reset(dailyQuotaPolicy);
+		when(providerRegistry.executeLlmTaskRouted(anyString(), isNull()))
+				.thenReturn(completed(validContext()));
+		org.mockito.Mockito.doThrow(new IllegalStateException("database down"))
+				.when(repository).save(any(InterviewSceneDefinition.class));
+		assertThrows(IllegalStateException.class,
+				() -> service.generate(request(material(), InterviewDifficulty.EASY)));
 	}
 
 	@Test
@@ -400,12 +546,158 @@ class InterviewSceneServiceTest {
 	}
 
 	@Test
+	void advanceTopicStateInitializesFromPersistedTopicsBeforeAdvancing() {
+		InterviewSceneDefinition definition = definitionWithContext(
+				"interview_1", "user-1", "{\"interviewTopics\":[\"自我介绍\",\"项目经历\"]}");
+		InterviewTopicState expected = new InterviewTopicState(
+				"自我介绍", 0, 1, 0, 0, false, false, "继续追问");
+		when(stateMachine.current("session-1")).thenReturn(null);
+		when(repository.findById("interview_1")).thenReturn(Optional.of(definition));
+		when(stateMachine.advance("session-1", 1,
+				new InterviewTopicEvent("自我介绍", false))).thenReturn(expected);
+
+		InterviewTopicState actual = service.advanceTopicState(
+				"interview_1", "session-1", 1,
+				new InterviewTopicEvent("自我介绍", false));
+
+		assertEquals(expected, actual);
+		verify(stateMachine).start(
+				"session-1", List.of("自我介绍", "项目经历"), InterviewDifficulty.HARD);
+		verify(stateMachine).advance("session-1", 1,
+				new InterviewTopicEvent("自我介绍", false));
+	}
+
+	@Test
+	void advanceTopicStateRejectsMissingSceneBeforeStartingStateMachine() {
+		when(stateMachine.current("session-1")).thenReturn(null);
+		when(repository.findById("missing")).thenReturn(Optional.empty());
+
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> service.advanceTopicState(
+						"missing", "session-1", 1, InterviewTopicEvent.unknown()));
+
+		assertEquals(InterviewErrorCode.INTERVIEW_SCENE_NOT_FOUND, exception.code());
+		verify(stateMachine, never()).start(anyString(), any(), any());
+		verify(stateMachine, never()).advance(
+				anyString(), org.mockito.ArgumentMatchers.anyInt(), any());
+	}
+
+	@Test
+	void interviewTopicsRejectsStoredContextWithoutUsableTopics() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		InterviewSceneDefinition definition = definitionWithContext(
+				"interview_1", "user-1", "{\"interviewTopics\":[]}");
+		when(repository.findById("interview_1")).thenReturn(Optional.of(definition));
+		when(repository.findOwnedById("interview_1", "user-1"))
+				.thenReturn(Optional.of(definition));
+
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> service.interviewTopics("interview_1"));
+
+		assertEquals(InterviewErrorCode.INTERVIEW_REQUEST_INVALID, exception.code());
+	}
+
+	@Test
+	void deleteSceneCleansUpEveryAssociatedRecordingAfterSoftDelete() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		InterviewSceneDefinition definition = definition("interview_1", "user-1");
+		when(repository.findById("interview_1")).thenReturn(Optional.of(definition));
+		when(repository.findOwnedById("interview_1", "user-1"))
+				.thenReturn(Optional.of(definition));
+		when(practiceSessionRepository.findBySceneId("interview_1")).thenReturn(List.of(
+				new com.unispeaking.domain.po.session.PracticeSessionRecord(
+						"session-1", UUID.randomUUID(), "interview_1",
+						SceneType.INTERVIEW_SCENE, SessionStatus.COMPLETED,
+						java.time.Instant.EPOCH, java.time.Instant.EPOCH),
+				new com.unispeaking.domain.po.session.PracticeSessionRecord(
+						"session-2", UUID.randomUUID(), "interview_1",
+						SceneType.INTERVIEW_SCENE, SessionStatus.COMPLETED,
+						java.time.Instant.EPOCH, java.time.Instant.EPOCH)));
+
+		service.deleteScene("interview_1");
+
+		verify(repository).softDelete("interview_1", "user-1");
+		verify(interviewRecordingStore).deleteSessionAudio("session-1");
+		verify(interviewRecordingStore).deleteSessionAudio("session-2");
+	}
+
+	@Test
 	void isOcrAvailableDelegatesToOcrProvider() {
 		when(ocrProvider.available()).thenReturn(true);
 		assertTrue(service.isOcrAvailable());
 
 		when(ocrProvider.available()).thenReturn(false);
 		assertFalse(service.isOcrAvailable());
+	}
+
+	@Test
+	void prepareDialogueAndTopicQueriesRejectMissingOrUnauthorizedScenes() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(repository.findById("missing")).thenReturn(Optional.empty());
+		BusinessException missing = assertThrows(BusinessException.class,
+				() -> service.prepareDialogue("missing"));
+		assertEquals(InterviewErrorCode.INTERVIEW_SCENE_NOT_FOUND, missing.code());
+
+		InterviewSceneDefinition definition = definition("interview_1", "owner");
+		when(repository.findById("interview_1")).thenReturn(Optional.of(definition));
+		when(repository.findOwnedById("interview_1", "user-1")).thenReturn(Optional.empty());
+		BusinessException denied = assertThrows(BusinessException.class,
+				() -> service.interviewTopics("interview_1"));
+		assertEquals(InterviewErrorCode.INTERVIEW_SCENE_ACCESS_DENIED, denied.code());
+	}
+
+	@Test
+	void listOwnedScenesNormalizesMalformedAndBlankJobTitlesAndNullReportStatus() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		InterviewSceneDefinition invalidJson = definitionWithContext("bad", "user-1", "{}");
+		InterviewSceneDefinition malformedJson = new InterviewSceneDefinition(
+				"malformed", "user-1", "not-json", "final", "{}", null,
+				"prompt", OffsetDateTime.now(ZoneOffset.UTC), OffsetDateTime.now(ZoneOffset.UTC), null);
+		InterviewReportRecord nullStatus = new InterviewReportRecord(
+				"session-null", "bad", "user-1", null, null, null, null, null, null,
+				null, null, null, null, null, null, null, null, null, null, null, null, 0, null, null, null);
+		when(repository.findByUserId("user-1")).thenReturn(List.of(invalidJson, malformedJson));
+		when(interviewReportRepository.findBySceneId("bad")).thenReturn(List.of(nullStatus));
+		when(interviewReportRepository.findBySceneId("malformed")).thenReturn(List.of());
+
+		List<InterviewAssetItem> items = service.listOwnedScenes();
+
+		assertEquals(2, items.size());
+		assertNull(items.getFirst().jobTitle());
+		assertNull(items.getFirst().latestReportStatus());
+		assertEquals("session-null", items.getFirst().latestSessionId());
+		assertNull(items.get(1).jobTitle());
+		assertNull(items.get(1).difficulty());
+	}
+
+	@Test
+	void advanceTopicStateUsesExistingStateWithoutReloadingScene() {
+		InterviewTopicState current = new InterviewTopicState(
+				"项目经历", 1, 1, 0, 0, false, false, "继续");
+		InterviewTopicEvent event = new InterviewTopicEvent("项目经历", true);
+		when(stateMachine.current("session-1")).thenReturn(current);
+		when(stateMachine.advance("session-1", 2, event)).thenReturn(current);
+
+		assertEquals(current, service.advanceTopicState("interview_1", "session-1", 2, event));
+		verify(repository, never()).findById(anyString());
+		verify(stateMachine, never()).start(anyString(), any(), any());
+	}
+
+	@Test
+	void prepareMaterialsPropagatesExtractionAndDesensitizerFailures() {
+		when(authService.requireUserId(null)).thenReturn("user-1");
+		when(materialTextExtraction.extract(any()))
+				.thenThrow(new IllegalArgumentException("unsupported file"));
+		assertThrows(IllegalArgumentException.class,
+				() -> service.prepareMaterials(new InterviewMaterialPreparationInput("resume", null, "jd", null)));
+
+		org.mockito.Mockito.reset(materialTextExtraction);
+		when(materialTextExtraction.extract(any()))
+				.thenReturn(new MaterialTextExtraction.MaterialTextResult("jd", "resume", false));
+		when(materialDesensitizer.desensitize("jd"))
+				.thenThrow(new IllegalStateException("desensitizer down"));
+		assertThrows(IllegalStateException.class,
+				() -> service.prepareMaterials(new InterviewMaterialPreparationInput("resume", null, "jd", null)));
 	}
 
 	private InterviewReportRecord completedReport(
@@ -450,6 +742,16 @@ class InterviewSceneServiceTest {
 				null);
 	}
 
+	private InterviewSceneDefinition definitionWithContext(
+			String sceneId,
+			String userId,
+			String contextJson) {
+		OffsetDateTime now = OffsetDateTime.now(ZoneOffset.UTC);
+		return new InterviewSceneDefinition(
+				sceneId, userId, "{}", "final text", contextJson,
+				InterviewDifficulty.HARD, "面试系统提示词", now, now, null);
+	}
+
 	private InterviewMaterial material() {
 		return new InterviewMaterial(
 				"后端开发工程师",
@@ -474,18 +776,13 @@ class InterviewSceneServiceTest {
 	}
 
 	private String validContext() {
-		return """
-				{
-				  "candidate_overview": "候选人有三年后端开发经验，熟悉支付系统。",
-				  "role_overview": "负责支付系统的设计与性能优化。",
-				  "interview_topics": [
-				    "自我介绍",
-				    "项目经历",
-				    "技术栈",
-				    "职业规划"
-				  ]
-				}
-				""";
+		return contextWithTopics("自我介绍", "项目经历", "技术栈", "职业规划");
+	}
+
+	private String contextWithTopics(String... topics) {
+		return "{\"candidate_overview\":\"候选人有三年后端开发经验，熟悉支付系统。\","
+				+ "\"role_overview\":\"负责支付系统的设计与性能优化。\",\"interview_topics\":"
+				+ objectMapper.writeValueAsString(java.util.Arrays.asList(topics)) + "}";
 	}
 
 	private String invalidContext() {

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/CustomSessionServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/CustomSessionServiceTest.java
@@ -1,12 +1,15 @@
 package com.unispeaking.service.session;
 
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.doThrow;
 
 import com.unispeaking.component.session.ObsoleteDialogueCleanup;
 import com.unispeaking.component.session.RealtimeSessionCoordinator;
@@ -19,10 +22,13 @@ import com.unispeaking.domain.dto.session.CompleteCustomSceneDialogueResponse;
 import com.unispeaking.domain.dto.session.StartCustomSceneDialogueRequest;
 import com.unispeaking.domain.dto.session.StartCustomSessionCommand;
 import com.unispeaking.domain.dto.session.StartSessionResponse;
+import com.unispeaking.domain.dto.session.StartSceneSessionResponse;
+import com.unispeaking.domain.dto.session.Message;
 import com.unispeaking.domain.po.scene.CustomSceneDefinition;
 import com.unispeaking.domain.po.session.CustomSceneSession;
 import com.unispeaking.domain.vo.scene.SceneType;
 import com.unispeaking.domain.vo.scene.CustomStage;
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.service.evaluation.CustomEvaluationService;
 import com.unispeaking.service.scene.CustomSceneFlowService;
 import com.unispeaking.service.scene.CustomSceneService;
@@ -33,19 +39,24 @@ import org.junit.jupiter.api.Test;
 
 class CustomSessionServiceTest {
 
+	private CustomSessionService service(
+			CustomSceneService scenes,
+			SessionLifecycleManager lifecycle,
+			CustomSceneFlowService flow,
+			RealtimeSessionCoordinator coordinator,
+			CustomEvaluationService evaluation,
+			ObsoleteDialogueCleanup cleanup) {
+		return new CustomSessionService(scenes, lifecycle, flow, coordinator, evaluation, cleanup);
+	}
+
 	@Test
 	void repracticeReusesDialogueFlowWithoutReplayingLearningStages() {
 		CustomSceneService scenes = mock(CustomSceneService.class);
 		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
 		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
 		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
-		CustomSessionService service = new CustomSessionService(
-				scenes,
-				lifecycle,
-				flow,
-				coordinator,
-				mock(CustomEvaluationService.class),
-				mock(ObsoleteDialogueCleanup.class));
+		CustomSessionService service = service(scenes, lifecycle, flow, coordinator,
+				mock(CustomEvaluationService.class), mock(ObsoleteDialogueCleanup.class));
 		String sceneId = "scene-1";
 		StartCustomSceneDialogueRequest request = mock(StartCustomSceneDialogueRequest.class);
 		CustomDialogueSceneContext context = mock(CustomDialogueSceneContext.class);
@@ -135,5 +146,87 @@ class CustomSessionServiceTest {
 		verify(flow).clearDialogueState(sessionId);
 		verify(coordinator).remove(sessionId);
 		verify(cleanup).retainLatestDialogue(sceneId, sessionId);
+	}
+
+	@Test
+	void startsDialogueFromMissingFlowAndAdvancesThroughLearningStages() {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		CustomDialogueSceneContext context = mock(CustomDialogueSceneContext.class);
+		StartSessionResponse started = mock(StartSessionResponse.class);
+		StartCustomSceneDialogueRequest request = mock(StartCustomSceneDialogueRequest.class);
+		when(scenes.prepareDialogue("scene")).thenReturn(context);
+		when(context.sceneId()).thenReturn("scene");
+		when(context.userId()).thenReturn("user");
+		when(context.scene()).thenReturn(mock(SceneGenerationResponse.class));
+		when(flow.current("scene")).thenThrow(new BusinessException("SCENE_FLOW_NOT_FOUND", "missing"));
+		when(flow.start("scene")).thenReturn(CustomStage.WORD);
+		when(flow.next("scene")).thenReturn(CustomStage.DIALOGUE);
+		when(lifecycle.startSession(any())).thenReturn(started);
+		when(started.sessionId()).thenReturn("session");
+		when(coordinator.connect(any(), any(), any(), any(Boolean.class), any(), any(), any(), any(),
+				any(), any(), any(), any(), any())).thenReturn(mock(StartSceneSessionResponse.class));
+
+		service(scenes, lifecycle, flow, coordinator, mock(CustomEvaluationService.class),
+				mock(ObsoleteDialogueCleanup.class)).startSession(
+				new StartCustomSessionCommand("scene", request));
+
+		verify(flow).start("scene");
+		verify(flow).next("scene");
+	}
+
+	@Test
+	void restartsCompletedFlowAndCleansStateWhenRealtimeConnectFails() {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		CustomDialogueSceneContext context = mock(CustomDialogueSceneContext.class);
+		StartSessionResponse started = mock(StartSessionResponse.class);
+		StartCustomSceneDialogueRequest request = mock(StartCustomSceneDialogueRequest.class);
+		when(scenes.prepareDialogue("scene")).thenReturn(context);
+		when(context.sceneId()).thenReturn("scene");
+		when(context.userId()).thenReturn("user");
+		when(context.scene()).thenReturn(mock(SceneGenerationResponse.class));
+		when(flow.current("scene")).thenReturn(CustomStage.COMPLETED);
+		when(flow.start("scene")).thenReturn(CustomStage.DIALOGUE);
+		when(lifecycle.startSession(any())).thenReturn(started);
+		when(started.sessionId()).thenReturn("session");
+		doThrow(new IllegalStateException("connect failed")).when(coordinator).connect(
+			any(), any(), any(), any(Boolean.class), any(), any(), any(), any(),
+			any(), any(), any(), any(), any());
+
+		assertThrows(IllegalStateException.class, () -> service(scenes, lifecycle, flow, coordinator,
+				mock(CustomEvaluationService.class), mock(ObsoleteDialogueCleanup.class)).startSession(
+				new StartCustomSessionCommand("scene", request)));
+		verify(flow).start("scene");
+		verify(flow).clearDialogueState("session");
+	}
+
+	@Test
+	void rejectsNonCustomSessionBindingAndForwardsMessages() {
+		CustomSceneService scenes = mock(CustomSceneService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		CustomSceneFlowService flow = mock(CustomSceneFlowService.class);
+		CustomSceneDefinition definition = new CustomSceneDefinition(
+				"scene", "user", "title", "label", null, null, null, "goal", null, null,
+				List.of(), List.of(), List.of());
+		CustomSceneSession session = new CustomSceneSession("session", "user");
+		session.setSceneId("other");
+		session.setSceneType(SceneType.CUSTOM_SCENE);
+		when(scenes.getOwnedDefinition("scene")).thenReturn(definition);
+		when(coordinator.requireOwnedSession("user", "session")).thenReturn(session);
+		CustomSessionService service = service(scenes, lifecycle, flow,
+				coordinator, mock(CustomEvaluationService.class), mock(ObsoleteDialogueCleanup.class));
+
+		BusinessException exception = assertThrows(BusinessException.class,
+				() -> service.endSession(new EndCustomSessionCommand("scene", "session", "time")));
+		assertEquals("SESSION_ACCESS_DENIED", exception.code());
+		Message message = mock(Message.class);
+		service.addMessage("session", message);
+		verify(lifecycle).addMessage("session", message);
 	}
 }

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/FreeChatSessionServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/FreeChatSessionServiceTest.java
@@ -1,0 +1,80 @@
+package com.unispeaking.service.session;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.component.session.RealtimeSessionCoordinator;
+import com.unispeaking.component.session.SessionLifecycleManager;
+import com.unispeaking.domain.dto.scene.FreeChatSceneContext;
+import com.unispeaking.domain.dto.scene.FreeChatSceneResult;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.dto.session.StartFreeChatRequest;
+import com.unispeaking.domain.dto.session.StartSceneSessionResponse;
+import com.unispeaking.domain.dto.session.StartSessionCommand;
+import com.unispeaking.domain.dto.session.StartSessionResponse;
+import com.unispeaking.domain.vo.provider.ProviderType;
+import com.unispeaking.domain.vo.scene.SceneFlowStage;
+import com.unispeaking.domain.vo.scene.SceneType;
+import com.unispeaking.service.scene.FreeChatSceneService;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class FreeChatSessionServiceTest {
+
+	@Test
+	void preparesSceneStartsLifecycleAndConnectsRealtime() {
+		FreeChatSceneService scenes = mock(FreeChatSceneService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		FreeChatSessionService service = new FreeChatSessionService(
+				scenes, lifecycle, coordinator);
+		FreeChatSceneContext prepared = new FreeChatSceneContext(
+				"user-1", new FreeChatSceneResult("free-1", "system prompt"));
+		StartSessionResponse started = new StartSessionResponse("session-1", "time");
+		StartSceneSessionResponse expected = mock(StartSceneSessionResponse.class);
+		when(scenes.prepare(any())).thenReturn(prepared);
+		when(lifecycle.startSession(any(StartSessionCommand.class))).thenReturn(started);
+		when(coordinator.connect(
+				any(), any(), any(), any(Boolean.class), any(), any(), any(), any(),
+				any(), any(), any(), any(), any())).thenReturn(expected);
+
+		StartFreeChatRequest request = new StartFreeChatRequest(
+				"offer", ProviderType.QWEN, "qwen3.5-plus", "Tina", true);
+		assertSame(expected, service.startSession(request));
+
+		ArgumentCaptor<StartSessionCommand> command =
+				ArgumentCaptor.forClass(StartSessionCommand.class);
+		verify(lifecycle).startSession(command.capture());
+		assertEquals("user-1", command.getValue().userId());
+		assertEquals("free-1", command.getValue().sceneId());
+		assertEquals(SceneType.FREE_CHAT, command.getValue().sceneType());
+		assertEquals("DIALOGUE", command.getValue().stage());
+		assertEquals("system prompt", command.getValue().prompt());
+		verify(coordinator).connect(
+				any(), eq("Free Chat"), eq(SceneFlowStage.DIALOGUE), eq(false),
+				same(started), eq(SceneType.FREE_CHAT), eq("free-1"),
+				eq("system prompt"), eq("offer"), eq(ProviderType.QWEN),
+				eq("qwen3.5-plus"), eq("Tina"), eq(true));
+	}
+
+	@Test
+	void delegatesMessagesAndReturnsNullAfterEndingSession() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		FreeChatSessionService service = new FreeChatSessionService(
+				mock(FreeChatSceneService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		Message message = new Message(1, "hello", null);
+
+		service.addMessage("session-1", message);
+		assertEquals(null, service.endSession("session-1"));
+		verify(lifecycle).addMessage("session-1", message);
+		verify(lifecycle).endSession("session-1");
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/IeltsSessionServiceRepracticeTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/IeltsSessionServiceRepracticeTest.java
@@ -2,14 +2,34 @@ package com.unispeaking.service.session;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.component.session.ActiveSessionRegistry;
 import com.unispeaking.component.session.RealtimeSessionCoordinator;
 import com.unispeaking.component.session.SessionLifecycleManager;
+import com.unispeaking.domain.dto.scene.IeltsDialogueSceneContext;
+import com.unispeaking.domain.dto.scene.SceneFlowResponse;
+import com.unispeaking.domain.dto.session.Message;
+import com.unispeaking.domain.dto.session.StartIeltsDialogueRequest;
+import com.unispeaking.domain.dto.session.StartIeltsSessionCommand;
+import com.unispeaking.domain.dto.session.StartIeltsSessionResponse;
+import com.unispeaking.domain.dto.session.StartSessionCommand;
+import com.unispeaking.domain.dto.session.StartSessionResponse;
 import com.unispeaking.domain.po.session.CustomSceneSession;
+import com.unispeaking.domain.vo.provider.ProviderType;
+import com.unispeaking.domain.vo.scene.IeltsContent;
+import com.unispeaking.domain.vo.scene.IeltsPart;
+import com.unispeaking.domain.vo.scene.SceneFlowStage;
 import com.unispeaking.domain.vo.scene.SceneType;
 import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
 import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
@@ -19,6 +39,241 @@ import com.unispeaking.service.session.IeltsSessionService;
 import org.junit.jupiter.api.Test;
 
 class IeltsSessionServiceRepracticeTest {
+
+	@Test
+	void startSessionPreparesLifecycleStateAndConnectsRealtimeSession() {
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		IeltsSessionService service = ieltsService(scenes, flow, lifecycle, coordinator);
+		IeltsContent content = new IeltsContent(null, null, null);
+		IeltsDialogueSceneContext prepared = new IeltsDialogueSceneContext(
+				"user-1",
+				"ielts-1",
+				content,
+				IeltsPart.PART_2,
+				"Describe a useful object",
+				new SceneFlowResponse(
+						"ielts-1",
+						SceneFlowStage.IELTS_PART_2,
+						false),
+				"IELTS prompt",
+				"Katerina");
+		StartIeltsDialogueRequest request = new StartIeltsDialogueRequest(
+				"offer-sdp",
+				ProviderType.QWEN,
+				"qwen3.5-plus",
+				"Katerina",
+				true);
+		StartIeltsSessionCommand command = new StartIeltsSessionCommand(
+				"ielts-1",
+				request);
+		StartSessionResponse started = new StartSessionResponse(
+				"session-1",
+				"2026-08-21T00:00:00Z");
+		StartIeltsSessionResponse expected = mock(StartIeltsSessionResponse.class);
+		when(scenes.prepareDialogue("ielts-1", "Katerina"))
+				.thenReturn(prepared);
+		when(lifecycle.startSession(any(StartSessionCommand.class)))
+				.thenReturn(started);
+		when(coordinator.connectIelts(
+					eq(content),
+					eq(IeltsPart.PART_2),
+					eq("Describe a useful object"),
+					eq(SceneFlowStage.IELTS_PART_2),
+					eq(true),
+					eq(started),
+					eq("ielts-1"),
+					eq("IELTS prompt"),
+					eq("offer-sdp"),
+					eq(ProviderType.QWEN),
+					eq("qwen3.5-plus"),
+					eq("Katerina"),
+					eq(true)))
+				.thenReturn(expected);
+
+		StartIeltsSessionResponse actual = service.startSession(command);
+
+		assertSame(expected, actual);
+		var lifecycleCommand = org.mockito.ArgumentCaptor
+				.forClass(StartSessionCommand.class);
+		verify(lifecycle).startSession(lifecycleCommand.capture());
+		assertEquals("user-1", lifecycleCommand.getValue().userId());
+		assertEquals("ielts-1", lifecycleCommand.getValue().sceneId());
+		assertEquals(SceneType.IELTS_SCENE,
+				lifecycleCommand.getValue().sceneType());
+		assertEquals("PART2", lifecycleCommand.getValue().stage());
+		assertEquals("IELTS prompt", lifecycleCommand.getValue().prompt());
+		verify(flow).startSessionState(
+				"ielts-1",
+				"session-1",
+				IeltsPart.PART_2);
+	}
+
+	@Test
+	void startSessionPropagatesScenePermissionFailureBeforePersistence() {
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSessionService service = ieltsService(
+				scenes,
+				mock(IeltsSceneFlowService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		BusinessException denied = new BusinessException(
+				"IELTS_PRACTICE_ACCESS_DENIED",
+				"当前用户无权访问该 IELTS 练习");
+		when(scenes.prepareDialogue("ielts-forbidden", "Katerina"))
+				.thenThrow(denied);
+
+		BusinessException actual = assertThrows(
+				BusinessException.class,
+				() -> service.startSession(new StartIeltsSessionCommand(
+						"ielts-forbidden",
+						new StartIeltsDialogueRequest(
+								"offer-sdp",
+								ProviderType.QWEN,
+								"qwen3.5-plus",
+								"Katerina",
+								false))));
+
+		assertSame(denied, actual);
+		verify(lifecycle, never()).startSession(any(StartSessionCommand.class));
+	}
+
+	@Test
+	void startSessionPropagatesPersistenceFailureWithoutStartingRealtimeFlow() {
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		IeltsSessionService service = ieltsService(scenes, flow, lifecycle, coordinator);
+		IeltsDialogueSceneContext prepared = preparedContext(IeltsPart.PART_1);
+		RuntimeException persistenceFailure = new RuntimeException("practice insert failed");
+		when(scenes.prepareDialogue("ielts-1", "Katerina")).thenReturn(prepared);
+		when(lifecycle.startSession(any(StartSessionCommand.class)))
+				.thenThrow(persistenceFailure);
+
+		RuntimeException actual = assertThrows(
+				RuntimeException.class,
+				() -> service.startSession(command("ielts-1")));
+
+		assertSame(persistenceFailure, actual);
+		verifyNoInteractions(flow, coordinator);
+	}
+
+	@Test
+	void startSessionClearsFlowStateWhenRealtimeConnectionFails() {
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		IeltsSessionService service = ieltsService(scenes, flow, lifecycle, coordinator);
+		IeltsDialogueSceneContext prepared = preparedContext(IeltsPart.PART_3);
+		StartSessionResponse started = new StartSessionResponse(
+				"session-3",
+				"2026-08-21T00:00:00Z");
+		RuntimeException connectionFailure = new RuntimeException("SDP exchange failed");
+		when(scenes.prepareDialogue("ielts-1", "Katerina")).thenReturn(prepared);
+		when(lifecycle.startSession(any(StartSessionCommand.class))).thenReturn(started);
+		when(coordinator.connectIelts(
+				any(), any(), any(), any(), any(Boolean.class), any(), any(), any(), any(),
+				any(), any(), any(), any(Boolean.class))).thenThrow(connectionFailure);
+
+		RuntimeException actual = assertThrows(
+				RuntimeException.class,
+				() -> service.startSession(command("ielts-1")));
+
+		assertSame(connectionFailure, actual);
+		verify(flow).startSessionState("ielts-1", "session-3", IeltsPart.PART_3);
+		verify(flow).clearSessionState("session-3");
+	}
+
+	@Test
+	void addMessageDelegatesValidMessageToLifecycle() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSessionService service = ieltsService(
+				mock(IeltsSceneService.class),
+				mock(IeltsSceneFlowService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		Message message = new Message(1, "answer", new byte[] {1, 2});
+
+		service.addMessage("session-1", message);
+
+		verify(lifecycle).addMessage("session-1", message);
+	}
+
+	@Test
+	void addMessagePropagatesInvalidInputFailure() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSessionService service = ieltsService(
+				mock(IeltsSceneService.class),
+				mock(IeltsSceneFlowService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		BusinessException invalid = new BusinessException(
+				"MESSAGE_REQUIRED",
+				"消息不能为空");
+		doThrow(invalid).when(lifecycle).addMessage(
+				eq("session-1"),
+				org.mockito.ArgumentMatchers.isNull(Message.class));
+
+		BusinessException actual = assertThrows(
+				BusinessException.class,
+				() -> service.addMessage("session-1", null));
+
+		assertSame(invalid, actual);
+		verify(lifecycle).addMessage("session-1", null);
+	}
+
+	@Test
+	void addMessagePropagatesPermissionFailure() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSessionService service = ieltsService(
+				mock(IeltsSceneService.class),
+				mock(IeltsSceneFlowService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		BusinessException denied = new BusinessException(
+				"SESSION_ACCESS_DENIED",
+				"当前用户无权访问该会话");
+		doThrow(denied).when(lifecycle).addMessage(
+				eq("foreign-session"),
+				any(Message.class));
+
+		BusinessException actual = assertThrows(
+				BusinessException.class,
+				() -> service.addMessage(
+						"foreign-session",
+						new Message(0, "not yours", null)));
+
+		assertSame(denied, actual);
+		verify(lifecycle).addMessage(
+				eq("foreign-session"),
+				any(Message.class));
+	}
+
+	@Test
+	void addMessagePropagatesPersistenceFailure() {
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSessionService service = ieltsService(
+				mock(IeltsSceneService.class),
+				mock(IeltsSceneFlowService.class),
+				lifecycle,
+				mock(RealtimeSessionCoordinator.class));
+		RuntimeException persistenceFailure = new RuntimeException("message insert failed");
+		Message message = new Message(1, "answer", null);
+		doThrow(persistenceFailure).when(lifecycle).addMessage(
+				eq("session-1"),
+				eq(message));
+
+		RuntimeException actual = assertThrows(
+				RuntimeException.class,
+				() -> service.addMessage("session-1", message));
+
+		assertSame(persistenceFailure, actual);
+	}
 
 	@Test
 	void sessionServiceOnlyCreatesTheGenericSessionLifecycle() {
@@ -86,15 +341,128 @@ class IeltsSessionServiceRepracticeTest {
 		verify(scenes).completeDialogue("ielts_mock_1", userId);
 	}
 
+	@Test
+	void endSessionRejectsNonIeltsSessionBeforeClaimingOwnership() {
+		String userId = "user-1";
+		String sessionId = "free-chat-session";
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		IeltsSessionService service = ieltsService(
+				mock(IeltsSceneService.class), flow, lifecycle, coordinator);
+		when(lifecycle.requireOwnerId(sessionId)).thenReturn(userId);
+		when(lifecycle.requireSceneType(userId, sessionId))
+				.thenReturn(SceneType.FREE_CHAT);
+
+		BusinessException exception = assertThrows(
+				BusinessException.class,
+				() -> service.endSession(sessionId));
+
+		assertEquals("IELTS_SESSION_MISMATCH", exception.code());
+		verify(coordinator, never()).requireOwnedSession(any(), any());
+		verify(flow, never()).clearSessionState(any());
+	}
+
+	@Test
+	void endSessionClearsFlowStateWhenEndingLifecycleFails() {
+		String userId = "user-1";
+		String sessionId = "ielts-session";
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		CustomSceneSession session = ieltsSession(sessionId, userId, "ielts-1");
+		RuntimeException failure = new RuntimeException("close failed");
+		when(lifecycle.requireOwnerId(sessionId)).thenReturn(userId);
+		when(lifecycle.requireSceneType(userId, sessionId))
+				.thenReturn(SceneType.IELTS_SCENE);
+		when(coordinator.requireOwnedSession(userId, sessionId)).thenReturn(session);
+		doThrow(failure).when(lifecycle).endSession(sessionId);
+		IeltsSessionService service = ieltsService(scenes, flow, lifecycle, coordinator);
+
+		RuntimeException actual = assertThrows(
+				RuntimeException.class,
+				() -> service.endSession(sessionId));
+
+		assertSame(failure, actual);
+		verify(flow).clearSessionState(sessionId);
+		verify(scenes, never()).completeDialogue(any(), any());
+	}
+
+	@Test
+	void endSessionClearsFlowStateWhenCompletingDialogueFails() {
+		String userId = "user-1";
+		String sessionId = "ielts-session";
+		IeltsSceneService scenes = mock(IeltsSceneService.class);
+		IeltsSessionService service;
+		IeltsSceneFlowService flow = mock(IeltsSceneFlowService.class);
+		SessionLifecycleManager lifecycle = mock(SessionLifecycleManager.class);
+		RealtimeSessionCoordinator coordinator = mock(RealtimeSessionCoordinator.class);
+		CustomSceneSession session = ieltsSession(sessionId, userId, "ielts-1");
+		RuntimeException failure = new RuntimeException("completion failed");
+		when(lifecycle.requireOwnerId(sessionId)).thenReturn(userId);
+		when(lifecycle.requireSceneType(userId, sessionId))
+				.thenReturn(SceneType.IELTS_SCENE);
+		when(coordinator.requireOwnedSession(userId, sessionId)).thenReturn(session);
+		when(scenes.completeDialogue("ielts-1", userId)).thenThrow(failure);
+		service = ieltsService(scenes, flow, lifecycle, coordinator);
+
+		RuntimeException actual = assertThrows(
+				RuntimeException.class,
+				() -> service.endSession(sessionId));
+
+		assertSame(failure, actual);
+		verify(lifecycle).endSession(sessionId);
+		verify(flow).clearSessionState(sessionId);
+	}
+
 	private IeltsSessionService ieltsService(
 			IeltsSceneService scenes,
+			IeltsSceneFlowService flow,
 			SessionLifecycleManager lifecycle,
 			RealtimeSessionCoordinator coordinator) {
 		return new IeltsSessionService(
 				scenes,
+				flow,
+				lifecycle,
+				coordinator);
+	}
+
+	private IeltsSessionService ieltsService(
+			IeltsSceneService scenes,
+			SessionLifecycleManager lifecycle,
+			RealtimeSessionCoordinator coordinator) {
+		return ieltsService(
+				scenes,
 				mock(IeltsSceneFlowService.class),
 				lifecycle,
 				coordinator);
+	}
+
+	private IeltsDialogueSceneContext preparedContext(IeltsPart part) {
+		return new IeltsDialogueSceneContext(
+				"user-1",
+				"ielts-1",
+				new IeltsContent(null, null, null),
+				part,
+				"IELTS topic",
+				new SceneFlowResponse(
+						"ielts-1",
+						SceneFlowStage.valueOf("IELTS_" + part.name()),
+						false),
+				"IELTS prompt",
+				"Katerina");
+	}
+
+	private StartIeltsSessionCommand command(String ieltsId) {
+		return new StartIeltsSessionCommand(
+				ieltsId,
+				new StartIeltsDialogueRequest(
+						"offer-sdp",
+						ProviderType.QWEN,
+						"qwen3.5-plus",
+						"Katerina",
+						true));
 	}
 
 	private CustomSceneSession ieltsSession(

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/InterviewSessionServiceTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/session/InterviewSessionServiceTest.java
@@ -440,6 +440,93 @@ class InterviewSessionServiceTest {
 		verify(reportCoordinator).submit("session-1", sceneId, userId);
 	}
 
+	@Test
+	void redispatchesProcessingReportBeforeReturningTheRefreshedReadModel() {
+		InterviewReportRecord processing = record(ReportStatus.PROCESSING);
+		InterviewReportResponse response = new InterviewReportResponse(
+				"session-1", sceneId, ReportStatus.PROCESSING, null, null);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(interviewReportRepository.findById("session-1"))
+				.thenReturn(Optional.of(processing), Optional.of(processing));
+		when(reportCoordinator.toResponse(processing)).thenReturn(response);
+
+		assertSame(response, service.getReport(sceneId, "session-1"));
+
+		verify(reportCoordinator).redispatchIfStale("session-1", sceneId, userId);
+	}
+
+	@Test
+	void uploadsAiAudioOnlyForOwnedInterviewSessions() {
+		AbstractSceneSession session = interviewSession(SessionStatus.ACTIVE);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(coordinator.requireOwnedSession(userId, "session-1")).thenReturn(session);
+		when(interviewRecordingStore.storeAiAudio("session-1", new byte[] {1, 2}))
+				.thenReturn("interview/session-1/ai-answer.wav");
+
+		assertEquals(
+				"interview/session-1/ai-answer.wav",
+				service.uploadAiAudio(sceneId, "session-1", new byte[] {1, 2}));
+		assertEquals(
+				InterviewErrorCode.INTERVIEW_AUDIO_INVALID,
+				assertThrows(BusinessException.class,
+						() -> service.uploadAiAudio(sceneId, "session-1", new byte[0])).code());
+	}
+
+	@Test
+	void persistsTurnAudioAndTreatsMalformedTopicResponseAsUnknown() {
+		AbstractSceneSession session = interviewSession(SessionStatus.ACTIVE);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(coordinator.requireOwnedSession(userId, "session-1")).thenReturn(session);
+		when(sessionMessageRepository.findLearnerMessages("session-1"))
+				.thenReturn(List.of(new Message(1, "recorded transcript", null)));
+		when(interviewRecordingStore.storeTurn("session-1", 1, new byte[] {7}))
+				.thenReturn("turn-1.wav");
+		when(scenes.interviewTopics(sceneId)).thenReturn(List.of("自我介绍"));
+		when(providerRegistry.executeLlmTaskRouted(anyString(), any()))
+				.thenReturn(completed("not json"));
+		when(scenes.advanceTopicState(
+				eq(sceneId), eq("session-1"), eq(1), any(InterviewTopicEvent.class)))
+				.thenReturn(new InterviewTopicState(null, 0, 0, 1, 0, false, false, "continue"));
+
+		InterviewTurnResult result = service.submitTurn(
+				sceneId, "session-1", 1, "recorded transcript", new byte[] {7});
+
+		assertEquals(false, result.state().shouldEnd());
+		verify(sessionMessageRepository).attachLearnerAudioObjectKey(
+				"session-1", 1, "turn-1.wav");
+		ArgumentCaptor<InterviewTopicEvent> event =
+				ArgumentCaptor.forClass(InterviewTopicEvent.class);
+		verify(scenes).advanceTopicState(eq(sceneId), eq("session-1"), eq(1), event.capture());
+		assertEquals(InterviewTopicEvent.unknown(), event.getValue());
+	}
+
+	@Test
+	void endsInterviewWhenTopicStateRequestsTermination() {
+		AbstractSceneSession session = interviewSession(SessionStatus.ACTIVE);
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(coordinator.requireOwnedSession(userId, "session-1")).thenReturn(session);
+		when(sessionMessageRepository.findLearnerMessages("session-1"))
+				.thenReturn(List.of(new Message(1, "recorded transcript", null)));
+		when(scenes.interviewTopics(sceneId)).thenReturn(List.of("自我介绍"));
+		when(providerRegistry.executeLlmTaskRouted(anyString(), any()))
+				.thenThrow(new BusinessException("AI_UNAVAILABLE", "offline"));
+		when(scenes.advanceTopicState(
+				eq(sceneId), eq("session-1"), eq(1), any(InterviewTopicEvent.class)))
+				.thenReturn(new InterviewTopicState("自我介绍", 1, 1, 0, 0, true, true, "wrap up"));
+		when(interviewReportRepository.createIfAbsent("session-1", sceneId, userId)).thenReturn(true);
+		when(interviewReportRepository.findById("session-1"))
+				.thenReturn(Optional.of(record(ReportStatus.PROCESSING)));
+
+		InterviewTurnResult result = service.submitTurn(
+				sceneId, "session-1", 1, "recorded transcript", null);
+
+		assertEquals(ReportStatus.PROCESSING, result.reportStatus());
+		verify(lifecycle).terminateSceneSession(eq(userId), eq("session-1"),
+				eq(SessionStatus.COMPLETED), any());
+		verify(reportCoordinator).submit("session-1", sceneId, userId);
+		verify(coordinator).remove("session-1");
+	}
+
 	private InterviewReportRecord record(ReportStatus status) {
 		return new InterviewReportRecord(
 				"session-1",

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/websocket/SessionMessageWebSocketHandlerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/websocket/SessionMessageWebSocketHandlerTest.java
@@ -2,6 +2,8 @@ package com.unispeaking.websocket;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -14,6 +16,21 @@ import org.springframework.web.socket.WebSocketSession;
 import tools.jackson.databind.ObjectMapper;
 
 class SessionMessageWebSocketHandlerTest {
+
+	private WebSocketSession authenticatedSocket(String userId) {
+		WebSocketSession socket = mock(WebSocketSession.class);
+		when(socket.getAttributes()).thenReturn(new HashMap<>(userId == null
+				? java.util.Map.of()
+				: java.util.Map.of(SessionWebSocketAuthenticationInterceptor.AUTHENTICATED_USER_ID, userId)));
+		when(socket.isOpen()).thenReturn(true);
+		return socket;
+	}
+
+	private String ack(WebSocketSession socket) throws Exception {
+		var ack = org.mockito.ArgumentCaptor.forClass(TextMessage.class);
+		verify(socket).sendMessage(ack.capture());
+		return ack.getValue().getPayload();
+	}
 	@Test
 	void acceptsProviderSessionBindingForTheAuthenticatedSession() throws Exception {
 		SessionMessageDispatcher dispatcher = mock(SessionMessageDispatcher.class);
@@ -52,5 +69,59 @@ class SessionMessageWebSocketHandlerTest {
 		var ack = org.mockito.ArgumentCaptor.forClass(TextMessage.class);
 		verify(socket).sendMessage(ack.capture());
 		assertTrue(ack.getValue().getPayload().contains("session.bind.failed"));
+	}
+
+	@Test
+	void dispatchesMessageAndEndAliasesAndDefaultsMissingTypeToMessage() throws Exception {
+		SessionMessageDispatcher dispatcher = mock(SessionMessageDispatcher.class);
+		SessionMessageWebSocketHandler handler = new SessionMessageWebSocketHandler(new ObjectMapper(), dispatcher);
+		WebSocketSession socket = authenticatedSocket("user-1");
+
+		handler.handleMessage(socket, new TextMessage(
+				"{\"type\":\"session.message\",\"sessionId\":\" s1 \",\"message\":{\"owner\":1,\"content\":\"hi\"}}"));
+		verify(dispatcher).addMessage(eq("user-1"), eq("s1"), any());
+		assertTrue(ack(socket).contains("session.message.accepted"));
+
+		org.mockito.Mockito.clearInvocations(socket);
+		handler.handleMessage(socket, new TextMessage(
+				"{\"type\":\"endSession\",\"sessionId\":\"s1\",\"stopTime\":\"now\"}"));
+		verify(dispatcher).endSession("user-1", "s1", "now");
+		assertTrue(ack(socket).contains("session.end.accepted"));
+
+		org.mockito.Mockito.clearInvocations(socket);
+		handler.handleMessage(socket, new TextMessage(
+				"{\"sessionId\":\"s1\",\"message\":{\"owner\":0,\"content\":\"hello\"}}"));
+		verify(dispatcher, org.mockito.Mockito.times(2)).addMessage(eq("user-1"), eq("s1"), any());
+		assertTrue(ack(socket).contains("session.message.accepted"));
+	}
+
+	@Test
+	void rejectsUnsupportedTypesMissingSessionOrAuthenticationAndKeepsClosedSocketQuiet() throws Exception {
+		SessionMessageDispatcher dispatcher = mock(SessionMessageDispatcher.class);
+		SessionMessageWebSocketHandler handler = new SessionMessageWebSocketHandler(new ObjectMapper(), dispatcher);
+		WebSocketSession socket = authenticatedSocket("user-1");
+
+		handler.handleMessage(socket, new TextMessage("{\"type\":\"unknown\",\"sessionId\":\"s1\"}"));
+		assertTrue(ack(socket).contains("session.unknown.failed"));
+		verifyNoDispatcher(dispatcher);
+
+		org.mockito.Mockito.clearInvocations(socket);
+		handler.handleMessage(socket, new TextMessage("{\"type\":\"end\"}"));
+		assertTrue(ack(socket).contains("session.end.failed"));
+
+		WebSocketSession anonymous = authenticatedSocket(null);
+		handler.handleMessage(anonymous, new TextMessage("{\"type\":\"message\",\"sessionId\":\"s1\"}"));
+		assertTrue(ack(anonymous).contains("session.message.failed"));
+
+		WebSocketSession closed = authenticatedSocket("user-1");
+		when(closed.isOpen()).thenReturn(false);
+		handler.handleMessage(closed, new TextMessage("{\"type\":\"bad\",\"sessionId\":\"s1\"}"));
+		verify(closed, never()).sendMessage(any());
+	}
+
+	private void verifyNoDispatcher(SessionMessageDispatcher dispatcher) {
+		verify(dispatcher, never()).addMessage(any(), any(), any());
+		verify(dispatcher, never()).endSession(any(), any(), any());
+		verify(dispatcher, never()).bindProviderSession(any(), any(), any());
 	}
 }

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -21,7 +21,7 @@ Redis 引入生产运行时。
 
 工作流文件本身发生变化时会强制运行全部检查。其他变更按路径执行：
 
-- 后端：编译、186 项单元测试、打包、PostgreSQL/Redis 集成测试、70% 行覆盖率和镜像构建；
+- 后端：编译、单元测试、打包、PostgreSQL/Redis 集成测试、85% 行覆盖率和镜像构建；
 - Web 前端：Node.js 22、`npm ci`、路由与 Realtime 事件检查、生产构建和镜像构建；
 - 移动端：Node.js 22、`npm ci`、TypeScript 检查和 Expo Web 静态导出；
 - Compose、环境模板或 Nginx：配置解析或 `nginx -t`；
@@ -43,7 +43,7 @@ PostgreSQL 与 Redis 集成测试：
   -Pci-integration -DskipUnitTests verify
 ```
 
-合并两类测试的 JaCoCo 数据并执行 70% 门禁：
+合并两类测试的 JaCoCo 数据并执行 85% 门禁：
 
 ```bash
 ./mvnw --batch-mode --no-transfer-progress \


### PR DESCRIPTION
## 变更说明

- 补充 AI Provider、认证、会话、场景、评估、报告、管理端及持久化层测试。
- 增加 Controller、Gateway、WebSocket、录音存储和实时通信相关边界测试。
- 将聚合 JaCoCo LINE 覆盖率门禁从 70% 提升至 85%。
- 聚合单元测试与 PostgreSQL/Redis 集成测试覆盖率。
- 保持现有 exclusions、Codecov badge URL 和 coverage workflow 不变。
- 未修改生产业务逻辑。

## 验证结果

- 单元测试：1265 项通过
- PostgreSQL/Redis 集成测试：10 项通过
- 聚合 JaCoCo 85% 覆盖率门禁：通过
- 当前已生成报告的 LINE 覆盖率：93.84%

## 提交拆分

- `fc69b22` ci: raise aggregate coverage gate to 85 percent
- `fa9958c` test: expand AI provider and adapter coverage
- `1b751fc` test: cover email and token authentication flows
- `09abb85` test: expand evaluation and report coverage
- `09f8aec` test: expand scene and controller coverage
- `da6f910` test: expand session report and recording coverage
- `1ebd13c` test: expand admin and persistence coverage
- `0ba18c2` test: cover realtime profile and gateway edges

## 关联 Issue

Close #148