### PR TITLE
fix(web)：增加练习退出确认并优化面试页面布局

### DIFF
--- a/frontend/web/scripts/check-routes.mjs
+++ b/frontend/web/scripts/check-routes.mjs
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
 import { paths, resolveRoute, sidebarPageTarget } from "../src/controller/router.js";
 
 const route = (pathname, search = "") => resolveRoute({ pathname, search });
@@ -91,4 +92,43 @@ assert.equal(sidebarPageTarget("interview-assets", "scenes"), "interview");
 assert.equal(sidebarPageTarget("scenes", "assets"), "assets");
 assert.equal(sidebarPageTarget("assets", "scenes"), "scenes");
 
-console.log(`Route contract passed: ${cases.length + 41} assertions`);
+const appSource = await readFile(
+  new URL("../src/controller/App.jsx", import.meta.url),
+  "utf8",
+);
+const appShellSource = appSource.slice(
+  appSource.indexOf("function AppShell("),
+  appSource.indexOf("function PageHeader("),
+);
+const trainingSource = appSource.slice(
+  appSource.indexOf("function Training("),
+  appSource.indexOf("function AssetModuleMenu("),
+);
+
+assert.match(
+  appShellSource,
+  /if \(navigationGuardActive\) \{\s+setPendingPage\(targetPage\);\s+return;/,
+  "Active practice must defer sidebar navigation until confirmation",
+);
+assert.match(
+  appShellSource,
+  /onClick=\{\(\) => navigateSidebar\("profile"\)\}/,
+  "Profile navigation must use the same practice guard as sidebar items",
+);
+assert.match(
+  appShellSource,
+  /<TrainingExitConfirmation open=\{Boolean\(pendingPage\)\}/,
+  "Guarded navigation must reuse the existing training exit confirmation",
+);
+assert.match(
+  trainingSource,
+  /<TrainingExitConfirmation open=\{exitOpen\}/,
+  "The custom training close button must use the shared exit confirmation",
+);
+assert.match(
+  appSource,
+  /\(training && !result\)[\s\S]*?freeConversationActive[\s\S]*?ieltsRoute\?\.screen === "session"[\s\S]*?interviewRoute\?\.screen === "session"/,
+  "Navigation guard must cover unfinished custom, free, IELTS, and interview practice",
+);
+
+console.log(`Route contract passed: ${cases.length + 46} assertions`);

--- a/frontend/web/scripts/check-routes.mjs
+++ b/frontend/web/scripts/check-routes.mjs
@@ -131,4 +131,29 @@ assert.match(
   "Navigation guard must cover unfinished custom, free, IELTS, and interview practice",
 );
 
-console.log(`Route contract passed: ${cases.length + 46} assertions`);
+const interviewSource = await readFile(
+  new URL("../src/component/interview/InterviewModule.jsx", import.meta.url),
+  "utf8",
+);
+const stylesSource = await readFile(
+  new URL("../src/common/styles.css", import.meta.url),
+  "utf8",
+);
+
+assert.match(
+  interviewSource,
+  /className="interview-home-assets-cta" onClick=\{\(\) => onNavigate\(paths\.interview\.assets\.root\)\}/,
+  "Interview home must link directly to interview learning assets",
+);
+assert.match(
+  interviewSource,
+  /className="ielts-assets-actions interview-assets-actions"/,
+  "Interview asset header actions must have a module-specific layout hook",
+);
+assert.match(
+  stylesSource,
+  /\.interview-assets-page \.page-header \{ width: 100%;[\s\S]*?\.interview-assets-actions \{ margin-right: 0; \}/,
+  "Interview asset header and actions must align with the full content width",
+);
+
+console.log(`Route contract passed: ${cases.length + 49} assertions`);

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -2488,7 +2488,8 @@ svg { display: block; }
 .page--interview .page-header { width: min(1360px, 100%); margin-bottom: 24px; }
 .page--interview .page-header h1 { margin-bottom: 8px; font-size: 48px; }
 .page--interview .page-header > div > p:last-child { font-size: 15px; }
-.interview-home { width: min(1360px, 100%); }
+.interview-home,
+.interview-home .page-header { width: 100%; }
 
 .interview-builder {
   padding: 26px 28px 28px;
@@ -3293,7 +3294,7 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
   isolation: isolate;
   overflow: hidden;
   align-items: center;
-  padding: 30px clamp(230px, 29vw, 420px) 30px 34px;
+  padding: 30px 34px;
   border: 1px solid rgba(76, 145, 214, .55);
   border-radius: 18px;
   background-color: var(--interview-hero);
@@ -3303,6 +3304,15 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
   background-size: cover;
   box-shadow: 0 12px 30px rgba(18, 50, 85, .18);
 }
+.interview-home .page-header > div:first-child { max-width: min(700px, 65%); }
+.interview-home-assets-cta {
+  min-width: 150px;
+  flex: 0 0 auto;
+  border-color: rgba(255, 255, 255, .72);
+  color: var(--interview-hero);
+  background: rgba(247, 251, 255, .96);
+}
+.interview-home-assets-cta:hover { border-color: #fff; background: #fff; }
 .interview-home .page-header::after {
   content: "";
   position: absolute;
@@ -3532,8 +3542,9 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
 .interview-report-pending > p:not(.eyebrow) { color: var(--interview-muted); }
 
 /* Interview learning assets */
-.interview-assets-page .page-header { padding-bottom: 24px; border-bottom: 1px solid var(--interview-border); }
+.interview-assets-page .page-header { width: 100%; padding-bottom: 24px; border-bottom: 1px solid var(--interview-border); }
 .interview-assets-page .page-header > div > p:last-child { color: var(--interview-muted); }
+.interview-assets-actions { margin-right: 0; }
 .interview-assets-page .ielts-assets-actions .ielts-assets-header-cta,
 .interview-other-assets .asset-module-menu__trigger,
 .interview-other-assets .asset-module-menu__popover {
@@ -3626,10 +3637,12 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
 .interview-assets-tab-indicator.is-ready { opacity: 1; }
 
 .interview-assets-overview {
+  min-width: 0;
   display: grid;
   gap: 16px;
   padding-top: 20px;
 }
+.interview-assets-overview > * { min-width: 0; }
 .interview-assets-hero {
   min-height: 176px;
   padding: 26px 30px;
@@ -3803,11 +3816,15 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
   .page--interview .ielts-back { margin-top: 0; }
   .interview-home .page-header {
     min-height: 240px;
-    align-items: flex-end;
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 18px;
     padding: 28px 22px;
     background-position: 60% 62%;
     background-size: auto 180%;
   }
+  .interview-home .page-header > div:first-child { max-width: none; }
+  .interview-home-assets-cta { width: 100%; }
   .interview-home .page-header::after { background: rgba(10, 43, 82, .68); }
   .interview-home .page-header h1 { font-size: 38px; }
   .interview-home .page-header > div > p:last-child { font-size: 13px; }
@@ -3834,8 +3851,8 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
   .interview-assets-hero > div:nth-child(2) { padding: 16px 0 0; border-left: 0; border-top: 1px solid var(--interview-border); }
   .interview-assets-weekly { min-height: 0; padding: 22px; }
   .interview-assets-weekly__bars { min-height: 160px; gap: 3px; }
-  .interview-assets-weekly__bars > span { width: 32px; }
-  .interview-assets-weekly__bars i { width: 20px; }
+  .interview-assets-weekly__bars > span { width: 24px; }
+  .interview-assets-weekly__bars i { width: 16px; }
   .interview-assets-recent > div { grid-template-columns: 1fr; }
   .interview-assets-recent button,
   .interview-assets-recent article { border-left: 0; border-top: 1px solid var(--interview-border); }

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -406,6 +406,7 @@ function InterviewHome({ onNavigate, onBack }) {
           eyebrow="JOB INTERVIEW"
           title="模拟面试"
           subtitle="上传 JD 与简历，AI 面试官按真实岗位流程向你提问，并在结束后生成五维报告。"
+          action={<SimpleCta className="interview-home-assets-cta" onClick={() => onNavigate(paths.interview.assets.root)}>查看学习资产</SimpleCta>}
         />
         <section className="interview-builder interview-module">
           <div className="scene-section-heading scene-section-heading--primary">
@@ -1251,7 +1252,7 @@ export function InterviewAssets({ route, onNavigate, onBack, onBackToAssets, onB
   return (
     <main className={cx("page", "page--interview", "interview-assets-page", tab === "overview" && "interview-assets-page--overview", tab === "trends" && "interview-assets-page--trends")}>
       <button className="ielts-back" onClick={onBack}><ArrowLeft />返回</button>
-      <PageHeader title="面试学习资产" action={<div className="ielts-assets-actions">{otherAssetsMenu}<SimpleCta className="ielts-assets-header-cta" onClick={onTraining}>返回训练中心</SimpleCta></div>} />
+      <PageHeader title="面试学习资产" action={<div className="ielts-assets-actions interview-assets-actions">{otherAssetsMenu}<SimpleCta className="ielts-assets-header-cta" onClick={onTraining}>返回训练中心</SimpleCta></div>} />
       <nav className="interview-assets-tabs" ref={tabRef} aria-label="面试学习资产视图">
         <span className={cx("interview-assets-tab-indicator", tabIndicator.ready && "is-ready")} style={{ width: tabIndicator.width, transform: `translateX(${tabIndicator.x}px)` }} />
         {interviewAssetTabs.map((item) => <button ref={(node) => { tabButtons.current[item.id] = node; }} key={item.id} className={tab === item.id ? "is-active" : ""} onClick={() => setTab(item.id)}>{item.label}</button>)}

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -936,28 +936,48 @@ function TeacherSetup({ selectedId, onSelect, onFinish }) {
   );
 }
 
-function AppShell({ page, setPage, teacher, avatarUrl, children }) {
+function TrainingExitConfirmation({ open, onContinue, onConfirm }) {
+  if (!open) return null;
+  return <Modal dismissible={false}><p className="eyebrow">EXIT TRAINING</p><h2>确定要退出当前训练吗？</h2><p className="modal-lead">退出后将返回上一页。</p><div className="modal-actions"><Button variant="secondary" onClick={onContinue}>继续训练</Button><Button onClick={onConfirm}>确认退出</Button></div></Modal>;
+}
+
+function AppShell({ page, setPage, teacher, avatarUrl, navigationGuardActive = false, children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [pendingPage, setPendingPage] = useState(null);
   const items = [
     { id: "conversation", label: "自由对话", icon: Waveform },
     { id: "scenes", label: "场景广场", icon: SquaresFour },
     { id: "assets", label: "学习资产", icon: BookOpenText },
   ];
   const activePage = page === "ielts" || page === "interview" ? "scenes" : page === "ielts-assets" || page === "interview-assets" ? "assets" : page;
+  useEffect(() => {
+    if (!navigationGuardActive) setPendingPage(null);
+  }, [navigationGuardActive]);
   const navigateSidebar = (destination) => {
     const targetPage = sidebarPageTarget(page, destination);
     // Keep the current specialty page selected when clicking its active sidebar section.
     if (activePage === destination && targetPage === destination) return;
-    if (targetPage !== page) setPage(targetPage);
+    if (targetPage === page) return;
+    if (navigationGuardActive) {
+      setPendingPage(targetPage);
+      return;
+    }
+    setPage(targetPage);
+  };
+  const confirmNavigation = () => {
+    const targetPage = pendingPage;
+    setPendingPage(null);
+    if (targetPage && targetPage !== page) setPage(targetPage);
   };
   return (
     <div className={cx("app-shell", sidebarOpen && "is-sidebar-open")}>
       <aside className={cx("sidebar", sidebarOpen && "is-open")} onMouseEnter={() => setSidebarOpen(true)} onMouseLeave={() => setSidebarOpen(false)}>
         <Brand compact={!sidebarOpen} />
         <nav>{items.map(({ id, label, icon: Icon }) => <button key={id} className={cx("sidebar__item", activePage === id && "is-active")} onClick={() => navigateSidebar(id)} aria-label={label} title={label}><Icon weight={activePage === id ? "bold" : "regular"} /><span className="sidebar__label"><span>{label}</span></span></button>)}</nav>
-        <button className={cx("sidebar__avatar", ["profile", "insights", "membership", "settings", "help", "about"].includes(page) && "is-active")} onClick={() => setPage("profile")}><img src={avatarUrl || teacher.image} alt="个人中心" /></button>
+        <button className={cx("sidebar__avatar", ["profile", "insights", "membership", "settings", "help", "about"].includes(page) && "is-active")} onClick={() => navigateSidebar("profile")}><img src={avatarUrl || teacher.image} alt="个人中心" /></button>
       </aside>
       <div className="app-main">{children}</div>
+      <TrainingExitConfirmation open={Boolean(pendingPage)} onContinue={() => setPendingPage(null)} onConfirm={confirmNavigation} />
     </div>
   );
 }
@@ -1092,7 +1112,7 @@ function ConversationSettings({ speed, level, teacher, onSave, onClose }) {
   );
 }
 
-function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, onSessionStarted, onSessionEnded }) {
+function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, onSessionStarted, onSessionEnded, onActiveChange }) {
   const [inCall, setInCall] = useState(false);
   const [callState, setCallState] = useState("idle");
   const [callStatus, setCallStatus] = useState("准备开始");
@@ -1411,6 +1431,13 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
       void client?.stop({ notifyBackend: false, reason: "component_unmount" });
     };
   }, []);
+
+  useEffect(() => {
+    onActiveChange?.(inCall);
+    return () => {
+      if (inCall) onActiveChange?.(false);
+    };
+  }, [inCall, onActiveChange]);
 
   if (!inCall) return (
     <main className="conversation standby">
@@ -2227,7 +2254,7 @@ function Training({ sceneId, sessionId, sceneTitle, sceneContent, teacher, speed
   const score = readScores[readIndex] ?? null;
   const readEvaluation = readEvaluations[readIndex] ?? null;
   const completeStep = (id) => setCompletedSteps((current) => current.includes(id) ? current : [...current, id]);
-  const exitConfirmation = exitOpen && <Modal dismissible={false}><p className="eyebrow">EXIT TRAINING</p><h2>确定要退出当前训练吗？</h2><p className="modal-lead">退出后将返回上一页。</p><div className="modal-actions"><Button variant="secondary" onClick={() => setExitOpen(false)}>继续训练</Button><Button onClick={onExit}>确认退出</Button></div></Modal>;
+  const exitConfirmation = <TrainingExitConfirmation open={exitOpen} onContinue={() => setExitOpen(false)} onConfirm={onExit} />;
   const goToStep = (id) => {
     const targetIndex = steps.findIndex((item) => item.id === id);
     if (targetIndex > unlockedStepIndex) return;
@@ -3115,6 +3142,7 @@ export function App() {
   const [aboutRoute, setAboutRoute] = useState(initialRoute.aboutRoute || null);
   const [paywall, setPaywall] = useState(null);
   const [feedbackInvitationOpen, setFeedbackInvitationOpen] = useState(false);
+  const [freeConversationActive, setFreeConversationActive] = useState(false);
   const preferenceWriteChainRef = useRef(Promise.resolve());
   const preferenceWriteVersionRef = useRef(0);
   const profileOverviewRequestVersionRef = useRef(0);
@@ -3623,7 +3651,7 @@ export function App() {
   }
   let content;
   if (training) content = <Training sceneId={training.sceneId} sessionId={training.sessionId} sceneTitle={sceneTitle} sceneContent={generatedScene} teacher={teacher} speed={conversationSpeed} initialStep={training.initialStep} initialStage={training.stage} standaloneSpeak={training.standaloneSpeak} result={result} onExit={() => setMainPage(training.returnPage || "scenes")} onComplete={completeScenePractice} onBack={() => setMainPage(training.returnPage || "scenes")} onAssets={openCompletedAssetDetail} onStageChange={navigateSceneStage} />;
-  else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={(sessionId) => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); recordCompletedPractice("free", sessionId); void refreshProfileOverview(); void synchronizeAchievements({ revealNotifications: true }); }} />;
+  else if (page === "conversation") content = <Conversation teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onBeforeStart={() => preferenceWriteChainRef.current.catch(() => undefined)} onSessionStarted={(sessionId) => navigate(paths.conversation.session(sessionId), { page: "conversation", conversationSessionId: sessionId, authMode })} onSessionEnded={(sessionId) => { navigate(paths.conversation.root, { page: "conversation", conversationSessionId: null, authMode }, true); recordCompletedPractice("free", sessionId); void refreshProfileOverview(); void synchronizeAchievements({ revealNotifications: true }); }} onActiveChange={setFreeConversationActive} />;
   else if (page === "scenes") content = <Scenes teacher={teacher} onStartTraining={startTraining} onLocked={setPaywall} onIelts={selectIelts} onInterview={selectInterview} />;
   else if (page === "assets") content = <Assets sceneId={assetSceneId} initialView={assetView} initialRecordTitle={sceneTitle} onOpenRecord={openCompletedAssetDetail} onCloseRecord={() => navigate(paths.assets.root, { assetView: "home", assetSceneId: null, authMode })} onIelts={() => selectMainPage("ielts-assets")} onInterview={() => selectMainPage("interview-assets")} onPractice={(scene) => startTraining(scene, "speak", { standaloneSpeak: false, returnPage: "assets" })} />;
   else if (page === "ielts") content = <IeltsTrainingCenter route={ieltsRoute} onNavigate={navigateIelts} onExit={() => setMainPage("scenes")} onAssets={() => navigateIelts(paths.ielts.assets.root)} />;
@@ -3631,5 +3659,11 @@ export function App() {
   else if (page === "interview") content = <InterviewModule route={interviewRoute} teacher={teacher} speed={conversationSpeed} onNavigate={navigateInterview} onBack={() => setMainPage("scenes")} />;
   else if (page === "interview-assets") content = <InterviewAssets route={interviewRoute} onNavigate={navigateInterview} onBack={() => setMainPage("scenes")} onBackToAssets={() => setMainPage("assets")} onBackToIelts={() => selectMainPage("ielts-assets")} onTraining={() => navigateInterview(paths.interview.root)} onPractice={(sceneId) => navigateInterview(paths.interview.session(sceneId))} />;
   else content = <Profile section={page} setSection={setMainPage} helpRoute={helpRoute} aboutRoute={aboutRoute} onHelpNavigate={navigateHelp} onAboutNavigate={navigateAbout} user={user} profile={profileOverview} teacher={teacher} speed={conversationSpeed} level={level} onSettingsChange={persistSettings} onMonthChange={loadProfileMonth} onNicknameChange={updateNickname} onAvatarChange={updateAvatar} onPasswordChange={updatePassword} onAssets={() => setMainPage("assets")} onLogout={logout} />;
-  return <AppShell page={page} setPage={selectMainPage} teacher={teacher} avatarUrl={profileOverview?.account?.avatarUrl}>{content}{paywall && <Paywall title={paywall} onClose={() => setPaywall(null)} onMembership={() => { setPaywall(null); setMainPage("membership"); }} />}{feedbackInvitationOpen && <FeedbackInvitation onDismiss={() => setFeedbackInvitationOpen(false)} onAccept={acceptFeedbackInvitation} />}</AppShell>;
+  const navigationGuardActive = Boolean(
+    (training && !result)
+    || freeConversationActive
+    || (page === "ielts" && ieltsRoute?.screen === "session")
+    || (page === "interview" && interviewRoute?.screen === "session"),
+  );
+  return <AppShell page={page} setPage={selectMainPage} teacher={teacher} avatarUrl={profileOverview?.account?.avatarUrl} navigationGuardActive={navigationGuardActive}>{content}{paywall && <Paywall title={paywall} onClose={() => setPaywall(null)} onMembership={() => { setPaywall(null); setMainPage("membership"); }} />}{feedbackInvitationOpen && <FeedbackInvitation onDismiss={() => setFeedbackInvitationOpen(false)} onAccept={acceptFeedbackInvitation} />}</AppShell>;
 }


### PR DESCRIPTION
## 修改内容

### 练习退出保护

- 为自定义训练、自由对话、雅思练习和模拟面试增加侧栏导航退出保护。
- 用户点击左侧导航或头像时，复用现有的练习退出确认弹窗。
- 取消退出时保留当前练习进度和连接。
- 确认退出后执行用户原本选择的页面导航。
- 已完成结果页和当前激活的导航项不会触发确认。

### 模拟面试页面优化

- 调整模拟面试首页宽度和布局，使内容更合理地居中并利用可用空间。
- 调整模拟面试学习资产页头和顶部操作按钮的对齐方式。
- 在模拟面试首页增加“查看学习资产”入口。
- 修复移动端学习资产页面可能出现的横向溢出。

## 影响范围

仅涉及 Web 端以下文件：

- `frontend/web/src/controller/App.jsx`
- `frontend/web/src/component/interview/InterviewModule.jsx`
- `frontend/web/src/common/styles.css`
- `frontend/web/scripts/check-routes.mjs`

不涉及后端接口、数据库结构和计费逻辑。

## 测试结果

- [x] `npm run check:routes`
- [x] `npm run check:realtime-events`
- [x] `npm run check:call-timer`
- [x] `npm run build`
- [x] 路由契约测试通过，共 77 条断言
- [x] 桌面端布局检查
- [x] 移动端布局检查