### PR TITLE
fix: tolerate pronunciation scoring outliers

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/policy/SentenceReadingPassPolicy.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/common/evaluation/policy/SentenceReadingPassPolicy.java
@@ -1,0 +1,39 @@
+package com.unispeaking.common.evaluation.policy;
+
+import com.unispeaking.common.evaluation.model.PronunciationAssessmentResult;
+import java.math.BigDecimal;
+import java.util.Objects;
+
+/** Decides whether a sentence reading is good enough to continue practice. */
+public final class SentenceReadingPassPolicy {
+
+	private static final BigDecimal STANDARD_PASS_SCORE = score("80");
+	private static final BigDecimal NEAR_PASS_SCORE = score("70");
+	private static final BigDecimal MINIMUM_PRONUNCIATION = score("75");
+	private static final BigDecimal MINIMUM_INTEGRITY = score("80");
+	private static final BigDecimal REPEATED_BEST_PASS_SCORE = score("75");
+	private static final long MINIMUM_REPEATED_ATTEMPTS = 3;
+
+	public boolean passes(PronunciationAssessmentResult assessment) {
+		Objects.requireNonNull(assessment, "assessment must not be null");
+		if (atLeast(assessment.overallScore(), STANDARD_PASS_SCORE)) {
+			return true;
+		}
+		return atLeast(assessment.overallScore(), NEAR_PASS_SCORE)
+				&& atLeast(assessment.pronunciationScore(), MINIMUM_PRONUNCIATION)
+				&& atLeast(assessment.integrityScore(), MINIMUM_INTEGRITY);
+	}
+
+	public boolean passesRepeatedBest(long attemptCount, BigDecimal bestScore) {
+		return attemptCount >= MINIMUM_REPEATED_ATTEMPTS
+				&& atLeast(bestScore, REPEATED_BEST_PASS_SCORE);
+	}
+
+	private boolean atLeast(BigDecimal value, BigDecimal threshold) {
+		return value != null && value.compareTo(threshold) >= 0;
+	}
+
+	private static BigDecimal score(String value) {
+		return new BigDecimal(value);
+	}
+}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/evaluation/EvaluationProcessor.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/evaluation/EvaluationProcessor.java
@@ -70,6 +70,7 @@ import com.unispeaking.common.evaluation.validation.EnglishWordCounter;
 import com.unispeaking.common.prompt.evaluation.DialogueTurnEvaluationHistory;
 import com.unispeaking.common.prompt.evaluation.DialogueTurnEvaluationPromptInput;
 import com.unispeaking.common.evaluation.policy.UnavailableTurnEvaluationPolicy;
+import com.unispeaking.common.evaluation.policy.SentenceReadingPassPolicy;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
@@ -96,8 +97,9 @@ public class EvaluationProcessor {
 
 	private static final Logger LOGGER = LoggerFactory.getLogger(
 			EvaluationProcessor.class);
-	private static final BigDecimal SENTENCE_PASS_SCORE = new BigDecimal("80");
 	private static final int IELTS_EVALUATION_LOCK_STRIPES = 64;
+	private static final SentenceReadingPassPolicy SENTENCE_READING_PASS_POLICY =
+			new SentenceReadingPassPolicy();
 
 	private final PronunciationAssessmentClient pronunciationClient;
 	private final EvaluationLlmClient llmClient;
@@ -988,9 +990,22 @@ public class EvaluationProcessor {
 				sceneId,
 				sentence,
 				assessment);
+		SceneSentenceReadingRepository.AttemptSummary attemptSummary =
+				sceneSentenceReadingRepository.summarizeAttempts(
+						sceneId,
+						sentenceId);
+		BigDecimal bestScore = attemptSummary == null
+				|| attemptSummary.bestScore() == null
+				? assessment.overallScore()
+				: assessment.overallScore().max(attemptSummary.bestScore());
+		boolean passed = SENTENCE_READING_PASS_POLICY.passes(assessment)
+				|| (attemptSummary != null
+						&& SENTENCE_READING_PASS_POLICY.passesRepeatedBest(
+								attemptSummary.attemptCount(),
+								bestScore));
 		return new SentenceEvaluationResponse(
-				assessment.overallScore(),
-				assessment.overallScore().compareTo(SENTENCE_PASS_SCORE) >= 0,
+				passed ? bestScore : assessment.overallScore(),
+				passed,
 				mapWords(assessment.words()));
 	}
 

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/ai/iflytek/IflytekScoringProvider.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/ai/iflytek/IflytekScoringProvider.java
@@ -358,6 +358,7 @@ public class IflytekScoringProvider extends ScoringProvider {
 									Map.entry("phoneme_output", 1),
 									Map.entry("scale", 100),
 									Map.entry("precision", 0.1),
+									Map.entry("slack", 0.2),
 									Map.entry("output_rawtext", 1),
 									Map.entry("dict_type", "IPA88"),
 									Map.entry("dict_dialect", "en_us"),

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepository.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepository.java
@@ -126,13 +126,15 @@ public class SceneSentenceReadingRepository {
 							.eq(SentenceEvaluationEntity::getSceneId, sceneId)
 							.eq(SentenceEvaluationEntity::getSentenceId, sentenceId);
 			long count = evaluationMapper.selectCount(scope);
-			SentenceEvaluationEntity best = evaluationMapper.selectOne(
+			List<SentenceEvaluationEntity> rankedAttempts = evaluationMapper.selectList(
 					new LambdaQueryWrapper<SentenceEvaluationEntity>()
 							.select(SentenceEvaluationEntity::getOverallScore)
 							.eq(SentenceEvaluationEntity::getSceneId, sceneId)
 							.eq(SentenceEvaluationEntity::getSentenceId, sentenceId)
-							.orderByDesc(SentenceEvaluationEntity::getOverallScore)
-							.last("LIMIT 1"));
+							.orderByDesc(SentenceEvaluationEntity::getOverallScore));
+			SentenceEvaluationEntity best = rankedAttempts.isEmpty()
+					? null
+					: rankedAttempts.getFirst();
 			return new AttemptSummary(
 					count,
 					best == null ? null : best.getOverallScore());

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepository.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepository.java
@@ -13,6 +13,7 @@ import com.unispeaking.common.evaluation.model.PronunciationAssessmentResult;
 import com.unispeaking.common.evaluation.model.PronunciationPhonemeResult;
 import com.unispeaking.common.evaluation.model.PronunciationWordResult;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -24,6 +25,9 @@ import org.springframework.stereotype.Repository;
  */
 @Repository
 public class SceneSentenceReadingRepository {
+
+	public record AttemptSummary(long attemptCount, BigDecimal bestScore) {
+	}
 
 	private final SceneSentenceMapper sentenceMapper;
 	private final SentenceEvaluationMapper evaluationMapper;
@@ -109,6 +113,29 @@ public class SceneSentenceReadingRepository {
 							.in(
 									SentenceEvaluationEntity::getSceneId,
 									ownedSceneIds));
+		}
+		catch (RuntimeException exception) {
+			throw persistenceFailure();
+		}
+	}
+
+	public AttemptSummary summarizeAttempts(String sceneId, String sentenceId) {
+		try {
+			LambdaQueryWrapper<SentenceEvaluationEntity> scope =
+					new LambdaQueryWrapper<SentenceEvaluationEntity>()
+							.eq(SentenceEvaluationEntity::getSceneId, sceneId)
+							.eq(SentenceEvaluationEntity::getSentenceId, sentenceId);
+			long count = evaluationMapper.selectCount(scope);
+			SentenceEvaluationEntity best = evaluationMapper.selectOne(
+					new LambdaQueryWrapper<SentenceEvaluationEntity>()
+							.select(SentenceEvaluationEntity::getOverallScore)
+							.eq(SentenceEvaluationEntity::getSceneId, sceneId)
+							.eq(SentenceEvaluationEntity::getSentenceId, sentenceId)
+							.orderByDesc(SentenceEvaluationEntity::getOverallScore)
+							.last("LIMIT 1"));
+			return new AttemptSummary(
+					count,
+					best == null ? null : best.getOverallScore());
 		}
 		catch (RuntimeException exception) {
 			throw persistenceFailure();

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/policy/SentenceReadingPassPolicyTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/common/evaluation/policy/SentenceReadingPassPolicyTest.java
@@ -1,0 +1,64 @@
+package com.unispeaking.common.evaluation.policy;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.unispeaking.common.evaluation.model.EndingTone;
+import com.unispeaking.common.evaluation.model.PronunciationAssessmentResult;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class SentenceReadingPassPolicyTest {
+
+	private final SentenceReadingPassPolicy policy =
+			new SentenceReadingPassPolicy();
+
+	@Test
+	void acceptsTheRealContractSentenceNearPassInsteadOfBlockingForever() {
+		PronunciationAssessmentResult assessment = assessment(
+				"76.40",
+				"83.70",
+				"90.40",
+				"90.00");
+
+		assertTrue(policy.passes(assessment));
+	}
+
+	@Test
+	void keepsLowOrIncompleteReadingsBelowThePassLine() {
+		assertFalse(policy.passes(assessment("69.90", "90", "90", "90")));
+		assertFalse(policy.passes(assessment("75", "90", "90", "70")));
+	}
+
+	@Test
+	void preservesTheExistingEightyPointPassRule() {
+		assertTrue(policy.passes(assessment("80", "60", "60", "60")));
+	}
+
+	@Test
+	void allowsARepeatedNearPassWhenTheBestOfThreeAttemptsReachedSeventyFive() {
+		assertTrue(policy.passesRepeatedBest(
+				3,
+				new BigDecimal("76.40")));
+		assertFalse(policy.passesRepeatedBest(
+				2,
+				new BigDecimal("79.90")));
+	}
+
+	private PronunciationAssessmentResult assessment(
+			String overall,
+			String pronunciation,
+			String fluency,
+			String integrity) {
+		return new PronunciationAssessmentResult(
+				new BigDecimal(overall),
+				new BigDecimal("80"),
+				null,
+				new BigDecimal(integrity),
+				new BigDecimal(pronunciation),
+				new BigDecimal(fluency),
+				EndingTone.FALL,
+				List.of());
+	}
+}

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenRealtimeProviderTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/ai/qwen/QwenRealtimeProviderTest.java
@@ -726,6 +726,10 @@ class QwenRealtimeProviderTest {
 				"IPA88",
 				startFrame.path("parameter").path("st")
 						.path("dict_type").asString());
+		assertEquals(
+				0.2,
+				startFrame.path("parameter").path("st")
+						.path("slack").asDouble());
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
@@ -170,6 +170,29 @@ class SceneSentenceReadingRepositoryTest {
 		assertEquals(0, repository.countAttemptsBySceneIds(null));
 	}
 
+	@Test
+	void summarizesRepeatedAttemptsWithTheirBestScore() {
+		SentenceEvaluationMapper evaluationMapper =
+				mock(SentenceEvaluationMapper.class);
+		SentenceEvaluationEntity best = new SentenceEvaluationEntity();
+		best.setOverallScore(new BigDecimal("76.40"));
+		when(evaluationMapper.selectCount(any())).thenReturn(11L);
+		when(evaluationMapper.selectOne(any())).thenReturn(best);
+		SceneSentenceReadingRepository repository =
+				new SceneSentenceReadingRepository(
+						mock(SceneSentenceMapper.class),
+						evaluationMapper,
+						new EvaluationJsonbCodec(new ObjectMapper()));
+
+		SceneSentenceReadingRepository.AttemptSummary summary =
+				repository.summarizeAttempts(
+						"custom_scene1",
+						"sentence_1");
+
+		assertEquals(11, summary.attemptCount());
+		assertEquals(new BigDecimal("76.40"), summary.bestScore());
+	}
+
 	private PronunciationAssessmentResult assessment() {
 		PronunciationPhonemeResult phoneme =
 				new PronunciationPhonemeResult(

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/infrastructure/persistence/repository/evaluation/SceneSentenceReadingRepositoryTest.java
@@ -177,7 +177,7 @@ class SceneSentenceReadingRepositoryTest {
 		SentenceEvaluationEntity best = new SentenceEvaluationEntity();
 		best.setOverallScore(new BigDecimal("76.40"));
 		when(evaluationMapper.selectCount(any())).thenReturn(11L);
-		when(evaluationMapper.selectOne(any())).thenReturn(best);
+		when(evaluationMapper.selectList(any())).thenReturn(List.of(best));
 		SceneSentenceReadingRepository repository =
 				new SceneSentenceReadingRepository(
 						mock(SceneSentenceMapper.class),

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/SentenceReadingEvaluationTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/service/evaluation/SentenceReadingEvaluationTest.java
@@ -1,0 +1,191 @@
+package com.unispeaking.service.evaluation;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.AdditionalMatchers.aryEq;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.unispeaking.common.evaluation.model.EndingTone;
+import com.unispeaking.common.evaluation.model.PronunciationAssessmentResult;
+import com.unispeaking.common.evaluation.model.PronunciationPhonemeResult;
+import com.unispeaking.common.evaluation.model.PronunciationWordResult;
+import com.unispeaking.common.evaluation.model.WordReadStatus;
+import com.unispeaking.component.evaluation.EvaluationProcessor;
+import com.unispeaking.component.session.ActiveSessionRegistry;
+import com.unispeaking.domain.dto.scene.LearningContentItem;
+import com.unispeaking.domain.po.scene.CustomSceneDefinition;
+import com.unispeaking.infrastructure.config.ObjectStorageProperties;
+import com.unispeaking.infrastructure.evaluation.client.EvaluationLlmClient;
+import com.unispeaking.infrastructure.evaluation.client.IeltsEvaluationLlmClient;
+import com.unispeaking.infrastructure.evaluation.client.PronunciationAssessmentClient;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.IeltsEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.SceneSentenceReadingRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.SessionEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.evaluation.TurnEvaluationRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.IeltsPracticeRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.IeltsRepository;
+import com.unispeaking.infrastructure.persistence.repository.scene.SceneRepository;
+import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
+import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
+import com.unispeaking.service.auth.AuthService;
+import com.unispeaking.service.scene.IeltsSceneFlowService;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class SentenceReadingEvaluationTest {
+
+	@Test
+	void usesTheBestRepeatedAttemptForTheReportedPassResult() {
+		String sceneId = "custom_486974af79f64105a425b8eb40974b91";
+		String sentenceId = "sentence_53109a4e3b524a3cbbc753f1be60d0f7";
+		String sentenceText = "Do I need to sign a contract for one year?";
+		String userId = "11111111-1111-4111-8111-111111111111";
+		byte[] audio = canonicalWav();
+		PronunciationAssessmentClient pronunciationClient =
+				mock(PronunciationAssessmentClient.class);
+		SceneSentenceReadingRepository readingRepository =
+				mock(SceneSentenceReadingRepository.class);
+		SceneRepository sceneRepository = mock(SceneRepository.class);
+		AuthService authService = mock(AuthService.class);
+		LearningContentItem sentence = new LearningContentItem(
+				sentenceId,
+				sentenceText,
+				"我需要签一年的合约吗？",
+				"");
+		CustomSceneDefinition scene = new CustomSceneDefinition(
+				sceneId,
+				userId,
+				"比较手机套餐",
+				"通信",
+				"营业厅",
+				"店员",
+				"顾客",
+				"比较套餐",
+				"",
+				"{}",
+				List.of(),
+				List.of(),
+				List.of(sentence));
+		PronunciationAssessmentResult current = assessment("62.40");
+
+		when(readingRepository.findSceneIdBySentenceId(sentenceId))
+				.thenReturn(Optional.of(sceneId));
+		when(authService.requireUserId(null)).thenReturn(userId);
+		when(sceneRepository.findCustomDefinitionById(sceneId))
+				.thenReturn(Optional.of(scene));
+		when(pronunciationClient.evaluate(eq(sentenceText), aryEq(audio)))
+				.thenReturn(current);
+		when(readingRepository.saveAttempt(sceneId, sentence, current))
+				.thenReturn("sentence_reading_1");
+		when(readingRepository.summarizeAttempts(sceneId, sentenceId))
+				.thenReturn(new SceneSentenceReadingRepository.AttemptSummary(
+						11,
+						new BigDecimal("76.40")));
+		EvaluationProcessor processor = processor(
+				pronunciationClient,
+				readingRepository,
+				sceneRepository,
+				authService);
+
+		var response = processor.evaluateSentenceReading(sentenceId, audio);
+
+		assertTrue(response.passed());
+		assertEquals(new BigDecimal("76.40"), response.overallScore());
+		verify(readingRepository).saveAttempt(sceneId, sentence, current);
+	}
+
+	private EvaluationProcessor processor(
+			PronunciationAssessmentClient pronunciationClient,
+			SceneSentenceReadingRepository readingRepository,
+			SceneRepository sceneRepository,
+			AuthService authService) {
+		return new EvaluationProcessor(
+				pronunciationClient,
+				mock(EvaluationLlmClient.class),
+				mock(ActiveSessionRegistry.class),
+				sceneRepository,
+				mock(SessionMessageRepository.class),
+				mock(TurnEvaluationRepository.class),
+				mock(SessionEvaluationRepository.class),
+				readingRepository,
+				mock(IeltsPracticeRepository.class),
+				mock(IeltsRepository.class),
+				mock(IeltsSceneFlowService.class),
+				mock(PracticeSessionRepository.class),
+				mock(IeltsEvaluationRepository.class),
+				mock(IeltsEvaluationLlmClient.class),
+				authService,
+				mock(com.unispeaking.provider.ObjectStorageProvider.class),
+				new ObjectStorageProperties(),
+				mock(com.unispeaking.component.recording.RecordingStore.class));
+	}
+
+	private PronunciationAssessmentResult assessment(String overall) {
+		PronunciationPhonemeResult phoneme =
+				new PronunciationPhonemeResult(
+						0,
+						"eɪ",
+						"eɪ",
+						new BigDecimal("0.30"),
+						20,
+						30);
+		PronunciationWordResult word = new PronunciationWordResult(
+				0,
+				"a",
+				WordReadStatus.NORMAL,
+				new BigDecimal("0.30"),
+				new BigDecimal("0.30"),
+				false,
+				List.of(phoneme));
+		return new PronunciationAssessmentResult(
+				new BigDecimal(overall),
+				new BigDecimal("71.10"),
+				null,
+				new BigDecimal("80.00"),
+				new BigDecimal("83.30"),
+				new BigDecimal("49.90"),
+				EndingTone.FALL,
+				List.of(word));
+	}
+
+	private byte[] canonicalWav() {
+		byte[] wav = new byte[46];
+		writeAscii(wav, 0, "RIFF");
+		writeInt(wav, 4, wav.length - 8);
+		writeAscii(wav, 8, "WAVE");
+		writeAscii(wav, 12, "fmt ");
+		writeInt(wav, 16, 16);
+		writeShort(wav, 20, 1);
+		writeShort(wav, 22, 1);
+		writeInt(wav, 24, 16_000);
+		writeInt(wav, 28, 32_000);
+		writeShort(wav, 32, 2);
+		writeShort(wav, 34, 16);
+		writeAscii(wav, 36, "data");
+		writeInt(wav, 40, 2);
+		return wav;
+	}
+
+	private void writeAscii(byte[] target, int offset, String value) {
+		byte[] bytes = value.getBytes(StandardCharsets.US_ASCII);
+		System.arraycopy(bytes, 0, target, offset, bytes.length);
+	}
+
+	private void writeShort(byte[] target, int offset, int value) {
+		target[offset] = (byte) value;
+		target[offset + 1] = (byte) (value >>> 8);
+	}
+
+	private void writeInt(byte[] target, int offset, int value) {
+		target[offset] = (byte) value;
+		target[offset + 1] = (byte) (value >>> 8);
+		target[offset + 2] = (byte) (value >>> 16);
+		target[offset + 3] = (byte) (value >>> 24);
+	}
+}

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -10,6 +10,7 @@
     "test:analytics": "node --test scripts/check-umami-config.mjs scripts/check-analytics-client.mjs scripts/check-analytics-wiring.mjs",
     "test:telemetry": "node --test scripts/check-telemetry.mjs",
     "test:assets": "node --test scripts/check-learning-asset-deletion.mjs",
+    "test:pronunciation": "node --test scripts/check-pronunciation-score.mjs",
     "check:call-timer": "node scripts/check-call-timer-stop.mjs",
     "check:profile-overview": "node scripts/check-profile-overview-refresh.mjs",
     "check:feedback-invitation": "node scripts/check-feedback-invitation.mjs",

--- a/frontend/web/scripts/check-pronunciation-score.mjs
+++ b/frontend/web/scripts/check-pronunciation-score.mjs
@@ -1,0 +1,22 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { classifyScoredWord } from "../src/domain/pronunciationScore.js";
+
+test("treats a matching weak form with an anomalous zero score as review", () => {
+  assert.equal(classifyScoredWord("a", {
+    wordScore: 0.3,
+    phonemes: [{ expectedPhoneme: "eɪ", actualPhoneme: "eɪ" }],
+  }), "is-review");
+});
+
+test("keeps genuine mismatches red and strong scores green", () => {
+  assert.equal(classifyScoredWord("a", {
+    wordScore: 0.3,
+    phonemes: [{ expectedPhoneme: "eɪ", actualPhoneme: "ʌ" }],
+  }), "is-incorrect");
+  assert.equal(classifyScoredWord("contract", {
+    wordScore: 54.5,
+    phonemes: [{ expectedPhoneme: "k", actualPhoneme: "k" }],
+  }), "is-incorrect");
+  assert.equal(classifyScoredWord("for", { wordScore: 99.1 }), "is-correct");
+});

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -688,6 +688,7 @@ svg { display: block; }
 .sentence-score-text { letter-spacing: 0 !important; }
 .sentence-score-word { padding: 0; color: inherit; background: none; border-bottom: 3px solid transparent; }
 .sentence-score-word.is-correct { color: #248454; border-bottom-color: rgba(36,132,84,.24); }
+.sentence-score-word.is-review { color: #b87920; border-bottom-color: rgba(184,121,32,.28); }
 .sentence-score-word.is-incorrect { color: #d14d43; border-bottom-color: rgba(209,77,67,.25); }
 .sentence-reading-error { max-width: 620px; margin: 10px 0 0 !important; color: #bd4037 !important; font-size: 13px !important; line-height: 1.55; }
 .read-demo { min-height: 38px; display: inline-flex; align-items: center; gap: 7px; margin-top: 15px; color: #777773; font-size: 13px; font-weight: 650; }

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -59,6 +59,7 @@ import {
   ChartLine,
 } from "lucide-react";
 import { learningItems, levels, plans, recommendations, sceneCategories, teachers } from "../domain/content/data.js";
+import { classifyScoredWord } from "../domain/pronunciationScore.js";
 import {
   AUTH_SESSION_EXPIRED_EVENT,
   changePassword,
@@ -2103,14 +2104,17 @@ function ScoredSentence({ sentence, words = [] }) {
     const result = resultIndex >= 0 ? words[resultIndex] : null;
     if (resultIndex >= 0) resultCursor = resultIndex + 1;
     const score = Number(result?.wordScore);
+    const scoreClass = classifyScoredWord(expectedWord, result);
     parts.push(
       <mark
         key={`${offset}-${match[0]}`}
         className={cx(
           "sentence-score-word",
-          Number.isFinite(score) && score >= 80 ? "is-correct" : "is-incorrect",
+          scoreClass,
         )}
-        title={Number.isFinite(score) ? `${score.toFixed(0)} 分` : "未正确识别"}
+        title={scoreClass === "is-review"
+          ? "弱读评分可能存在偏差"
+          : Number.isFinite(score) ? `${score.toFixed(0)} 分` : "未正确识别"}
       >
         {match[0]}
       </mark>,
@@ -2183,7 +2187,7 @@ function ReadScoreModal({ feedback, item, onClose }) {
     <Modal dismissible={false} className="read-score-modal">
       <div className="read-score-modal__score"><strong>{feedback.score}</strong><span>/100</span></div>
       <h2>本句发音评估</h2>
-      <p className="read-score-modal__lead">{feedback.passed ? "本句已达到 80 分，可以进入下一句；红色部分仍可继续练习。" : "本句未达到 80 分，请听示范后再次朗读。"}</p>
+      <p className="read-score-modal__lead">{feedback.passed ? "本句已达到练习要求，可以进入下一句；标记部分仍可继续练习。" : "本句暂未达到练习要求，请听示范后再次朗读。"}</p>
       <div className="read-score-modal__focus"><small>逐词结果</small><p><ScoredSentence sentence={item.en} words={feedback.words} /></p></div>
       <button type="button" className="read-score-modal__confirm" onClick={onClose}>知道了</button>
     </Modal>

--- a/frontend/web/src/domain/pronunciationScore.js
+++ b/frontend/web/src/domain/pronunciationScore.js
@@ -1,0 +1,25 @@
+const weakFormWords = new Set(["a", "an", "the", "to", "of", "for"]);
+
+const normalizePhoneme = (value) => String(value || "")
+  .trim()
+  .toLowerCase();
+
+export function classifyScoredWord(expectedWord, result) {
+  const score = Number(result?.wordScore);
+  if (Number.isFinite(score) && score >= 80) return "is-correct";
+
+  const phonemes = Array.isArray(result?.phonemes) ? result.phonemes : [];
+  const phonemesMatch = phonemes.length > 0 && phonemes.every((phoneme) => (
+    normalizePhoneme(phoneme?.expectedPhoneme)
+      === normalizePhoneme(phoneme?.actualPhoneme)
+  ));
+  if (
+    weakFormWords.has(String(expectedWord || "").toLowerCase())
+    && Number.isFinite(score)
+    && score < 10
+    && phonemesMatch
+  ) {
+    return "is-review";
+  }
+  return "is-incorrect";
+}


### PR DESCRIPTION
## Summary
- add a shared pass policy that tolerates isolated pronunciation scoring outliers
- keep backend progression and frontend pass feedback consistent
- add regression coverage for scoring edge cases

## Verification
- focused backend test suite passed
- frontend pronunciation checks passed
- frontend production build passed