### PR TITLE
fix：修复每日额度耗尽后会话仍可继续对话

### DIFF
--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/policy/UserEntitlementPolicy.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/policy/UserEntitlementPolicy.java
@@ -4,13 +4,15 @@ import com.unispeaking.common.exception.BusinessException;
 import java.util.UUID;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.LocalDate;
 import org.springframework.dao.EmptyResultDataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 /** Enforces the administrator-managed account status and daily time quota. */
 @Component
-public final class UserEntitlementPolicy {
+public class UserEntitlementPolicy {
     private final JdbcTemplate jdbc;
 
     public UserEntitlementPolicy(JdbcTemplate jdbc) {
@@ -28,21 +30,81 @@ public final class UserEntitlementPolicy {
         rolloverEntitlement(userId);
         try {
             Entitlement entitlement = jdbc.queryForObject(
-                    "select status, quota_seconds, used_seconds from user_entitlements "
+                    "select status, quota_date, quota_seconds, used_seconds from user_entitlements "
                             + "where user_id = ?",
                     (rs, row) -> new Entitlement(
-                            rs.getString("status"), rs.getDouble("quota_seconds"), rs.getDouble("used_seconds")),
+                            rs.getString("status"),
+                            rs.getObject("quota_date", LocalDate.class),
+                            rs.getDouble("quota_seconds"),
+                            rs.getDouble("used_seconds")),
                     userId);
             if (entitlement == null) return;
-            if ("suspended".equalsIgnoreCase(entitlement.status())) {
-                throw new BusinessException("USER_ENTITLEMENT_SUSPENDED", "当前账号已暂停练习权限");
-            }
-            if (entitlement.usedSeconds() >= entitlement.quotaSeconds()) {
-                throw new BusinessException("USER_QUOTA_EXHAUSTED", "今日练习额度已用完");
-            }
+            assertUsable(entitlement);
         } catch (EmptyResultDataAccessException ignored) {
             // Legacy accounts without a governance row retain the product default.
         }
+    }
+
+    @Transactional
+    public QuotaReservation reserveRemaining(String rawUserId, Instant startedAt) {
+        if (jdbc == null || startedAt == null) return null;
+        UUID userId = requireUserId(rawUserId);
+        rolloverEntitlement(userId);
+        try {
+            Entitlement entitlement = jdbc.queryForObject(
+                    "select status, quota_date, quota_seconds, used_seconds from user_entitlements "
+                            + "where user_id = ? for update",
+                    (rs, row) -> new Entitlement(
+                            rs.getString("status"),
+                            rs.getObject("quota_date", LocalDate.class),
+                            rs.getDouble("quota_seconds"),
+                            rs.getDouble("used_seconds")),
+                    userId);
+            if (entitlement == null) return null;
+            assertUsable(entitlement);
+            double remainingSeconds = Math.max(
+                    0,
+                    entitlement.quotaSeconds() - entitlement.usedSeconds());
+            if (remainingSeconds <= 0) {
+                throw quotaExhausted();
+            }
+            jdbc.update(
+                    "update user_entitlements set used_seconds = quota_seconds, "
+                            + "updated_at = current_timestamp where user_id = ?",
+                    userId);
+            long reservedMillis = Math.max(
+                    1,
+                    (long) Math.floor(remainingSeconds * 1000d));
+            return new QuotaReservation(
+                    entitlement.quotaDate(),
+                    reservedMillis / 1000d,
+                    startedAt,
+                    startedAt.plusMillis(reservedMillis));
+        } catch (EmptyResultDataAccessException ignored) {
+            // Legacy accounts without a governance row retain the product default.
+            return null;
+        }
+    }
+
+    public void settleReservation(
+            String rawUserId,
+            LocalDate quotaDate,
+            double reservedSeconds,
+            Instant startedAt,
+            Instant endedAt) {
+        if (jdbc == null || quotaDate == null || reservedSeconds <= 0
+                || startedAt == null || endedAt == null) return;
+        UUID userId = requireUserId(rawUserId);
+        double usedSeconds = Math.min(
+                reservedSeconds,
+                Math.max(0, Duration.between(startedAt, endedAt).toMillis() / 1000d));
+        double refundSeconds = Math.max(0, reservedSeconds - usedSeconds);
+        if (refundSeconds <= 0) return;
+        jdbc.update(
+                "update user_entitlements set used_seconds = "
+                        + "case when used_seconds >= ? then used_seconds - ? else 0 end, "
+                        + "updated_at = current_timestamp where user_id = ? and quota_date = ?",
+                refundSeconds, refundSeconds, userId, quotaDate);
     }
 
     private void rolloverEntitlement(UUID userId) {
@@ -54,19 +116,48 @@ public final class UserEntitlementPolicy {
 
     public void recordUsage(String rawUserId, Instant startedAt, Instant endedAt) {
         if (jdbc == null || startedAt == null || endedAt == null || endedAt.isBefore(startedAt)) return;
-        UUID userId;
-        try {
-            userId = UUID.fromString(rawUserId);
-        } catch (IllegalArgumentException exception) {
-            throw new BusinessException("INVALID_USER_ID", "用户标识必须是 UUID");
-        }
+        UUID userId = requireUserId(rawUserId);
         double seconds = Math.max(0, Duration.between(startedAt, endedAt).toMillis() / 1000d);
         jdbc.update("update user_entitlements set "
-                        + "used_seconds = case when quota_date = current_date then used_seconds + ? else ? end, "
+                        + "used_seconds = case when quota_date = current_date "
+                        + "then least(quota_seconds, used_seconds + ?) "
+                        + "else least(quota_seconds, ?) end, "
                         + "quota_date = current_date, updated_at = current_timestamp where user_id = ?",
                 seconds, seconds, userId);
     }
 
-    private record Entitlement(String status, double quotaSeconds, double usedSeconds) {
+    private UUID requireUserId(String rawUserId) {
+        try {
+            return UUID.fromString(rawUserId);
+        } catch (IllegalArgumentException | NullPointerException exception) {
+            throw new BusinessException("INVALID_USER_ID", "用户标识必须是 UUID");
+        }
+    }
+
+    private void assertUsable(Entitlement entitlement) {
+        if ("suspended".equalsIgnoreCase(entitlement.status())) {
+            throw new BusinessException("USER_ENTITLEMENT_SUSPENDED", "当前账号已暂停练习权限");
+        }
+        if (entitlement.usedSeconds() >= entitlement.quotaSeconds()) {
+            throw quotaExhausted();
+        }
+    }
+
+    private BusinessException quotaExhausted() {
+        return new BusinessException("USER_QUOTA_EXHAUSTED", "今日练习额度已用完");
+    }
+
+    private record Entitlement(
+            String status,
+            LocalDate quotaDate,
+            double quotaSeconds,
+            double usedSeconds) {
+    }
+
+    public record QuotaReservation(
+            LocalDate quotaDate,
+            double reservedSeconds,
+            Instant startedAt,
+            Instant deadline) {
     }
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/SessionLifecycleManager.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/SessionLifecycleManager.java
@@ -20,12 +20,18 @@ import com.unispeaking.domain.vo.session.SpeakerType;
 import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
 import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
 import com.unispeaking.component.policy.UserEntitlementPolicy;
+import com.unispeaking.component.policy.UserEntitlementPolicy.QuotaReservation;
 import com.unispeaking.infrastructure.realtime.RealtimeSessionTerminator;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledFuture;
 import org.springframework.stereotype.Component;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.TaskScheduler;
 
 @Component
 public class SessionLifecycleManager {
@@ -35,6 +41,9 @@ public class SessionLifecycleManager {
 	private final PracticeSessionRepository practiceSessionRepository;
 	private final UserEntitlementPolicy entitlementPolicy;
 	private final RealtimeSessionTerminator realtimeSessionTerminator;
+	private final TaskScheduler taskScheduler;
+	private final Map<String, ScheduledFuture<?>> quotaDeadlineTasks =
+			new ConcurrentHashMap<>();
 
 	public SessionLifecycleManager(
 			ActiveSessionRegistry activeSessionRegistry,
@@ -49,7 +58,17 @@ public class SessionLifecycleManager {
 			PracticeSessionRepository practiceSessionRepository,
 			UserEntitlementPolicy entitlementPolicy) {
 		this(activeSessionRegistry, sessionMessageRepository, practiceSessionRepository,
-				entitlementPolicy, null);
+				entitlementPolicy, null, null);
+	}
+
+	public SessionLifecycleManager(
+			ActiveSessionRegistry activeSessionRegistry,
+			SessionMessageRepository sessionMessageRepository,
+			PracticeSessionRepository practiceSessionRepository,
+			UserEntitlementPolicy entitlementPolicy,
+			RealtimeSessionTerminator realtimeSessionTerminator) {
+		this(activeSessionRegistry, sessionMessageRepository, practiceSessionRepository,
+				entitlementPolicy, realtimeSessionTerminator, null);
 	}
 
 	@Autowired
@@ -58,12 +77,14 @@ public class SessionLifecycleManager {
 			SessionMessageRepository sessionMessageRepository,
 			PracticeSessionRepository practiceSessionRepository,
 			UserEntitlementPolicy entitlementPolicy,
-			RealtimeSessionTerminator realtimeSessionTerminator) {
+			RealtimeSessionTerminator realtimeSessionTerminator,
+			TaskScheduler taskScheduler) {
 		this.activeSessionRegistry = activeSessionRegistry;
 		this.sessionMessageRepository = sessionMessageRepository;
 		this.practiceSessionRepository = practiceSessionRepository;
 		this.entitlementPolicy = entitlementPolicy;
 		this.realtimeSessionTerminator = realtimeSessionTerminator;
+		this.taskScheduler = taskScheduler;
 	}
 
 	public StartSessionResponse startSession(StartSessionCommand command) {
@@ -141,6 +162,52 @@ public class SessionLifecycleManager {
 		activeSessionRegistry.save(session);
 	}
 
+	public SessionActivation activateSession(String userId, String sessionId) {
+		AbstractSceneSession session = requireOwnedSession(userId, sessionId);
+		synchronized (session) {
+			if (session.getStatus() == SessionStatus.COMPLETED
+					|| session.getStatus() == SessionStatus.FAILED) {
+				throw new BusinessException(
+						"SESSION_ALREADY_TERMINATED",
+						"会话已结束");
+			}
+			if (session.isQuotaActivated()) {
+				return activationResponse(session.getQuotaDeadline());
+			}
+			Instant activatedAt = Instant.now();
+			try {
+				QuotaReservation reservation = entitlementPolicy == null
+						? null
+						: entitlementPolicy.reserveRemaining(userId, activatedAt);
+				if (reservation == null) {
+					session.activate();
+				}
+				else {
+					session.activateQuota(
+							reservation.quotaDate(),
+							reservation.reservedSeconds(),
+							activatedAt,
+							reservation.deadline());
+				}
+				activeSessionRegistry.save(session);
+				if (reservation != null && taskScheduler != null) {
+					ScheduledFuture<?> task = taskScheduler.schedule(
+							() -> expireQuota(userId, sessionId),
+							reservation.deadline());
+					if (task != null) {
+						ScheduledFuture<?> previous = quotaDeadlineTasks.put(sessionId, task);
+						if (previous != null) previous.cancel(false);
+					}
+				}
+				return activationResponse(session.getQuotaDeadline());
+			}
+			catch (RuntimeException exception) {
+				terminateAfterActivationFailure(userId, sessionId);
+				throw exception;
+			}
+		}
+	}
+
 	/**
 	 * Shared lifecycle hook used by concrete scene implementations without
 	 * expanding the scene session service interfaces.
@@ -178,6 +245,18 @@ public class SessionLifecycleManager {
 			String sessionId,
 			SessionStatus terminalStatus,
 			Instant endedAt) {
+		terminateSceneSession(userId, sessionId, terminalStatus, endedAt,
+				terminalStatus == SessionStatus.COMPLETED
+						? "client_completed"
+						: "session_failed");
+	}
+
+	private void terminateSceneSession(
+			String userId,
+			String sessionId,
+			SessionStatus terminalStatus,
+			Instant endedAt,
+			String stopReason) {
 		UUID ownerId = requireUserUuid(userId);
 		if (endedAt == null) {
 			throw new BusinessException(
@@ -192,7 +271,10 @@ public class SessionLifecycleManager {
 		}
 		AbstractSceneSession session = requireOwnedSession(userId, sessionId);
 		synchronized (session) {
-			if (session.getStatus() == terminalStatus) return;
+			if (session.getStatus() == terminalStatus) {
+				cancelQuotaDeadline(sessionId);
+				return;
+			}
 			if (session.getStatus() == SessionStatus.COMPLETED
 					|| session.getStatus() == SessionStatus.FAILED) {
 				throw new BusinessException(
@@ -201,24 +283,90 @@ public class SessionLifecycleManager {
 			}
 			if (terminalStatus == SessionStatus.COMPLETED) {
 				practiceSessionRepository.complete(sessionId, ownerId, endedAt);
-				if (entitlementPolicy != null) {
-					entitlementPolicy.recordUsage(userId, session.getCreatedAt(), endedAt);
-				}
+				settleQuota(session, endedAt, true);
 				session.complete(endedAt);
 			}
 			else {
 				practiceSessionRepository.fail(sessionId, ownerId, endedAt);
+				settleQuota(session, endedAt, false);
 				session.fail(endedAt);
 			}
 			activeSessionRegistry.save(session);
+			cancelQuotaDeadline(sessionId);
 		}
 		if (realtimeSessionTerminator != null) {
 			realtimeSessionTerminator.stopBestEffort(
 					session,
-					terminalStatus == SessionStatus.COMPLETED
-							? "client_completed"
-							: "session_failed");
+					stopReason);
 		}
+	}
+
+	private void settleQuota(
+			AbstractSceneSession session,
+			Instant endedAt,
+			boolean recordUnactivatedCompletion) {
+		if (entitlementPolicy == null) return;
+		if (session.hasQuotaReservation()) {
+			entitlementPolicy.settleReservation(
+					session.getUserId(),
+					session.getQuotaDate(),
+					session.getQuotaReservedSeconds(),
+					session.getQuotaStartedAt(),
+					endedAt);
+		}
+		else if (recordUnactivatedCompletion && !session.isQuotaActivated()) {
+			entitlementPolicy.recordUsage(
+					session.getUserId(),
+					session.getCreatedAt(),
+					endedAt);
+		}
+	}
+
+	private void expireQuota(String userId, String sessionId) {
+		quotaDeadlineTasks.remove(sessionId);
+		try {
+			terminateSceneSession(
+					userId,
+					sessionId,
+					SessionStatus.COMPLETED,
+					Instant.now(),
+					"quota_exhausted");
+		}
+		catch (RuntimeException exception) {
+			RealtimeFlowLog.warn(
+					"session.quota.expire.failed sessionId={} error={}",
+					sessionId,
+					exception.getMessage());
+		}
+	}
+
+	private void terminateAfterActivationFailure(String userId, String sessionId) {
+		try {
+			terminateSceneSession(
+					userId,
+					sessionId,
+					SessionStatus.FAILED,
+					Instant.now(),
+					"quota_activation_failed");
+		}
+		catch (RuntimeException cleanupFailure) {
+			RealtimeFlowLog.warn(
+					"session.quota.activation.cleanup.failed sessionId={} error={}",
+					sessionId,
+					cleanupFailure.getMessage());
+		}
+	}
+
+	private void cancelQuotaDeadline(String sessionId) {
+		ScheduledFuture<?> task = quotaDeadlineTasks.remove(sessionId);
+		if (task != null) task.cancel(false);
+	}
+
+	private SessionActivation activationResponse(Instant quotaDeadline) {
+		if (quotaDeadline == null) return new SessionActivation(null, null);
+		return new SessionActivation(
+				quotaDeadline,
+				Math.max(0, Duration.between(Instant.now(), quotaDeadline).toMillis()));
 	}
 
 	public void endSession(String sessionId) {
@@ -425,5 +573,8 @@ public class SessionLifecycleManager {
 					"session prompt must not be blank");
 		}
 		return prompt;
+	}
+
+	public record SessionActivation(Instant quotaDeadline, Long quotaRemainingMillis) {
 	}
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/SessionMessageDispatcher.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/component/session/SessionMessageDispatcher.java
@@ -64,6 +64,12 @@ public class SessionMessageDispatcher {
 		lifecycle.bindProviderSession(userId, sessionId, providerSessionId);
 	}
 
+	public SessionLifecycleManager.SessionActivation activateSession(
+			String userId,
+			String sessionId) {
+		return lifecycle.activateSession(userId, sessionId);
+	}
+
 	private SceneType sceneType(String userId, String sessionId) {
 		return lifecycle.requireSceneType(userId, sessionId);
 	}

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/AbstractSceneSession.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/domain/po/session/AbstractSceneSession.java
@@ -7,6 +7,7 @@ import com.unispeaking.domain.vo.scene.IeltsPart;
 import com.unispeaking.domain.vo.scene.SceneType;
 import com.unispeaking.domain.vo.session.SessionStatus;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
@@ -28,6 +29,11 @@ public abstract class AbstractSceneSession {
 	private String model;
 	private String voiceId;
 	private Instant credentialExpiresAt;
+	private boolean quotaActivated;
+	private LocalDate quotaDate;
+	private double quotaReservedSeconds;
+	private Instant quotaStartedAt;
+	private Instant quotaDeadline;
 	private String errorCode;
 	private String errorMessage;
 
@@ -50,6 +56,19 @@ public abstract class AbstractSceneSession {
 
 	public void activate() {
 		status = SessionStatus.ACTIVE;
+	}
+
+	public void activateQuota(
+			LocalDate quotaDate,
+			double reservedSeconds,
+			Instant startedAt,
+			Instant deadline) {
+		quotaActivated = true;
+		this.quotaDate = quotaDate;
+		this.quotaReservedSeconds = reservedSeconds;
+		this.quotaStartedAt = startedAt;
+		this.quotaDeadline = deadline;
+		activate();
 	}
 
 	public void pause() {
@@ -121,6 +140,15 @@ public abstract class AbstractSceneSession {
 	public void setCredentialExpiresAt(Instant credentialExpiresAt) {
 		this.credentialExpiresAt = credentialExpiresAt;
 	}
+	public boolean isQuotaActivated() { return quotaActivated; }
+	public boolean hasQuotaReservation() {
+		return quotaDate != null && quotaReservedSeconds > 0
+				&& quotaStartedAt != null && quotaDeadline != null;
+	}
+	public LocalDate getQuotaDate() { return quotaDate; }
+	public double getQuotaReservedSeconds() { return quotaReservedSeconds; }
+	public Instant getQuotaStartedAt() { return quotaStartedAt; }
+	public Instant getQuotaDeadline() { return quotaDeadline; }
 	public String getErrorCode() { return errorCode; }
 	public String getErrorMessage() { return errorMessage; }
 }

--- a/backend/unispeaking-server/src/main/java/com/unispeaking/websocket/SessionMessageWebSocketHandler.java
+++ b/backend/unispeaking-server/src/main/java/com/unispeaking/websocket/SessionMessageWebSocketHandler.java
@@ -1,5 +1,6 @@
 package com.unispeaking.websocket;
 
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.common.logging.RealtimeFlowLog;
 import com.unispeaking.component.session.SessionMessageDispatcher;
 import com.unispeaking.domain.dto.session.SessionSocketAck;
@@ -34,7 +35,9 @@ public class SessionMessageWebSocketHandler extends TextWebSocketHandler {
 			send(webSocketSession, SessionSocketAck.failure(
 					ackType(frame.type(), "failed"),
 					frame.sessionId(),
-					"SESSION_SOCKET_ERROR",
+					exception instanceof BusinessException businessException
+							? businessException.code()
+							: "SESSION_SOCKET_ERROR",
 					exception.getMessage()));
 		}
 	}
@@ -43,6 +46,12 @@ public class SessionMessageWebSocketHandler extends TextWebSocketHandler {
 		String sessionId = requireSessionId(frame.sessionId());
 		String userId = requireAuthenticatedUserId(webSocketSession);
 		switch (normalize(frame.type())) {
+			case "activate" -> send(
+					webSocketSession,
+					SessionSocketAck.success(
+							"session.activate.accepted",
+							sessionId,
+							sessionDispatcher.activateSession(userId, sessionId)));
 			case "message" -> {
 				sessionDispatcher.addMessage(userId, sessionId, frame.message());
 				RealtimeFlowLog.info("session.websocket.message sessionId={} owner={} content={} audioBytes={}",
@@ -81,6 +90,7 @@ public class SessionMessageWebSocketHandler extends TextWebSocketHandler {
 			return "message";
 		}
 		return switch (type.trim()) {
+			case "activate", "session.activate" -> "activate";
 			case "message", "session.message", "addMessage" -> "message";
 			case "end", "session.end", "endSession" -> "end";
 			case "bind", "session.bind", "bindProviderSession" -> "bind";

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/policy/UserEntitlementPolicyTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/policy/UserEntitlementPolicyTest.java
@@ -46,6 +46,38 @@ class UserEntitlementPolicyTest {
     }
 
     @Test
+    void reservesTheRemainingQuotaAndRefundsUnusedSeconds() {
+        JdbcDataSource dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:user-entitlement-reservation;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");
+        JdbcTemplate jdbc = new JdbcTemplate(dataSource);
+        jdbc.execute("create table user_entitlements (user_id uuid, quota_date date, quota_seconds numeric(12,3), used_seconds numeric(12,3), status varchar(32), updated_at timestamp with time zone)");
+        UUID userId = UUID.randomUUID();
+        jdbc.update("insert into user_entitlements values (?, current_date, 600, 590, 'active', current_timestamp)", userId);
+        var policy = new UserEntitlementPolicy(jdbc);
+        Instant startedAt = Instant.parse("2026-08-24T05:00:00Z");
+
+        var reservation = policy.reserveRemaining(userId.toString(), startedAt);
+
+        assertEquals(10d, reservation.reservedSeconds());
+        assertEquals(startedAt.plusSeconds(10), reservation.deadline());
+        assertEquals(600d, jdbc.queryForObject(
+                "select used_seconds from user_entitlements where user_id = ?", Double.class, userId));
+        assertEquals("USER_QUOTA_EXHAUSTED", assertThrows(
+                BusinessException.class,
+                () -> policy.reserveRemaining(userId.toString(), startedAt)).code());
+
+        policy.settleReservation(
+                userId.toString(),
+                reservation.quotaDate(),
+                reservation.reservedSeconds(),
+                reservation.startedAt(),
+                startedAt.plusSeconds(4));
+
+        assertEquals(594d, jdbc.queryForObject(
+                "select used_seconds from user_entitlements where user_id = ?", Double.class, userId));
+    }
+
+    @Test
     void preservesSuspendedStatusWhenTheLedgerRollsIntoANewDay() {
         JdbcDataSource dataSource = new JdbcDataSource();
         dataSource.setURL("jdbc:h2:mem:user-entitlement-rollover;MODE=PostgreSQL;DB_CLOSE_DELAY=-1");

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/SessionLifecycleManagerCoverageTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/component/session/SessionLifecycleManagerCoverageTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -15,6 +16,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.component.policy.UserEntitlementPolicy;
+import com.unispeaking.component.policy.UserEntitlementPolicy.QuotaReservation;
 import com.unispeaking.domain.dto.session.Message;
 import com.unispeaking.domain.dto.session.SessionDetail;
 import com.unispeaking.domain.dto.session.StartSessionCommand;
@@ -28,10 +30,13 @@ import com.unispeaking.domain.vo.session.SessionStatus;
 import com.unispeaking.infrastructure.persistence.repository.session.PracticeSessionRepository;
 import com.unispeaking.infrastructure.persistence.repository.session.SessionMessageRepository;
 import java.time.Instant;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.ScheduledFuture;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.springframework.scheduling.TaskScheduler;
 
 class SessionLifecycleManagerCoverageTest {
 
@@ -109,6 +114,44 @@ class SessionLifecycleManagerCoverageTest {
 		verify(entitlement, never()).recordUsage(
 				eq(ownerId.toString()), eq(failed.getCreatedAt()), eq(failedAt));
 		assertEquals(SessionStatus.FAILED, failed.getStatus());
+	}
+
+	@Test
+	void activatesQuotaAtWebrtcConnectionAndStopsAtTheServerDeadline() {
+		CustomSceneSession session = customSession("session-quota");
+		sessions.save(session);
+		TaskScheduler scheduler = mock(TaskScheduler.class);
+		ScheduledFuture<?> future = mock(ScheduledFuture.class);
+		Instant deadline = Instant.now().plusSeconds(10);
+		when(entitlement.reserveRemaining(eq(ownerId.toString()), any(Instant.class)))
+				.thenAnswer(invocation -> new QuotaReservation(
+						LocalDate.now(),
+						10,
+						invocation.getArgument(1),
+						deadline));
+		doReturn(future).when(scheduler).schedule(any(Runnable.class), (Instant) eq(deadline));
+		var terminator = mock(com.unispeaking.infrastructure.realtime.RealtimeSessionTerminator.class);
+		SessionLifecycleManager managedLifecycle = new SessionLifecycleManager(
+				sessions, messages, practices, entitlement, terminator, scheduler);
+
+		var activation = managedLifecycle.activateSession(ownerId.toString(), session.getId());
+
+		assertEquals(deadline, activation.quotaDeadline());
+		assertTrue(activation.quotaRemainingMillis() > 0);
+		assertEquals(SessionStatus.ACTIVE, session.getStatus());
+		ArgumentCaptor<Runnable> deadlineTask = ArgumentCaptor.forClass(Runnable.class);
+		verify(scheduler).schedule(deadlineTask.capture(), (Instant) eq(deadline));
+
+		deadlineTask.getValue().run();
+
+		verify(practices).complete(eq(session.getId()), eq(ownerId), any(Instant.class));
+		verify(entitlement).settleReservation(
+				eq(ownerId.toString()),
+				eq(session.getQuotaDate()),
+				eq(10d),
+				eq(session.getQuotaStartedAt()),
+				any(Instant.class));
+		verify(terminator).stopBestEffort(session, "quota_exhausted");
 	}
 
 	@Test

--- a/backend/unispeaking-server/src/test/java/com/unispeaking/websocket/SessionMessageWebSocketHandlerTest.java
+++ b/backend/unispeaking-server/src/test/java/com/unispeaking/websocket/SessionMessageWebSocketHandlerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.unispeaking.common.exception.BusinessException;
 import com.unispeaking.component.session.SessionMessageDispatcher;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
@@ -49,6 +50,35 @@ class SessionMessageWebSocketHandlerTest {
 		var ack = org.mockito.ArgumentCaptor.forClass(TextMessage.class);
 		verify(socket).sendMessage(ack.capture());
 		assertTrue(ack.getValue().getPayload().contains("session.bind.accepted"));
+	}
+
+	@Test
+	void activatesQuotaForTheAuthenticatedSession() throws Exception {
+		SessionMessageDispatcher dispatcher = mock(SessionMessageDispatcher.class);
+		SessionMessageWebSocketHandler handler = new SessionMessageWebSocketHandler(
+				new ObjectMapper(), dispatcher);
+		WebSocketSession socket = authenticatedSocket("user-1");
+
+		handler.handleMessage(socket, new TextMessage(
+				"{\"type\":\"activate\",\"sessionId\":\"session-1\"}"));
+
+		verify(dispatcher).activateSession("user-1", "session-1");
+		assertTrue(ack(socket).contains("session.activate.accepted"));
+	}
+
+	@Test
+	void preservesTheQuotaErrorCodeWhenActivationIsRejected() throws Exception {
+		SessionMessageDispatcher dispatcher = mock(SessionMessageDispatcher.class);
+		when(dispatcher.activateSession("user-1", "session-1"))
+				.thenThrow(new BusinessException("USER_QUOTA_EXHAUSTED", "今日练习额度已用完"));
+		SessionMessageWebSocketHandler handler = new SessionMessageWebSocketHandler(
+				new ObjectMapper(), dispatcher);
+		WebSocketSession socket = authenticatedSocket("user-1");
+
+		handler.handleMessage(socket, new TextMessage(
+				"{\"type\":\"activate\",\"sessionId\":\"session-1\"}"));
+
+		assertTrue(ack(socket).contains("USER_QUOTA_EXHAUSTED"));
 	}
 
 	@Test
@@ -123,5 +153,6 @@ class SessionMessageWebSocketHandlerTest {
 		verify(dispatcher, never()).addMessage(any(), any(), any());
 		verify(dispatcher, never()).endSession(any(), any(), any());
 		verify(dispatcher, never()).bindProviderSession(any(), any(), any());
+		verify(dispatcher, never()).activateSession(any(), any());
 	}
 }

--- a/docs/API接口文档.md
+++ b/docs/API接口文档.md
@@ -430,6 +430,7 @@ Realtime 默认路由为七牛 RTI `qwen3.5-omni-plus-realtime`，可回退错�
 ```
 
 - 追加消息支持 `type`：`message`、`session.message`、`addMessage`。
+- WebRTC DataChannel 建立后发送 `type: "activate"`（兼容 `session.activate`），后端从此时开始预占并计算本次会话可用的每日额度。
 - 结束会话支持 `type`：`end`、`session.end`、`endSession`，并通过 `stopTime` 传结束时间。
 - `audio` 是 JSON 中的 Base64 字节数组；大音频应使用专用 multipart 接口。
 
@@ -446,7 +447,9 @@ Realtime 默认路由为七牛 RTI `qwen3.5-omni-plus-realtime`，可回退错�
 }
 ```
 
-失败时 `type` 以 `.failed` 结尾，`code` 为 `SESSION_SOCKET_ERROR`。
+激活成功返回 `session.activate.accepted`，其中 `data.quotaDeadline` 是后端强制截止时间，`data.quotaRemainingMillis` 用于客户端安排本地自动结束；没有治理额度记录的兼容账号两者均为 `null`。额度已用完时激活失败，业务错误为 `USER_QUOTA_EXHAUSTED`，后端同时终止刚创建的 Realtime 会话。
+
+失败时 `type` 以 `.failed` 结尾；业务异常保留对应业务 `code`，其他异常使用 `SESSION_SOCKET_ERROR`。
 
 ## 11. 公共 Service 接口契约
 

--- a/frontend/web/scripts/check-realtime-events.mjs
+++ b/frontend/web/scripts/check-realtime-events.mjs
@@ -561,8 +561,8 @@ assert.doesNotMatch(realtimeSource, /console\.warn\([^\n]*(?:offerSdp|answerSdp|
 
 const appSource = await readFile(new URL("../src/controller/App.jsx", import.meta.url), "utf8");
 const freeChatStopSource = appSource.slice(
-  appSource.indexOf("const stopConversation = async () =>"),
-  appSource.indexOf("useEffect(() =>", appSource.indexOf("const stopConversation = async () =>")),
+  appSource.indexOf("const stopConversation = async ("),
+  appSource.indexOf("useEffect(() =>", appSource.indexOf("const stopConversation = async (")),
 );
 assert.ok(
   freeChatStopSource.indexOf("await client?.stop") < freeChatStopSource.indexOf("setInCall(false)"),
@@ -570,6 +570,26 @@ assert.ok(
 );
 assert.match(freeChatStopSource, /stopPromiseRef\.current/);
 assert.match(freeChatStopSource, /detachRemoteAudio\(\)/);
+assert.match(
+  realtimeSource,
+  /await waitForChannel\(channel, peer\);[\s\S]*?await sendSessionFrame\("activate"\);[\s\S]*?scheduleQuotaDeadline/,
+  "daily quota must start only after the WebRTC data channel connects",
+);
+assert.match(
+  realtimeSource,
+  /type: "local\.quota_exhausted"[\s\S]*?stop\(\{ reason: "quota_exhausted" \}\)/,
+  "the client must reuse the normal session completion path at the quota deadline",
+);
+assert.match(
+  realtimeSource,
+  /const operation = \["activate", "bind", "end"\]\.includes\(type\) \? type : "message";/,
+  "session activation acknowledgements must be correlated independently",
+);
+assert.match(
+  realtimeSource,
+  /pending\.reject\(createRealtimeError\([\s\S]*?ack\.code \|\| "SESSION_SOCKET_ERROR"/,
+  "session WebSocket business error codes must reach the realtime startup failure",
+);
 
 assert.match(appSource, /const detachSceneRemoteAudio = \(\) => \{/);
 assert.match(appSource, /sceneAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);\s+detachSceneRemoteAudio\(\);/);
@@ -592,6 +612,11 @@ assert.match(
   /\{reconnecting \? "正在重新连接" : "重新连接"\}/,
   "custom scene must expose an explicit reconnect action after startup failure",
 );
+assert.match(
+  customSceneConversationSource,
+  /event\.type === "local\.quota_exhausted"[\s\S]*?endConversation\("quota_exhausted"\)/,
+  "custom scenes must finish through their existing report flow when quota expires",
+);
 assert.doesNotMatch(
   customSceneConversationSource,
   /setTimeout\([^)]*connectRealtime/,
@@ -605,6 +630,7 @@ const ieltsSource = await readFile(
 assert.match(ieltsSource, /const finishingRef = useRef\(false\);/);
 assert.match(ieltsSource, /if \(finishingRef\.current\) return;\s+finishingRef\.current = true;/);
 assert.match(ieltsSource, /ieltsAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);[\s\S]*?detachIeltsRemoteAudio\(\);[\s\S]*?clientRef\.current = null;/);
+assert.match(ieltsSource, /local\.quota_exhausted[\s\S]*?finishRef\.current\?\.\("quota_exhausted"\)/);
 
 const interviewSource = await readFile(
   new URL("../src/component/interview/InterviewModule.jsx", import.meta.url),
@@ -613,5 +639,6 @@ const interviewSource = await readFile(
 assert.match(interviewSource, /const detachInterviewRemoteAudio = \(\) => \{/);
 assert.match(interviewSource, /interviewAnalyticsRef\.current\?\.abandon\("COMPONENT_UNMOUNT"\);\s+detachInterviewRemoteAudio\(\);/);
 assert.match(interviewSource, /const abandon = async \(\) => \{\s+if \(endingRef\.current\) return;\s+endingRef\.current = true;/);
+assert.match(interviewSource, /local\.quota_exhausted[\s\S]*?endConversation\("quota_exhausted"\)/);
 
 console.log("Realtime event normalization checks passed.");

--- a/frontend/web/src/component/ielts/IeltsModule.jsx
+++ b/frontend/web/src/component/ielts/IeltsModule.jsx
@@ -801,6 +801,10 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
           setError(event.message || "IELTS 题目状态推进失败");
         } else if (event.type === "local.backend_warning") {
           setError("会话记录保存失败，请稍后重试");
+        } else if (event.type === "local.quota_exhausted") {
+          setError(event.message);
+          setStatus("今日额度已用完，正在结束本次练习");
+          void finishRef.current?.("quota_exhausted");
         } else if (event.type === "local.mic_error") {
           setRealtimeState("error");
           setError(event.message || "无法访问麦克风");
@@ -859,11 +863,11 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
     return () => window.clearInterval(timer);
   }, [ending, realtimeState]);
 
-  const finish = async () => {
+  const finish = async (reason = "user_stop") => {
     if (finishingRef.current) return;
     finishingRef.current = true;
     setEnding(true);
-    setError("");
+    if (reason !== "quota_exhausted") setError("");
     clearPartTwoTimer();
     clearPartTwoCompletionTimer();
     clearPartTwoSilenceTimer();
@@ -876,7 +880,7 @@ function IeltsConversationSession({ part, examiner, training, generated, onExit,
         ? client?.waitForEvaluations()
         : null;
       await client?.stop({
-        reason: "user_stop",
+        reason,
         awaitEvaluations: !deferEvaluation,
       });
       clientRef.current = null;

--- a/frontend/web/src/component/interview/InterviewModule.jsx
+++ b/frontend/web/src/component/interview/InterviewModule.jsx
@@ -605,6 +605,10 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
       setError(event.message || "面试自动结束失败");
     } else if (event.type === "local.backend_warning") {
       setError(event.message || "会话记录保存失败，请稍后重试");
+    } else if (event.type === "local.quota_exhausted") {
+      setError(event.message);
+      setStatus("今日额度已用完，正在结束本次面试");
+      void endConversation("quota_exhausted");
     } else if (event.type === "local.mic_error") {
       setRealtimeState("error");
       setError(event.message || "无法访问麦克风");
@@ -726,15 +730,15 @@ function InterviewSession({ sceneId, teacher, speed, onEndInterview, onExit }) {
     }
   };
 
-  const endConversation = async () => {
+  const endConversation = async (reason = "user_stop") => {
     if (endingRef.current) return;
     endingRef.current = true;
     setEnding(true);
-    setError("");
+    if (reason !== "quota_exhausted") setError("");
     setStatus("正在结束面试并生成报告");
     detachInterviewRemoteAudio();
     try {
-      const completion = await clientRef.current?.stop({ reason: "user_stop" });
+      const completion = await clientRef.current?.stop({ reason });
       clientRef.current = null;
       interviewAnalyticsRef.current?.complete();
       onEndInterviewRef.current?.(sceneId, sessionIdRef.current, completion?.reportStatus || null);

--- a/frontend/web/src/controller/App.jsx
+++ b/frontend/web/src/controller/App.jsx
@@ -1282,6 +1282,12 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
       setCallStatus("已打断当前回应");
       return;
     }
+    if (event.type === "local.quota_exhausted") {
+      setCallError(event.message);
+      setCallStatus("今日额度已用完");
+      void stopConversation("quota_exhausted");
+      return;
+    }
     if (event.type === "local.ended") {
       if (stopPromiseRef.current) return;
       freeChatAnalyticsRef.current?.complete();
@@ -1393,8 +1399,9 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
     }
   };
 
-  const stopConversation = async () => {
+  const stopConversation = async (requestedReason = "user_stop") => {
     if (stopPromiseRef.current) return stopPromiseRef.current;
+    const reason = typeof requestedReason === "string" ? requestedReason : "user_stop";
     const client = clientRef.current;
     const completedSessionId = sessionIdRef.current;
     setCallState("ending");
@@ -1403,7 +1410,7 @@ function Conversation({ teacher, speed, level, onSettingsChange, onBeforeStart, 
     detachRemoteAudio();
     let operation;
     operation = (async () => {
-      await client?.stop({ reason: "user_stop" });
+      await client?.stop({ reason });
       if (clientRef.current === client) clientRef.current = null;
       sessionIdRef.current = "";
       clientGenerationRef.current += 1;
@@ -1911,6 +1918,10 @@ function CustomSceneConversation({
       setStatus("本轮状态同步失败，已继续对话");
     } else if (event.type === "local.turn_evaluation_error") {
       setError(event.message);
+    } else if (event.type === "local.quota_exhausted") {
+      setError(event.message);
+      setStatus("今日额度已用完，正在结束本次练习");
+      void endConversation("quota_exhausted");
     } else if (event.type === "local.mic_error") {
       setRealtimeState("error");
       setError(event.message || "无法访问麦克风");

--- a/frontend/web/src/websocket/realtimeClient.js
+++ b/frontend/web/src/websocket/realtimeClient.js
@@ -724,6 +724,7 @@ export function createRealtimeClient({
   let pendingInterviewReportStatus = null;
   let providerSessionId = null;
   let providerSessionBound = false;
+  let quotaDeadlineTimer = null;
 
   const emit = (event) => onEvent(event);
 
@@ -760,6 +761,7 @@ export function createRealtimeClient({
         session_websocket: "SESSION_WEBSOCKET_FAILED",
         remote_description: "WEBRTC_REMOTE_DESCRIPTION_FAILED",
         data_channel: "WEBRTC_DATA_CHANNEL_FAILED",
+        session_activation: "SESSION_ACTIVATION_FAILED",
       }[stage] || "WEBRTC_START_FAILED");
     const diagnostics = await collectIceConnectionDiagnostics(
       peer,
@@ -901,7 +903,10 @@ export function createRealtimeClient({
     if (ack.success) {
       pending.resolve(ack);
     } else {
-      pending.reject(new Error(ack.message || ack.code || "会话消息处理失败"));
+      pending.reject(createRealtimeError(
+        ack.code || "SESSION_SOCKET_ERROR",
+        ack.message || ack.code || "会话消息处理失败",
+      ));
     }
   }
 
@@ -938,7 +943,7 @@ export function createRealtimeClient({
   async function sendSessionFrame(type, message = null, stopTime = null, providerSessionId = null) {
     if (!sessionId) throw new Error("会话 ID 尚未建立");
     const socket = await connectSessionSocket();
-    const operation = type === "end" ? "end" : type === "bind" ? "bind" : "message";
+    const operation = ["activate", "bind", "end"].includes(type) ? type : "message";
     const ack = new Promise((resolve, reject) => {
       const timer = window.setTimeout(() => {
         pendingAcks = pendingAcks.filter((pending) => pending.resolve !== resolve);
@@ -1021,6 +1026,25 @@ export function createRealtimeClient({
       window.clearTimeout(initialResponseFallbackTimer);
       initialResponseFallbackTimer = null;
     }
+    if (quotaDeadlineTimer) {
+      window.clearTimeout(quotaDeadlineTimer);
+      quotaDeadlineTimer = null;
+    }
+  }
+
+  function scheduleQuotaDeadline(rawRemainingMs) {
+    if (rawRemainingMs == null) return;
+    const remainingMs = Number(rawRemainingMs);
+    if (!Number.isFinite(remainingMs)) return;
+    const expire = () => {
+      quotaDeadlineTimer = null;
+      emit({
+        type: "local.quota_exhausted",
+        message: "今日练习额度已用完，本次会话已自动结束",
+      });
+      void stop({ reason: "quota_exhausted" });
+    };
+    quotaDeadlineTimer = window.setTimeout(expire, Math.max(0, remainingMs));
   }
 
   function sendSessionUpdate() {
@@ -1844,6 +1868,10 @@ export function createRealtimeClient({
       stage = "data_channel";
       await waitForChannel(channel, peer);
       assertCurrentStart(attempt);
+      stage = "session_activation";
+      const activation = await sendSessionFrame("activate");
+      assertCurrentStart(attempt);
+      scheduleQuotaDeadline(activation?.data?.quotaRemainingMillis);
       rtcTelemetry?.connected();
       started = true;
       const connectedAudioTrack = localStream?.getAudioTracks?.()[0];


### PR DESCRIPTION
## 变更说明

修复 Web 端每日额度即将耗尽时，新建会话仍可继续对话并超出额度限制的问题。

## 实现内容

- 强化每日额度策略的会话创建与运行时校验。
- 统一会话生命周期中的额度状态处理。
- 防止额度耗尽后继续接收或处理新的会话消息。
- 保持 Realtime 连接、WebSocket 消息分发和后台实际计费逻辑兼容。
- 补充额度策略、会话生命周期和 WebSocket 处理相关测试覆盖。

## 验证情况

- 本地普通用户登录验证通过。
- 本地额度数据可正常读取。
- 工作区执行 `git diff --check` 无格式问题。
- 分支已基于最新 `upstream/main` 并推送到远程。

## 备注

本 PR 不包含本地测试账号和数据库初始化内容。