### PR TITLE
fix: confirm before signing out

### DIFF
--- a/frontend/mobile/src/screens/ProfileScreen.tsx
+++ b/frontend/mobile/src/screens/ProfileScreen.tsx
@@ -76,6 +76,14 @@ function errorMessage(error: unknown, fallback: string) {
   return error instanceof Error ? error.message : fallback;
 }
 
+export function requestLogoutConfirmation(onLogout?: () => void | Promise<void>) {
+  if (!onLogout) return;
+  Alert.alert('退出登录', '确定要退出当前账号吗？退出后需要重新登录才能继续练习。', [
+    { text: '取消', style: 'cancel' },
+    { text: '退出登录', style: 'destructive', onPress: () => void onLogout() },
+  ]);
+}
+
 function useProfileApi() {
   const { signOut } = useAppModel();
   return useMemo(() => {
@@ -1138,7 +1146,7 @@ export function AssistantSettings({ onBack }: { onBack: () => void }) {
   );
 }
 
-export function AccountSettings({ onBack, onLogout }: { onBack: () => void; onLogout?: () => void }) {
+export function AccountSettings({ onBack, onLogout }: { onBack: () => void; onLogout?: () => void | Promise<void> }) {
   const api = useProfileApi();
   const { nickname, setNickname, email } = useAppModel();
   const [draft, setDraft] = useState(nickname);
@@ -1217,7 +1225,7 @@ export function AccountSettings({ onBack, onLogout }: { onBack: () => void; onLo
           icon="logout"
           danger
           meta="退出登录"
-          onPress={onLogout}
+          onPress={() => requestLogoutConfirmation(onLogout)}
         />
       </Card>
       {nicknameOpen ? (
@@ -1677,7 +1685,7 @@ export function ProfileHome({
 }: {
   activeRoute?: ProfileRoute;
   onOpen: (route: ProfileRoute) => void;
-  onLogout?: () => void;
+  onLogout?: () => void | Promise<void>;
 }) {
   const api = useProfileApi();
   const { nickname, setNickname, email, teacher } = useAppModel();
@@ -1797,7 +1805,7 @@ export function ProfileHome({
           onPress={() => onOpen('about')}
         />
       </View>
-      <Pressable accessibilityRole="button" onPress={onLogout} style={styles.logout}>
+      <Pressable accessibilityRole="button" onPress={() => requestLogoutConfirmation(onLogout)} style={styles.logout}>
         <AppIcon name="logout" size={19} color={colors.red} />
         <Text style={styles.logoutText}>退出登录</Text>
       </Pressable>

--- a/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
@@ -1,6 +1,7 @@
+import { Alert } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
-import { CalendarCard } from '../ProfileScreen';
+import { CalendarCard, requestLogoutConfirmation } from '../ProfileScreen';
 
 const calendarFor = (month: string) => ({
   month,
@@ -37,5 +38,32 @@ describe('CalendarCard', () => {
     await fireEvent.press(view.getByLabelText('7月31日，未打卡'));
 
     expect(view.getByText(/7\s*月\s*31\s*日/)).toBeTruthy();
+  });
+});
+
+describe('requestLogoutConfirmation', () => {
+  it('only logs out after destructive confirmation', () => {
+    const logout = jest.fn(async () => undefined);
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    requestLogoutConfirmation(logout);
+
+    expect(logout).not.toHaveBeenCalled();
+    const actions = alert.mock.calls[0]?.[2];
+    actions?.find((action) => action.text === '退出登录')?.onPress?.();
+    expect(logout).toHaveBeenCalledTimes(1);
+    alert.mockRestore();
+  });
+
+  it('keeps the session when the user cancels', () => {
+    const logout = jest.fn(async () => undefined);
+    const alert = jest.spyOn(Alert, 'alert').mockImplementation(() => undefined);
+
+    requestLogoutConfirmation(logout);
+
+    const actions = alert.mock.calls[0]?.[2];
+    actions?.find((action) => action.text === '取消')?.onPress?.();
+    expect(logout).not.toHaveBeenCalled();
+    alert.mockRestore();
   });
 });

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -109,6 +109,8 @@ svg { display: block; }
 .button--primary:hover:not(:disabled) { background: #30302f; }
 .button--secondary { background: #fff; color: var(--ink); border-color: #dcdcd7; }
 .button--secondary:hover:not(:disabled) { background: var(--soft); }
+.button--danger { background: #b63a32; color: #fff; }
+.button--danger:hover:not(:disabled) { background: #982f29; }
 .text-button, .back-link, .forgot-link { border: 0; background: none; cursor: pointer; font-weight: 600; }
 .eyebrow { color: #90908b; font-size: 11px; font-weight: 750; letter-spacing: .16em; text-transform: uppercase; }
 

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -942,6 +942,11 @@ function TrainingExitConfirmation({ open, onContinue, onConfirm }) {
   return <Modal dismissible={false}><p className="eyebrow">EXIT TRAINING</p><h2>确定要退出当前训练吗？</h2><p className="modal-lead">退出后将返回上一页。</p><div className="modal-actions"><Button variant="secondary" onClick={onContinue}>继续训练</Button><Button onClick={onConfirm}>确认退出</Button></div></Modal>;
 }
 
+function LogoutConfirmation({ open, submitting, onCancel, onConfirm }) {
+  if (!open) return null;
+  return <Modal dismissible={!submitting} onClose={onCancel}><p className="eyebrow">SIGN OUT</p><h2>确定要退出登录吗？</h2><p className="modal-lead">退出后需要重新登录才能继续练习。</p><div className="modal-actions"><Button variant="secondary" disabled={submitting} onClick={onCancel}>取消</Button><Button variant="danger" disabled={submitting} onClick={onConfirm}>{submitting ? "正在退出" : "退出登录"}</Button></div></Modal>;
+}
+
 function AppShell({ page, setPage, teacher, avatarUrl, navigationGuardActive = false, children }) {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [pendingPage, setPendingPage] = useState(null);
@@ -2770,6 +2775,18 @@ function Profile({ section, setSection, helpRoute, aboutRoute, onHelpNavigate, o
   const avatarUrl = account?.avatarUrl || teacher.image;
   const [profileEditOpen, setProfileEditOpen] = useState(false);
   const [passwordOpen, setPasswordOpen] = useState(false);
+  const [logoutOpen, setLogoutOpen] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
+  const confirmLogout = async () => {
+    if (loggingOut) return;
+    setLoggingOut(true);
+    try {
+      await onLogout();
+    } finally {
+      setLoggingOut(false);
+      setLogoutOpen(false);
+    }
+  };
   const startRecommendedTraining = (trainingType) => {
     const destination = trainingType === "FREE_CHAT"
       ? "conversation"
@@ -2795,14 +2812,14 @@ function Profile({ section, setSection, helpRoute, aboutRoute, onHelpNavigate, o
           <button className={section === "help" ? "is-active" : ""} onClick={() => setSection("help")}><Lifebuoy />帮助中心</button>
           <button className={section === "about" ? "is-active" : ""} onClick={() => setSection("about")}><Info />关于产品</button>
         </nav>
-        <button className="logout" onClick={onLogout}><SignOut />退出登录</button>
+        <button className="logout" onClick={() => setLogoutOpen(true)}><SignOut />退出登录</button>
       </aside>
       <section className={cx("profile-content", section === "help" && "profile-content--help")}>
         {section === "profile" && <Overview calendar={profile?.calendar} statistics={profile?.statistics} onMonthChange={onMonthChange} onAssets={onAssets} />}
         {section === "insights" && <LearningInsights onStartTraining={startRecommendedTraining} />}
         {section === "membership" && <Membership />}
         {section === "settings" && <Settings teacher={teacher} speed={speed} level={level} onSettingsChange={onSettingsChange} />}
-        {section === "security" && <AccountSecurity email={email} onOpenPassword={() => setPasswordOpen(true)} onLogout={onLogout} />}
+        {section === "security" && <AccountSecurity email={email} onOpenPassword={() => setPasswordOpen(true)} onLogout={() => setLogoutOpen(true)} />}
         {section === "help" && <HelpCenter route={helpRoute} onNavigate={onHelpNavigate} />}
         {section === "about" && (aboutRoute?.screen === "document"
           ? <ProductLegalDocument documentId={aboutRoute.documentId} onNavigate={onAboutNavigate} />
@@ -2810,6 +2827,7 @@ function Profile({ section, setSection, helpRoute, aboutRoute, onHelpNavigate, o
       </section>
       {profileEditOpen && <ProfileEditModal account={account} user={user} avatarUrl={avatarUrl} onClose={() => setProfileEditOpen(false)} onNicknameChange={onNicknameChange} onAvatarChange={onAvatarChange} />}
       {passwordOpen && <PasswordChangeModal onClose={() => setPasswordOpen(false)} onSubmit={onPasswordChange} />}
+      <LogoutConfirmation open={logoutOpen} submitting={loggingOut} onCancel={() => setLogoutOpen(false)} onConfirm={() => void confirmLogout()} />
     </main>
   );
 }


### PR DESCRIPTION
## Summary
- require confirmation before signing out from the Web profile and account security pages
- use a native destructive confirmation on mobile profile logout actions
- prevent duplicate Web logout requests while sign-out is in progress
- keep password-change forced sign-out behavior unchanged

## Verification
- Web production build passed
- mobile TypeScript check passed
- mobile logout confirmation tests passed
- mobile lint completed with no errors