### PR TITLE
feat(mobile): add independent 80% coverage gate and Codecov badge

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -366,7 +366,7 @@ jobs:
         run: npm run build
 
   mobile:
-    name: 移动端类型与 Expo Web 构建
+    name: 移动端测试、覆盖率与 Expo Web 构建
     needs: changes
     if: needs.changes.outputs.mobile == 'true'
     runs-on: ubuntu-latest
@@ -392,6 +392,20 @@ jobs:
 
       - name: 检查 TypeScript
         run: npx tsc --noEmit
+
+      - name: 运行 Jest 覆盖率门禁
+        run: npm run test:ci
+
+      - name: 保存移动端覆盖率报告
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mobile-coverage-${{ inputs.pr_number }}
+          path: |
+            frontend/mobile/coverage/lcov.info
+            frontend/mobile/coverage/coverage-summary.json
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: 导出 Expo Web
         env:

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -1,0 +1,66 @@
+name: Mobile Coverage
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/mobile/**
+      - .github/workflows/mobile-coverage.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mobile-coverage-main
+  cancel-in-progress: true
+
+jobs:
+  mobile:
+    name: 生成并发布移动端覆盖率
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: frontend/mobile
+    steps:
+      - name: 检出 main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: 配置 Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/mobile/package-lock.json
+
+      - name: 安装锁定依赖
+        run: npm ci
+
+      - name: 运行 Jest 覆盖率门禁
+        run: npm run test:ci
+
+      - name: 上传移动端覆盖率到 Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+        with:
+          use_oidc: true
+          files: frontend/mobile/coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          flags: mobile
+          name: mobile-unit
+
+      - name: 保存移动端覆盖率报告
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: mobile-main-coverage
+          path: |
+            frontend/mobile/coverage/lcov.info
+            frontend/mobile/coverage/coverage-summary.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # UniSpeaking
 
-[![后端测试](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml)
+后端： [![后端测试](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml)
 [![后端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
-[![移动端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=mobile)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
+
+移动端： [![移动端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=mobile)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
 
 后端与移动端 Codecov 使用独立的 `backend`、`mobile` flag，分别统计后端 JaCoCo 合并测试和移动端 Jest 行覆盖率；README 徽章显示 main 分支最新报告，移动端目标为保持在 80% 以上。
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 [![后端测试](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml/badge.svg?branch=main)](https://github.com/1024XEngineer/UniSpeaking/actions/workflows/coverage.yml)
 [![后端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=backend)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
+[![移动端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=mobile)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
 
-后端 Codecov 使用独立的 `backend` flag，统计 JaCoCo 合并的单元测试与 PostgreSQL/Redis 集成测试覆盖率；README 徽章显示的是 main 分支最新报告，目标为保持在 90% 以上。
+后端与移动端 Codecov 使用独立的 `backend`、`mobile` flag，分别统计后端 JaCoCo 合并测试和移动端 Jest 行覆盖率；README 徽章显示 main 分支最新报告，移动端目标为保持在 80% 以上。
 
 UniSpeaking 是一个面向英语口语训练的 AI 实时陪练系统。仓库包含 Spring Boot 后端、
 React Web 客户端、React Native 移动端、PostgreSQL 数据模型以及 Docker/Nginx 部署配置。

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -14,6 +14,7 @@ Redis 引入生产运行时。
 | `ci-refresh-pr.yml` | 等待包含最新 `main` 的 merge SHA，跳过冲突或已变化的 PR |
 | `ci-status.yml` | 在可信上下文校验当前 base、head、merge SHA 后发布 `CI / required` |
 | `coverage.yml` | `main` 后端变更后生成 JaCoCo 聚合报告并通过 OIDC 上传到 Codecov |
+| `mobile-coverage.yml` | `main` 移动端变更后运行 Jest 覆盖率门禁并通过 OIDC 上传到 Codecov |
 
 同一 PR 的核心检查使用 `ci-pr-<PR 编号>` 并发组。出现新提交或 `main` 更新时，旧检查
 会自动取消；不同 PR 可以并行执行。PR 工作流只使用只读权限，不接收仓库 Secrets。
@@ -23,7 +24,7 @@ Redis 引入生产运行时。
 
 - 后端：编译、单元测试、打包、PostgreSQL/Redis 集成测试、85% 行覆盖率和镜像构建；
 - Web 前端：Node.js 22、`npm ci`、路由与 Realtime 事件检查、生产构建和镜像构建；
-- 移动端：Node.js 22、`npm ci`、TypeScript 检查和 Expo Web 静态导出；
+- 移动端：Node.js 22、`npm ci`、TypeScript 检查、Jest 80% 行覆盖率门禁和 Expo Web 静态导出；
 - Compose、环境模板或 Nginx：配置解析或 `nginx -t`；
 - Maven/npm 依赖文件：Dependency Review，High 和 Critical 阻止合并。
 
@@ -71,6 +72,7 @@ npm run build
 cd frontend/mobile
 npm ci
 npx tsc --noEmit
+npm run test:ci
 EXPO_OFFLINE=1 npx expo export --platform web
 ```
 
@@ -81,20 +83,26 @@ GitHub Actions 在对应运行的 Artifacts 中保留以下内容 30 天：
 - Surefire 单元测试报告和必要日志；
 - Failsafe 集成测试报告和必要日志；
 - JaCoCo 单元、集成及合并覆盖率报告。
+- 移动端 Jest 的 LCOV 与 JSON summary 覆盖率报告。
 
 PR 不上传后端 JAR、前端 `dist` 或 Docker 镜像。用于在任务间合并覆盖率和校验 merge SHA
 的临时数据只保留 1 天。
 
-根目录 README 显示 `main` 分支的后端测试状态和 Codecov 覆盖率。覆盖率合并单元测试
+根目录 README 显示 `main` 分支的后端测试状态、后端 Codecov 覆盖率和移动端 Codecov 覆盖率。覆盖率合并单元测试
 及 PostgreSQL、Redis 集成测试所执行的后端 Java 代码；它不是数据库表或 SQL 语句的
-覆盖率。前端尚未建立自动化测试覆盖率，因此 README 暂不显示前端覆盖率。
+覆盖率。Web 前端尚未建立自动化测试覆盖率，因此 README 不显示 Web 覆盖率；移动端使用独立的 Jest 行覆盖率门禁，目标为 80%。
 `coverage.yml` 上传的是 JaCoCo 聚合报告
 `backend/unispeaking-server/target/site/jacoco-aggregate/jacoco.xml`，同时使用
 `backend` flag 标记报告。上传通过 GitHub OIDC 鉴权，不需要配置 `CODECOV_TOKEN`。
 
+`mobile-coverage.yml` 上传的是 `frontend/mobile/coverage/lcov.info`，使用 `mobile` flag
+标记报告。移动端 Jest 统计 `frontend/mobile/src` 生产源码，排除 Expo Router 的
+`src/app/**` 装配层、测试文件和声明文件；上传通过 GitHub OIDC 鉴权，不需要配置
+`CODECOV_TOKEN`。首次上传成功前，根 README 的移动端徽章可能显示 `unknown`。
+
 首次启用前，仓库管理员需要在 Codecov 中安装 GitHub App 并激活
 `1024XEngineer/UniSpeaking`。工作流合入 `main` 后会自动进行首次上传；也可以在
-Actions 的 Coverage 工作流中手动运行。首次上传成功前，README 徽章可能显示
+Actions 的 Coverage 或 Mobile Coverage 工作流中手动运行。首次上传成功前，README 徽章可能显示
 `unknown`。
 
 ## 首次启用与分支保护

--- a/frontend/mobile/.gitignore
+++ b/frontend/mobile/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 .expo/
 dist/
 web-build/
+coverage/
 expo-env.d.ts
 
 # Native

--- a/frontend/mobile/package.json
+++ b/frontend/mobile/package.json
@@ -66,7 +66,7 @@
     "web": "expo start --web",
     "lint": "expo lint",
     "test": "jest",
-    "test:ci": "jest --runInBand"
+    "test:ci": "jest --ci --runInBand --coverage"
   },
   "jest": {
     "preset": "jest-expo",
@@ -75,7 +75,23 @@
     ],
     "transformIgnorePatterns": [
       "node_modules/(?!((jest-)?react-native|@react-native(-community)?)|expo(nent)?|@expo(nent)?/.*|@expo-google-fonts/.*|react-navigation|@react-navigation/.*|react-native-svg|phosphor-react-native)"
-    ]
+    ],
+    "collectCoverageFrom": [
+      "src/**/*.{ts,tsx}",
+      "!src/app/**",
+      "!src/**/__tests__/**",
+      "!src/**/*.d.ts"
+    ],
+    "coverageReporters": [
+      "text-summary",
+      "json-summary",
+      "lcov"
+    ],
+    "coverageThreshold": {
+      "global": {
+        "lines": 80
+      }
+    }
   },
   "private": true
 }

--- a/frontend/mobile/src/components/__tests__/ConversationSettings.test.tsx
+++ b/frontend/mobile/src/components/__tests__/ConversationSettings.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { LevelSelector, SpeedSelector, TeacherSelector } from '../ConversationSettings';
+
+describe('conversation setting selectors', () => {
+  it('reports speed selection through its public callback', async () => {
+    const changeSpeed = jest.fn();
+    const speed = await render(<SpeedSelector value="自然" onChange={changeSpeed} />);
+    await fireEvent.press(speed.getByText('慢一些'));
+    expect(changeSpeed).toHaveBeenCalledWith('慢一些');
+    speed.unmount();
+  });
+
+  it('reports level selection through its public callback', async () => {
+    const changeLevel = jest.fn();
+    const level = await render(<LevelSelector value="starter" onChange={changeLevel} />);
+    await fireEvent.press(level.getByText('可以简单交流'));
+    expect(changeLevel).toHaveBeenCalledWith('basic');
+    level.unmount();
+  });
+
+  it('selects and previews the chosen teacher', async () => {
+    const selectTeacher = jest.fn();
+    const previewTeacher = jest.fn();
+    const teacher = await render(
+      <TeacherSelector selectedId="clara" onSelect={selectTeacher} onPreview={previewTeacher} />,
+    );
+    await fireEvent.press(teacher.getByLabelText('选择 James'));
+    expect(selectTeacher).toHaveBeenCalledWith(expect.objectContaining({ id: 'james' }));
+    expect(previewTeacher).toHaveBeenCalledWith(expect.objectContaining({ id: 'james' }));
+    teacher.unmount();
+  });
+});

--- a/frontend/mobile/src/components/__tests__/LiquidGlassTabBar.coverage.test.tsx
+++ b/frontend/mobile/src/components/__tests__/LiquidGlassTabBar.coverage.test.tsx
@@ -1,0 +1,140 @@
+import { cleanup, fireEvent, render } from '@testing-library/react-native';
+import { Platform, Text, View } from 'react-native';
+import type { BottomTabBarProps } from 'expo-router/build/react-navigation/bottom-tabs';
+
+import { LiquidGlassTabBar } from '../LiquidGlassTabBar';
+
+const mockIsGlassEffectAPIAvailable = jest.fn();
+const mockGlassView = jest.fn();
+
+jest.mock('expo-glass-effect', () => {
+  const React = require('react');
+  const { View: NativeView } = require('react-native');
+
+  return {
+    GlassView: (props: object) => {
+      mockGlassView(props);
+      return React.createElement(NativeView, { testID: 'glass-layer', ...props });
+    },
+    isGlassEffectAPIAvailable: () => mockIsGlassEffectAPIAvailable(),
+  };
+});
+
+type TabDefinition = {
+  key: string;
+  name: string;
+  params?: object;
+  options: Record<string, unknown>;
+};
+
+function propsFor(tabs: TabDefinition[], selectedIndex = 0, defaultPrevented = false): BottomTabBarProps {
+  const emit = jest.fn((event) => ({ ...event, defaultPrevented }));
+
+  return {
+    state: {
+      index: selectedIndex,
+      key: 'tabs',
+      routeNames: tabs.map((tab) => tab.name),
+      routes: tabs.map(({ key, name, params }) => ({ key, name, params })),
+      type: 'tab',
+      stale: false,
+      history: [],
+    },
+    descriptors: Object.fromEntries(tabs.map((tab) => [tab.key, { options: tab.options }])) as BottomTabBarProps['descriptors'],
+    navigation: { emit, navigate: jest.fn() } as unknown as BottomTabBarProps['navigation'],
+    insets: { top: 0, right: 0, bottom: 12, left: 0 },
+  } as unknown as BottomTabBarProps;
+}
+
+describe('LiquidGlassTabBar', () => {
+  const originalOS = Platform.OS;
+
+  beforeEach(() => {
+    mockGlassView.mockClear();
+    mockIsGlassEffectAPIAvailable.mockReturnValue(true);
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'ios' });
+  });
+
+  afterEach(async () => {
+    await cleanup();
+  });
+
+  afterAll(() => {
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: originalOS });
+  });
+
+  it('renders accessible tabs with focused state, icons, and native glass', async () => {
+    const homeIcon = jest.fn(({ color, focused }: { color: string; focused: boolean }) => (
+      <Text>{`home:${color}:${focused}`}</Text>
+    ));
+    const settingsIcon = jest.fn(({ color, focused }: { color: string; focused: boolean }) => (
+      <Text>{`settings:${color}:${focused}`}</Text>
+    ));
+    const props = propsFor([
+      {
+        key: 'home-key',
+        name: 'Home',
+        options: {
+          tabBarAccessibilityLabel: 'Home tab',
+          tabBarButtonTestID: 'home-tab',
+          tabBarActiveTintColor: '#123456',
+          tabBarIcon: homeIcon,
+        },
+      },
+      {
+        key: 'settings-key',
+        name: 'Settings',
+        options: { title: 'Settings title', tabBarInactiveTintColor: '#abcdef', tabBarIcon: settingsIcon },
+      },
+    ]);
+
+    const view = await render(<LiquidGlassTabBar {...props} />);
+
+    const homeTab = view.getByLabelText('Home tab');
+    expect(homeTab.props.accessibilityState).toEqual({ selected: true });
+    expect(view.getByLabelText('Settings title').props.accessibilityState).toEqual({ selected: false });
+    expect(view.getByTestId('home-tab')).toBeTruthy();
+    expect(view.getByText('home:#123456:true')).toBeTruthy();
+    expect(view.getByText('settings:#abcdef:false')).toBeTruthy();
+    expect(homeIcon).toHaveBeenCalledWith({ color: '#123456', focused: true, size: 25 });
+    expect(settingsIcon).toHaveBeenCalledWith({ color: '#abcdef', focused: false, size: 25 });
+    expect(mockGlassView).toHaveBeenLastCalledWith(expect.objectContaining({ glassEffectStyle: 'clear', isInteractive: true }));
+  });
+
+  it('emits tab events, navigates only for an unprevented inactive tab, and handles long presses', async () => {
+    mockIsGlassEffectAPIAvailable.mockReturnValue(false);
+    const props = propsFor([
+      { key: 'active', name: 'Active', options: {} },
+      { key: 'other', name: 'Other', params: { source: 'dock' }, options: {} },
+    ]);
+    const { emit, navigate } = props.navigation as unknown as { emit: jest.Mock; navigate: jest.Mock };
+    const view = await render(<LiquidGlassTabBar {...props} />);
+
+    await fireEvent.press(view.getByLabelText('Active'));
+    await fireEvent.press(view.getByLabelText('Other'));
+    await fireEvent(view.getByLabelText('Other'), 'longPress');
+
+    expect(emit).toHaveBeenNthCalledWith(1, { type: 'tabPress', target: 'active', canPreventDefault: true });
+    expect(emit).toHaveBeenNthCalledWith(2, { type: 'tabPress', target: 'other', canPreventDefault: true });
+    expect(emit).toHaveBeenNthCalledWith(3, { type: 'tabLongPress', target: 'other' });
+    expect(navigate).toHaveBeenCalledWith('Other', { source: 'dock' });
+    expect(mockGlassView).toHaveBeenLastCalledWith(expect.objectContaining({ glassEffectStyle: 'none' }));
+  });
+
+  it('does not navigate when a tab press is prevented and renders safely with no available tabs', async () => {
+    const preventedProps = propsFor([
+      { key: 'one', name: 'One', options: { tabBarAccessibilityLabel: 'One tab' } },
+      { key: 'two', name: 'Two', options: { tabBarAccessibilityLabel: 'Two tab' } },
+    ], 0, true);
+    const { navigate } = preventedProps.navigation as unknown as { navigate: jest.Mock };
+    const prevented = await render(<LiquidGlassTabBar {...preventedProps} />);
+
+    await fireEvent.press(prevented.getByLabelText('Two tab'));
+    expect(navigate).not.toHaveBeenCalled();
+
+    Object.defineProperty(Platform, 'OS', { configurable: true, value: 'web' });
+    const empty = await render(<LiquidGlassTabBar {...propsFor([])} />);
+    expect(empty.queryAllByRole('tab')).toHaveLength(0);
+    expect(empty.getByTestId('glass-layer')).toBeTruthy();
+  });
+});

--- a/frontend/mobile/src/components/__tests__/TeacherSwipeStack.coverage.test.tsx
+++ b/frontend/mobile/src/components/__tests__/TeacherSwipeStack.coverage.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockPlayTeacher = jest.fn();
+
+jest.mock('react-native-gesture-handler', () => {
+  const { View } = require('react-native');
+  const pan = { activeOffsetX: () => pan, onBegin: () => pan, onUpdate: () => pan, onEnd: () => pan };
+  return { Gesture: { Pan: () => pan }, GestureDetector: ({ children }: { children: React.ReactNode }) => <View>{children}</View> };
+});
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  const animated = Object.assign(View, { View });
+  return {
+    __esModule: true, default: animated, Easing: { out: (value: unknown) => value, inOut: (value: unknown) => value, cubic: 'cubic' },
+    FadeIn: { duration: () => ({ easing: () => ({}) }) }, FadeOut: { duration: () => ({}) },
+    interpolate: (value: number) => value, runOnJS: (fn: (...args: any[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(), useSharedValue: (value: number) => ({ value }), withTiming: (value: number) => value,
+  };
+});
+jest.mock('@/features/audio/useTeacherPreview', () => ({ useTeacherPreview: () => ({ playTeacher: mockPlayTeacher }) }));
+
+import { TeacherSwipeStack } from '../TeacherSwipeStack';
+import { teachers } from '@/theme/tokens';
+
+describe('TeacherSwipeStack', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('renders the selected teacher, previews it, and reports a dial selection', async () => {
+    const onSelect = jest.fn();
+    const view = await render(<TeacherSwipeStack selected={teachers[0]} onSelect={onSelect} />);
+    expect(view.getByText('Clara')).toBeTruthy();
+    await fireEvent.press(view.getByLabelText('试听 Clara'));
+    expect(mockPlayTeacher).toHaveBeenCalledWith(teachers[0]);
+    await fireEvent.press(view.getByLabelText('选择 James'));
+    await waitFor(() => expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ id: 'james' })));
+    expect(view.getByText('James')).toBeTruthy();
+    view.unmount();
+  });
+
+  it('falls back to the first teacher when a stale selected value is supplied', async () => {
+    const view = await render(<TeacherSwipeStack selected={{ ...teachers[0], id: 'removed-teacher' }} onSelect={jest.fn()} />);
+    expect(view.getByText('Clara')).toBeTruthy();
+    expect(view.getByLabelText('选择 Clara').props.accessibilityState).toEqual({ selected: true });
+    view.unmount();
+  });
+});

--- a/frontend/mobile/src/components/__tests__/sharedComponents.test.tsx
+++ b/frontend/mobile/src/components/__tests__/sharedComponents.test.tsx
@@ -1,0 +1,73 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+import { DevicePreviewFrame } from '../DevicePreviewFrame';
+import { LearningAssetsHeader } from '../LearningAssetsHeader';
+import { SceneCategoryTag } from '../SceneCategoryTag';
+import { LearningStageProvider, useLearningStage } from '@/navigation/learningStage';
+
+describe('shared mobile components', () => {
+  it('renders category labels for explicit and fallback categories', async () => {
+    const view = await render(
+      <>
+        <SceneCategoryTag category="food" />
+        <SceneCategoryTag category="workplace" subtle />
+        <SceneCategoryTag />
+      </>,
+    );
+
+    expect(view.getByText('餐饮')).toBeTruthy();
+    expect(view.getByText('职场')).toBeTruthy();
+    expect(view.getByText('其他')).toBeTruthy();
+  });
+
+  it('opens the learning asset module menu and calls the selected destination', async () => {
+    const onIelts = jest.fn();
+    const onInterview = jest.fn();
+    const view = await render(
+      <LearningAssetsHeader current="scenes" onIelts={onIelts} onInterview={onInterview} />,
+    );
+
+    await fireEvent.press(view.getByLabelText('切换学习资产模块'));
+    expect(view.getByText('雅思学习资产')).toBeTruthy();
+    expect(view.getByText('英文面试资产')).toBeTruthy();
+    await fireEvent.press(view.getByLabelText('进入雅思学习资产'));
+    expect(onIelts).toHaveBeenCalledTimes(1);
+    expect(view.queryByText('雅思学习资产')).toBeNull();
+
+    await fireEvent.press(view.getByLabelText('切换学习资产模块'));
+    await fireEvent.press(view.getByLabelText('关闭学习资产菜单'));
+    expect(onInterview).not.toHaveBeenCalled();
+  });
+
+  it('renders the preview frame around arbitrary screen content', async () => {
+    const view = await render(
+      <DevicePreviewFrame>
+        <Text>preview content</Text>
+      </DevicePreviewFrame>,
+    );
+
+    expect(view.getByTestId('device-preview-stage')).toBeTruthy();
+    expect(view.getByTestId('phone-preview-frame')).toBeTruthy();
+    expect(view.getByTestId('mobile-preview-frame')).toBeTruthy();
+    expect(view.getByText('preview content')).toBeTruthy();
+  });
+
+  it('passes learning stage state through the provider', async () => {
+    const setImmersiveLearning = jest.fn();
+    function Consumer() {
+      const stage = useLearningStage();
+      return <Text onPress={() => stage.setImmersiveLearning(true)}>{String(stage.immersiveLearning)}</Text>;
+    }
+
+    const view = await render(
+      <LearningStageProvider immersiveLearning={false} setImmersiveLearning={setImmersiveLearning}>
+        <Consumer />
+      </LearningStageProvider>,
+    );
+
+    expect(view.getByText('false')).toBeTruthy();
+    await fireEvent.press(view.getByText('false'));
+    expect(setImmersiveLearning).toHaveBeenCalledWith(true);
+  });
+});

--- a/frontend/mobile/src/features/audio/__tests__/TtsPlayer.nativeAdapters.test.ts
+++ b/frontend/mobile/src/features/audio/__tests__/TtsPlayer.nativeAdapters.test.ts
@@ -1,0 +1,65 @@
+const mockAssetFile = {
+  uri: 'file:///cache/unispeaking-tts.wav',
+  exists: true,
+  create: jest.fn(),
+  write: jest.fn(),
+  delete: jest.fn(),
+};
+const mockFile = jest.fn(() => mockAssetFile);
+const mockNativePlayer = { play: jest.fn(), pause: jest.fn(), remove: jest.fn(), volume: 0 };
+const mockCreateAudioPlayer = jest.fn(() => mockNativePlayer);
+const mockSetAudioModeAsync = jest.fn(async () => undefined);
+
+jest.mock('expo-file-system', () => ({
+  File: mockFile,
+  Paths: { cache: 'file:///cache' },
+}));
+jest.mock('expo-audio', () => ({
+  createAudioPlayer: mockCreateAudioPlayer,
+  setAudioModeAsync: mockSetAudioModeAsync,
+}));
+
+import { SceneSpeechClient, TtsPlayer } from '../TtsPlayer';
+
+describe('TTS native adapters', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAssetFile.exists = true;
+  });
+
+  it('writes default synthesized WAV assets into the cache and deletes them', async () => {
+    const client = new SceneSpeechClient({
+      baseUrl: 'https://api.example.test',
+      tokenStore: { get: async () => null },
+      fetchImpl: jest.fn(async () => ({
+        ok: true,
+        arrayBuffer: async () => new Uint8Array([82, 73, 70, 70]).buffer,
+      }) as Response),
+    });
+
+    const asset = await client.synthesize('scene', 'hello');
+
+    expect(mockFile).toHaveBeenCalledWith('file:///cache', expect.stringMatching(/^unispeaking-tts-.*\.wav$/));
+    expect(mockAssetFile.create).toHaveBeenCalledWith({ overwrite: true });
+    expect(mockAssetFile.write).toHaveBeenCalledWith(expect.objectContaining({ byteLength: 4 }));
+    asset.remove();
+    expect(mockAssetFile.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses Expo audio defaults when no native player adapters are supplied', async () => {
+    const asset = { uri: 'file:///speech.wav', remove: jest.fn() };
+    const player = new TtsPlayer({ speechClient: { synthesize: jest.fn().mockResolvedValue(asset) } });
+
+    await player.play('scene', 'hello');
+
+    expect(mockSetAudioModeAsync).toHaveBeenCalledWith({
+      allowsRecording: false,
+      interruptionMode: 'doNotMix',
+      playsInSilentMode: true,
+      shouldRouteThroughEarpiece: false,
+    });
+    expect(mockCreateAudioPlayer).toHaveBeenCalledWith('file:///speech.wav', { downloadFirst: true });
+    expect(mockNativePlayer.volume).toBe(1);
+    expect(mockNativePlayer.play).toHaveBeenCalledTimes(1);
+  });
+});

--- a/frontend/mobile/src/features/audio/__tests__/TtsPlayer.test.ts
+++ b/frontend/mobile/src/features/audio/__tests__/TtsPlayer.test.ts
@@ -44,6 +44,13 @@ describe('SceneSpeechClient', () => {
       expect.objectContaining({ byteLength: 4 }),
     );
   });
+
+  it('surfaces JSON speech errors and does not send an auth header without a token', async () => {
+    const fetchImpl = jest.fn(async () => ({ ok: false, status: 422, headers: { get: () => 'application/json' }, json: async () => ({ message: '文本过长' }) } as unknown as Response));
+    const client = new SceneSpeechClient({ baseUrl: 'https://api.example.com', tokenStore: { get: async () => null }, fetchImpl });
+    await expect(client.synthesize('scene', 'hello')).rejects.toThrow('文本过长');
+    expect((fetchImpl as jest.Mock).mock.calls[0][1]).toEqual(expect.objectContaining({ headers: { 'Content-Type': 'application/json' } }));
+  });
 });
 
 describe('TtsPlayer', () => {
@@ -103,5 +110,12 @@ describe('TtsPlayer', () => {
 
     expect(asset.remove).toHaveBeenCalledTimes(1);
     expect(nativePlayer.play).not.toHaveBeenCalled();
+  });
+
+  it('releases the synthesized asset when playback preparation fails', async () => {
+    const asset = { uri: 'file:///bad.wav', remove: jest.fn() };
+    const player = new TtsPlayer({ speechClient: { synthesize: jest.fn().mockResolvedValue(asset) }, preparePlayback: jest.fn().mockRejectedValue(new Error('audio unavailable')), createPlayer: jest.fn() });
+    await expect(player.play('scene', 'hello')).rejects.toThrow('audio unavailable');
+    expect(asset.remove).toHaveBeenCalled();
   });
 });

--- a/frontend/mobile/src/features/audio/__tests__/useTeacherPreview.test.tsx
+++ b/frontend/mobile/src/features/audio/__tests__/useTeacherPreview.test.tsx
@@ -1,0 +1,21 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+const mockPlay = jest.fn();
+const mockStop = jest.fn();
+const mockDispose = jest.fn();
+jest.mock('../TeacherPreviewPlayer', () => ({ TeacherPreviewPlayer: jest.fn(() => ({ play: mockPlay, stop: mockStop, dispose: mockDispose })) }));
+jest.mock('expo-audio', () => ({ createAudioPlayer: jest.fn(() => ({})), setAudioModeAsync: jest.fn(async () => undefined) }));
+
+import { useTeacherPreview } from '../useTeacherPreview';
+
+describe('useTeacherPreview', () => {
+  it('lazily creates a player, delegates playback and cleans up', async () => {
+    const { result, unmount } = await renderHook(() => useTeacherPreview());
+    const teacher = { id: 'clara', name: 'Clara', voiceId: 'Mione', accent: '英式', image: 1 } as any;
+    await act(async () => result.current.playTeacher(teacher));
+    await act(async () => result.current.stop());
+    expect(mockPlay).toHaveBeenCalledWith(teacher);
+    expect(mockStop).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/frontend/mobile/src/features/auth/__tests__/AuthSessionController.additional.test.ts
+++ b/frontend/mobile/src/features/auth/__tests__/AuthSessionController.additional.test.ts
@@ -1,0 +1,30 @@
+import { ApiError } from '@/infrastructure/http/ApiClient';
+
+import { authErrorMessage, AuthSessionController } from '../AuthSessionController';
+
+describe('AuthSessionController supplementary paths', () => {
+  it('forwards account recovery operations and falls back to clearing a legacy token store', async () => {
+    const authService = {
+      issueEmailChallenge: jest.fn(async (input) => ({ challengeId: input.email, expiresInSeconds: 60, resendAfterSeconds: 5 })),
+      issuePasswordResetChallenge: jest.fn(async (input) => ({ challengeId: `reset:${input.email}`, expiresInSeconds: 60, resendAfterSeconds: 5 })),
+      resetPassword: jest.fn(async () => undefined),
+      revoke: jest.fn(async () => undefined),
+    };
+    const tokenStore = { get: jest.fn(async () => null), set: jest.fn(async () => undefined), clear: jest.fn(async () => undefined) };
+    const controller = new AuthSessionController({ authService, tokenStore } as any);
+
+    await expect(controller.issueEmailChallenge({ email: 'a@example.test' })).resolves.toMatchObject({ challengeId: 'a@example.test' });
+    await expect(controller.issuePasswordResetChallenge({ email: 'a@example.test' })).resolves.toMatchObject({ challengeId: 'reset:a@example.test' });
+    await controller.resetPassword({ email: 'a@example.test', password: 'long-password', challengeId: 'challenge', code: '123456' });
+    await controller.unauthorized();
+
+    expect(authService.resetPassword).toHaveBeenCalledWith(expect.objectContaining({ challengeId: 'challenge' }));
+    expect(tokenStore.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it('maps known API failures to recovery-friendly Chinese messages', () => {
+    expect(authErrorMessage(new ApiError('ignored', 400, 'CHALLENGE_INVALID'))).toBe('验证码无效或已过期，请重新获取');
+    expect(authErrorMessage(new ApiError('ignored', 400, 'WEAK_PASSWORD'))).toBe('密码至少需要 12 位字符');
+    expect(authErrorMessage(null)).toBe('请求失败，请稍后重试');
+  });
+});

--- a/frontend/mobile/src/features/auth/__tests__/AuthSessionController.test.ts
+++ b/frontend/mobile/src/features/auth/__tests__/AuthSessionController.test.ts
@@ -191,4 +191,27 @@ describe('AuthSessionController', () => {
     expect(dependencies.tokenStore.clearTokens).toHaveBeenCalledTimes(1);
     expect(controller.getSnapshot().status).toBe('anonymous');
   });
+
+  it('maps login/register failures and rejects unauthenticated preference updates', async () => {
+    const loginDeps = createDependencies();
+    loginDeps.authService.login.mockRejectedValueOnce(new Error('登录失败'));
+    await expect(new AuthSessionController(loginDeps).login({ username: 'x', password: 'y' })).rejects.toThrow('登录失败');
+    const registerDeps = createDependencies();
+    registerDeps.authService.register.mockRejectedValueOnce(new Error('注册失败'));
+    await expect(new AuthSessionController(registerDeps).register({ username: 'x', password: 'y', nickname: null, challengeId: 'c', code: '1' })).rejects.toThrow('注册失败');
+    await expect(new AuthSessionController(createDependencies()).updatePreference({ cefrLevel: 'A' })).rejects.toThrow('需要登录');
+  });
+
+  it('uses refresh tokens during bootstrap and revokes on logout', async () => {
+    const dependencies = createDependencies();
+    (dependencies.tokenStore.get as jest.Mock).mockResolvedValue(null);
+    (dependencies.tokenStore as any).getRefreshToken = jest.fn().mockResolvedValue('refresh');
+    const coordinator = { refreshAccessToken: jest.fn().mockResolvedValue('fresh') } as any;
+    const controller = new AuthSessionController({ ...dependencies, tokenCoordinator: coordinator });
+    await controller.bootstrap();
+    expect(coordinator.refreshAccessToken).toHaveBeenCalled();
+    (dependencies.authService as any).revoke = jest.fn().mockResolvedValue(undefined);
+    await controller.logout();
+    expect((dependencies.authService as any).revoke).toHaveBeenCalledWith('refresh');
+  });
 });

--- a/frontend/mobile/src/features/conversation/__tests__/TranscriptTranslationApi.coverage.test.ts
+++ b/frontend/mobile/src/features/conversation/__tests__/TranscriptTranslationApi.coverage.test.ts
@@ -1,0 +1,12 @@
+import { TranscriptTranslationApi } from '../TranscriptTranslationApi';
+
+describe('TranscriptTranslationApi', () => {
+  it('posts free-chat and scene translation requests', async () => {
+    const request = jest.fn().mockResolvedValue({ translatedText: '你好' });
+    const api = new TranscriptTranslationApi({ request });
+    await expect(api.translateFreeChat('session/1', 'hello')).resolves.toBe('你好');
+    await expect(api.translateScene('scene/1', 'hello')).resolves.toBe('你好');
+    expect(request).toHaveBeenCalledWith('/api/scene-sessions/session%2F1/translations', expect.objectContaining({ method: 'POST' }));
+    expect(request).toHaveBeenCalledWith('/api/custom-scenes/scene%2F1/translations', expect.objectContaining({ method: 'POST' }));
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/AuthenticatedMediaClient.test.ts
+++ b/frontend/mobile/src/features/ielts/__tests__/AuthenticatedMediaClient.test.ts
@@ -1,0 +1,36 @@
+import { AuthenticatedMediaClient } from '../AuthenticatedMediaClient';
+
+const mockFile = { uri: 'cache://audio.wav', exists: true, create: jest.fn(), write: jest.fn(), delete: jest.fn() };
+jest.mock('expo-file-system', () => ({ File: jest.fn(() => mockFile), Paths: { cache: 'cache' } }));
+
+describe('AuthenticatedMediaClient', () => {
+  it('downloads relative media with a bearer token and caches it', async () => {
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true, status: 200, arrayBuffer: async () => new Uint8Array([1, 2]).buffer });
+    const coordinator = { getAccessToken: jest.fn().mockResolvedValue('token-1'), refreshAccessToken: jest.fn() } as any;
+    const client = new AuthenticatedMediaClient('https://api.example.com/', { get: jest.fn() }, fetchImpl, coordinator);
+    const file = await client.download('/media/audio.wav');
+    expect(fetchImpl).toHaveBeenCalledWith('https://api.example.com/media/audio.wav', { headers: { Authorization: 'Bearer token-1' } });
+    expect(file.uri).toBe('cache://audio.wav');
+    file.remove();
+    expect(mockFile.delete).toHaveBeenCalled();
+  });
+
+  it('refreshes after an unauthorized relative request and omits auth for absolute URLs', async () => {
+    const fetchImpl = jest.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, arrayBuffer: async () => new ArrayBuffer(0) })
+      .mockResolvedValueOnce({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) });
+    const coordinator = { getAccessToken: jest.fn().mockResolvedValue('old'), refreshAccessToken: jest.fn().mockResolvedValue('new') } as any;
+    const client = new AuthenticatedMediaClient('https://api.example.com', { get: jest.fn() }, fetchImpl, coordinator);
+    await client.download('/media/audio');
+    expect(fetchImpl.mock.calls[1][1]).toEqual({ headers: { Authorization: 'Bearer new' } });
+
+    const absoluteFetch = jest.fn().mockResolvedValue({ ok: true, status: 200, arrayBuffer: async () => new ArrayBuffer(0) });
+    await new AuthenticatedMediaClient('https://api.example.com', { get: jest.fn() }, absoluteFetch, coordinator).download('https://cdn.example.com/a.mp3');
+    expect(absoluteFetch.mock.calls[0][1]).toEqual({ headers: {} });
+  });
+
+  it('rejects unsuccessful downloads', async () => {
+    const client = new AuthenticatedMediaClient('https://api.example.com', { get: jest.fn() }, jest.fn().mockResolvedValue({ ok: false, status: 500 }), { getAccessToken: jest.fn().mockResolvedValue(null), refreshAccessToken: jest.fn() } as any);
+    await expect(client.download('/missing')).rejects.toThrow('录音加载失败（500）');
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/IeltsService.coverage.test.ts
+++ b/frontend/mobile/src/features/ielts/__tests__/IeltsService.coverage.test.ts
@@ -1,0 +1,27 @@
+import { IeltsService } from '../IeltsService';
+
+jest.mock('@/features/scenes/SceneService', () => ({ createWavUploadFile: (uri: string) => ({ uri }) }));
+
+describe('IeltsService request contracts', () => {
+  it('builds settings, topic, session and evaluation requests', async () => {
+    const request = jest.fn().mockResolvedValue({});
+    const service = new IeltsService({ request });
+    await service.getSettings();
+    await service.updateSettings({ targetScore: 7, examinerId: 'james' });
+    await service.searchTopics({ part: 'PART_1', category: 'food', keyword: '  tea ', page: 2, pageSize: 5 });
+    await service.getTraining('PART_2', 'topic/1');
+    await service.generateScene({ mode: 'PART_PRACTICE', part: 'PART_1', topicId: 'topic-1' });
+    await service.createFlow('scene/1');
+    await service.generateEvaluation('ielts/1', 'session/1');
+    await service.getEvaluationHistory();
+    await service.getDialogueState('ielts/1', 'session/1');
+    await service.advanceDialogueState('ielts/1', 'session/1', 2, true);
+    await service.getPart2State('ielts/1', 'session/1');
+    await service.advancePart2State('ielts/1', 'session/1', 'START_PREPARATION' as any);
+    await service.evaluateTurn('ielts/1', 'session/1', 1, 'hello', 'file.wav');
+    expect(request).toHaveBeenCalledWith('/api/ielts/settings');
+    expect(request).toHaveBeenCalledWith('/api/ielts/topics?part=PART_1&page=2&pageSize=5&category=food&keyword=tea');
+    expect(request).toHaveBeenCalledWith(expect.stringContaining('timedOut=true'), { method: 'POST' });
+    expect(request).toHaveBeenCalledTimes(13);
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/createIeltsService.test.ts
+++ b/frontend/mobile/src/features/ielts/__tests__/createIeltsService.test.ts
@@ -1,0 +1,13 @@
+import { createIeltsService } from '../createIeltsService';
+
+jest.mock('@/infrastructure/auth/SecureTokenStore', () => ({ SecureTokenStore: jest.fn() }));
+jest.mock('@/infrastructure/http/ApiClient', () => ({ ApiClient: jest.fn() }));
+jest.mock('../IeltsService', () => ({ IeltsService: jest.fn() }));
+jest.mock('@/infrastructure/config/runtimeConfig', () => ({ getRuntimeConfig: () => ({ backendUrl: 'https://api.example.com' }) }));
+
+describe('createIeltsService', () => {
+  it('wires runtime config, token store and unauthorized callback', () => {
+    const callback = jest.fn();
+    expect(createIeltsService(callback)).toBeDefined();
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/ieltsMappings.coverage.test.ts
+++ b/frontend/mobile/src/features/ielts/__tests__/ieltsMappings.coverage.test.ts
@@ -1,0 +1,18 @@
+import { examinerById, formatBand, fromApiPart, parseTargetScore, practiceTypeLabel, toApiCategory, toApiPart } from '../ieltsMappings';
+
+describe('IELTS mapping helpers', () => {
+  it('maps parts, categories, scores and practice labels', () => {
+    expect(toApiPart('p1')).toBe('PART_1');
+    expect(fromApiPart('PART_3')).toBe('p3');
+    expect(toApiCategory('全部')).toBeNull();
+    expect(toApiCategory('人物')).toBe('人物');
+    expect(formatBand(null)).toBe('—');
+    expect(formatBand(6.5)).toBe('6.5');
+    expect(parseTargetScore('7.5+')).toBe(7.5);
+    expect(parseTargetScore('bad')).toBe(7);
+    expect(practiceTypeLabel('MOCK_TEST')).toBe('模考练习');
+    expect(practiceTypeLabel('RANDOM_PART_PRACTICE')).toBe('随机专项练习');
+    expect(practiceTypeLabel('SELECTED_PART_PRACTICE')).toBe('指定专项练习');
+    expect(examinerById('unknown').id).toBe('daniel');
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/useIeltsFlowController.test.tsx
+++ b/frontend/mobile/src/features/ielts/__tests__/useIeltsFlowController.test.tsx
@@ -1,0 +1,132 @@
+import { act, renderHook, waitFor } from '@testing-library/react-native';
+
+import { createIeltsService } from '../createIeltsService';
+import { useIeltsFlowController } from '../useIeltsFlowController';
+
+jest.mock('../createIeltsService', () => ({
+  createIeltsService: jest.fn(),
+}));
+
+const mockedCreateIeltsService = jest.mocked(createIeltsService);
+
+function createService() {
+  return {
+    getSettings: jest.fn(async () => ({ targetScore: 6.5, examinerId: 'daniel' })),
+    updateSettings: jest.fn(async (input) => ({ targetScore: 6.5, examinerId: input.examinerId ?? 'daniel' })),
+    searchTopics: jest.fn(async () => ({
+      categories: [{ code: 'FOOD', label: '食物' }],
+      topics: [{ id: 'topic-1', title: 'Food' }],
+      total: 1,
+      totalPages: 1,
+    })),
+    generateScene: jest.fn(async () => ({ ieltsId: 'ielts-1', selectedTopicId: 'topic-1' })),
+    createFlow: jest.fn(async () => ({ sceneId: 'ielts-1' })),
+    getTraining: jest.fn(async () => ({ ieltsId: 'ielts-1', part: 'PART_2' })),
+    generateEvaluation: jest.fn(async () => ({ overallBand: 7 })),
+    getEvaluationHistory: jest.fn(async () => []),
+  };
+}
+
+describe('useIeltsFlowController', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockedCreateIeltsService.mockReturnValue(createService() as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('loads settings after mount and persists the selected target', async () => {
+    const service = createService();
+    mockedCreateIeltsService.mockReturnValue(service as never);
+    const { result } = await renderHook(() => useIeltsFlowController());
+
+    await act(async () => {
+      await jest.runOnlyPendingTimersAsync();
+    });
+    await waitFor(() => expect(result.current.settings).toEqual({ targetScore: 6.5, examinerId: 'daniel' }));
+
+    await act(async () => {
+      await result.current.saveTargetScore('7.5+');
+    });
+
+    expect(service.updateSettings).toHaveBeenCalledWith({ targetScore: 7.5 });
+    expect(result.current.settings).toEqual({ targetScore: 6.5, examinerId: 'daniel' });
+  });
+
+  it('maps topic filters and clears stale data when search fails', async () => {
+    const service = createService();
+    mockedCreateIeltsService.mockReturnValue(service as never);
+    const { result } = await renderHook(() => useIeltsFlowController());
+
+    await act(async () => {
+      await result.current.loadTopics('p1', 'ALL', 'food', 2);
+    });
+
+    expect(service.searchTopics).toHaveBeenCalledWith({
+      part: 'PART_1', category: null, keyword: 'food', page: 2, pageSize: 5,
+    });
+    expect(result.current.topics).toEqual([{ id: 'topic-1', title: 'Food' }]);
+
+    service.searchTopics.mockRejectedValueOnce(new Error('题库不可用'));
+    await act(async () => {
+      await result.current.loadTopics('p3', 'FOOD', '', 1);
+    });
+    expect(result.current.topics).toEqual([]);
+    expect(result.current.topicTotal).toBe(0);
+    expect(result.current.topicsError).toBe('题库不可用');
+  });
+
+  it('prepares Part 2 in order, exposes training, and retains the backend failure', async () => {
+    const service = createService();
+    mockedCreateIeltsService.mockReturnValue(service as never);
+    const { result } = await renderHook(() => useIeltsFlowController());
+
+    await act(async () => {
+      await result.current.prepareSession({
+        part: 'p2', topicId: 'topic-1', random: false, examiner: { id: 'marcus' } as never,
+      });
+    });
+
+    expect(service.updateSettings).toHaveBeenCalledWith({ examinerId: 'marcus' });
+    expect(service.generateScene).toHaveBeenCalledWith({ mode: 'PART_PRACTICE', part: 'PART_2', topicId: 'topic-1' });
+    expect(service.createFlow).toHaveBeenCalledWith('ielts-1');
+    expect(service.getTraining).toHaveBeenCalledWith('PART_2', 'topic-1');
+    expect(result.current.sessionBusy).toBe(false);
+    expect(result.current.training).toEqual({ ieltsId: 'ielts-1', part: 'PART_2' });
+
+    service.generateScene.mockRejectedValueOnce(new Error('生成失败'));
+    let caught: unknown;
+    await act(async () => {
+      try {
+        await result.current.prepareSession({
+          part: 'p1', random: true, examiner: { id: 'daniel' } as never,
+        });
+      } catch (error) {
+        caught = error;
+      }
+    });
+    expect(caught).toEqual(new Error('生成失败'));
+    expect(result.current.sessionError).toBe('生成失败');
+    expect(result.current.sessionBusy).toBe(false);
+  });
+
+  it('stores evaluation and degrades history refresh to an empty collection', async () => {
+    const service = createService();
+    mockedCreateIeltsService.mockReturnValue(service as never);
+    const { result } = await renderHook(() => useIeltsFlowController());
+
+    await act(async () => {
+      await result.current.finalizeEvaluation('ielts-1', 'session-1');
+    });
+    expect(result.current.latestEvaluation).toEqual({ overallBand: 7 });
+
+    service.getEvaluationHistory.mockRejectedValueOnce(new Error('offline'));
+    await act(async () => {
+      await result.current.refreshHistory();
+    });
+    expect(result.current.historyRecords).toEqual([]);
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/useIeltsSession.test.tsx
+++ b/frontend/mobile/src/features/ielts/__tests__/useIeltsSession.test.tsx
@@ -1,0 +1,207 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { RealtimeSessionSnapshot } from '@/features/realtime/RealtimeSessionController';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
+
+let mockController: any;
+
+jest.mock('@/model/AppModel', () => ({
+  useAppModel: () => ({ speed: '自然' }),
+}));
+
+jest.mock('@/features/realtime/RealtimeSessionController', () => ({
+  RealtimeSessionController: jest.fn().mockImplementation(() => mockController),
+}));
+jest.mock('@/features/realtime/ReactNativeWebRTCTransport', () => ({
+  ReactNativeWebRTCTransport: jest.fn(),
+}));
+jest.mock('@/features/realtime/RealtimeSessionApi', () => ({
+  RealtimeSessionApi: jest.fn(),
+}));
+jest.mock('@/features/realtime/SessionMessageSocket', () => ({
+  SessionMessageSocket: jest.fn(),
+}));
+jest.mock('@/features/ielts/IeltsDialogueApi', () => ({
+  IeltsDialogueApi: jest.fn(),
+}));
+jest.mock('@/features/audio/WavRecorder', () => ({
+  WavRecorder: jest.fn(),
+}));
+jest.mock('@/features/audio/TurnAudioCapture', () => ({
+  createTurnAudioCapture: jest.fn(() => ({})),
+}));
+jest.mock('@/infrastructure/auth/SecureTokenStore', () => ({
+  SecureTokenStore: jest.fn(),
+}));
+jest.mock('@/infrastructure/config/runtimeConfig', () => ({
+  getRuntimeConfig: () => ({ backendUrl: 'https://api.example.test' }),
+}));
+jest.mock('@/infrastructure/http/ApiClient', () => ({
+  ApiClient: jest.fn(),
+}));
+
+import { useIeltsSession, type IeltsSessionControllerPort } from '../useIeltsSession';
+
+const idleSnapshot: RealtimeSessionSnapshot = {
+  state: 'idle',
+  muted: false,
+  sessionId: null,
+  userTranscript: '',
+  assistantTranscript: '',
+  transcriptHistory: [],
+  error: null,
+};
+
+function createController(): IeltsSessionControllerPort & {
+  emit: (snapshot: RealtimeSessionSnapshot) => void;
+  start: jest.Mock;
+  setMuted: jest.Mock;
+  end: jest.Mock;
+  transitionPart2: jest.Mock;
+  forcePart3Timeout: jest.Mock;
+  restoreIeltsState: jest.Mock;
+  waitForTurnEvaluations: jest.Mock;
+} {
+  let snapshot = idleSnapshot;
+  const listeners = new Set<(next: RealtimeSessionSnapshot) => void>();
+  const controller = {
+    getSnapshot: () => snapshot,
+    subscribe: jest.fn((listener: (next: RealtimeSessionSnapshot) => void) => {
+      listeners.add(listener);
+      listener(snapshot);
+      return () => listeners.delete(listener);
+    }),
+    start: jest.fn(async () => undefined),
+    setMuted: jest.fn(),
+    end: jest.fn(async () => ({ ended: true })),
+    waitForTurnEvaluations: jest.fn(async () => undefined),
+    transitionPart2: jest.fn(async (event: unknown) => ({ event })),
+    forcePart3Timeout: jest.fn(async () => ({ timedOut: true })),
+    restoreIeltsState: jest.fn(async () => ({ restored: true })),
+    emit(next: RealtimeSessionSnapshot) {
+      snapshot = next;
+      listeners.forEach((listener) => listener(snapshot));
+    },
+  };
+  mockController = controller;
+  return controller;
+}
+
+function analyticsFixture(): TrainingTracker {
+  return {
+    attempt: jest.fn(),
+    started: jest.fn(),
+    fail: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    setVisible: jest.fn(),
+    settle: jest.fn(),
+    complete: jest.fn(),
+    abandon: jest.fn(),
+    isStarted: jest.fn(() => true),
+    start: jest.fn(),
+    stop: jest.fn(),
+  } as unknown as TrainingTracker;
+}
+
+describe('useIeltsSession', () => {
+  afterEach(async () => {
+    await cleanup();
+    mockController = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('returns an inert session when no IELTS config is provided', async () => {
+    const analytics = analyticsFixture();
+    const { result } = await renderHook(() => useIeltsSession(null, analytics));
+
+    expect(result.current.snapshot).toEqual(idleSnapshot);
+    expect(result.current.statusLabel).toBe('正在准备');
+    expect(await result.current.end()).toBeNull();
+    expect(await result.current.transitionPart2({ type: 'NEXT' } as any)).toBeNull();
+    expect(await result.current.forcePart3Timeout()).toBeNull();
+    expect(await result.current.restoreIeltsState()).toBeNull();
+    await result.current.waitForTurnEvaluations();
+    expect(analytics.attempt).not.toHaveBeenCalled();
+  });
+
+  it('starts a PART_2 session, mirrors snapshots, and delegates controls', async () => {
+    const controller = createController();
+    const analytics = analyticsFixture();
+    const { result } = await renderHook(() =>
+      useIeltsSession({ ieltsId: 'ielts-1', voiceId: 'Harvey', part: 'PART_2' }, analytics),
+    );
+
+    await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1));
+    expect(controller.setMuted).toHaveBeenCalledWith(true);
+    expect(analytics.attempt).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      controller.emit({
+        ...idleSnapshot,
+        state: 'ready',
+        sessionId: 'session-1',
+        assistantTranscript: 'Tell me about this topic.',
+      });
+    });
+    expect(result.current.sessionId).toBe('session-1');
+    expect(result.current.statusLabel).toBe('可以开始说了');
+    expect(analytics.started).toHaveBeenCalled();
+    expect(analytics.resume).toHaveBeenCalled();
+
+    await act(async () => {
+      result.current.toggleMuted(true);
+      await result.current.transitionPart2({ type: 'CUE_CARD_STARTED' } as any);
+      await result.current.forcePart3Timeout();
+      await result.current.restoreIeltsState();
+      await result.current.waitForTurnEvaluations();
+    });
+    expect(controller.setMuted).toHaveBeenLastCalledWith(true);
+    expect(controller.transitionPart2).toHaveBeenCalledWith({ type: 'CUE_CARD_STARTED' });
+    expect(controller.forcePart3Timeout).toHaveBeenCalledTimes(1);
+    expect(controller.restoreIeltsState).toHaveBeenCalledTimes(1);
+    expect(controller.waitForTurnEvaluations).toHaveBeenCalledTimes(1);
+
+    await result.current.end();
+    await result.current.end();
+    expect(controller.end).toHaveBeenCalledTimes(1);
+    expect(analytics.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports startup failures and snapshot errors through analytics', async () => {
+    const controller = createController();
+    controller.start.mockRejectedValueOnce(new Error('连接失败'));
+    const analytics = analyticsFixture();
+    const { result } = await renderHook(() =>
+      useIeltsSession({ ieltsId: 'ielts-2', voiceId: 'Aiden', part: 'PART_1' }, analytics),
+    );
+
+    await waitFor(() => expect(result.current.startupError).toBe('连接失败'));
+    expect(analytics.fail).toHaveBeenCalledWith('REALTIME_ERROR');
+
+    await act(async () => {
+      controller.emit({
+        ...idleSnapshot,
+        state: 'error',
+        error: { code: 'PEER_CONNECTION_FAILED', message: 'peer failed', retryable: true },
+      });
+    });
+    expect(analytics.abandon).toHaveBeenCalledWith('REALTIME_ERROR');
+  });
+
+  it('abandons and ends once when the hook is unmounted', async () => {
+    const controller = createController();
+    const analytics = analyticsFixture();
+    const { unmount } = await renderHook(() =>
+      useIeltsSession({ ieltsId: 'ielts-3', voiceId: 'Mione', part: 'PART_3' }, analytics),
+    );
+
+    await unmount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(controller.end).toHaveBeenCalledTimes(1));
+    expect(analytics.abandon).toHaveBeenCalledWith('USER_EXIT');
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/useRecordingPlayback.error.test.tsx
+++ b/frontend/mobile/src/features/ielts/__tests__/useRecordingPlayback.error.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { AuthenticatedMediaClient } from '../AuthenticatedMediaClient';
+import { useRecordingPlayback } from '../useRecordingPlayback';
+
+jest.mock('../AuthenticatedMediaClient', () => ({
+  AuthenticatedMediaClient: jest.fn(),
+}));
+
+const mockedMediaClient = jest.mocked(AuthenticatedMediaClient);
+
+describe('useRecordingPlayback download failure', () => {
+  beforeEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('returns to idle and exposes a rejected recording download', async () => {
+    let rejectDownload!: (error: Error) => void;
+    const download = jest.fn(() => new Promise<never>((_resolve, reject) => { rejectDownload = reject; }));
+    mockedMediaClient.mockImplementation(() => ({ download }) as never);
+    const { result } = await renderHook(() => useRecordingPlayback(['/missing.wav']));
+
+    await act(async () => {
+      result.current.toggle();
+      await Promise.resolve();
+    });
+    expect(result.current.playing).toBe(true);
+
+    await act(async () => {
+      rejectDownload(new Error('录音不存在'));
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(result.current.error).toBe('录音不存在');
+    expect(result.current.playing).toBe(false);
+  });
+});

--- a/frontend/mobile/src/features/ielts/__tests__/useRecordingPlayback.test.tsx
+++ b/frontend/mobile/src/features/ielts/__tests__/useRecordingPlayback.test.tsx
@@ -1,0 +1,85 @@
+import { act, renderHook } from '@testing-library/react-native';
+
+import { AuthenticatedMediaClient } from '../AuthenticatedMediaClient';
+import { useRecordingPlayback } from '../useRecordingPlayback';
+
+const mockCreateAudioPlayer = jest.fn();
+
+jest.mock('expo-audio', () => ({
+  createAudioPlayer: mockCreateAudioPlayer,
+}));
+
+jest.mock('../AuthenticatedMediaClient', () => ({
+  AuthenticatedMediaClient: jest.fn(),
+}));
+
+const mockedMediaClient = jest.mocked(AuthenticatedMediaClient);
+
+describe('useRecordingPlayback', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    mockCreateAudioPlayer.mockReset();
+    mockedMediaClient.mockImplementation(() => ({
+      download: jest.fn(async (url: string) => ({ uri: `file://${url}`, remove: jest.fn() })),
+    }) as never);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('plays every downloaded recording and releases native and cached resources', async () => {
+    const firstPlayer = { play: jest.fn(), pause: jest.fn(), remove: jest.fn() };
+    const secondPlayer = { play: jest.fn(), pause: jest.fn(), remove: jest.fn() };
+    mockCreateAudioPlayer.mockReturnValueOnce(firstPlayer).mockReturnValueOnce(secondPlayer);
+    const download = jest.fn()
+      .mockResolvedValueOnce({ uri: 'file://first', remove: jest.fn() })
+      .mockResolvedValueOnce({ uri: 'file://second', remove: jest.fn() });
+    mockedMediaClient.mockImplementation(() => ({ download }) as never);
+    const { result } = await renderHook(() => useRecordingPlayback(['/one.wav', '/two.mp3']));
+
+    await act(async () => {
+      result.current.toggle();
+      await jest.runAllTimersAsync();
+    });
+
+    expect(download).toHaveBeenNthCalledWith(1, '/one.wav');
+    expect(download).toHaveBeenNthCalledWith(2, '/two.mp3');
+    expect(firstPlayer.play).toHaveBeenCalledTimes(1);
+    expect(secondPlayer.play).toHaveBeenCalledTimes(1);
+    expect(secondPlayer.pause).toHaveBeenCalledTimes(1);
+    expect(secondPlayer.remove).toHaveBeenCalledTimes(1);
+    expect(result.current.playing).toBe(false);
+  });
+
+  it('stops an in-flight request without creating a native player', async () => {
+    let resolveDownload!: (value: { uri: string; remove: jest.Mock }) => void;
+    const download = jest.fn(() => new Promise((resolve) => { resolveDownload = resolve; }));
+    mockedMediaClient.mockImplementation(() => ({ download }) as never);
+    const { result } = await renderHook(() => useRecordingPlayback(['/one.wav']));
+
+    await act(async () => {
+      result.current.toggle();
+      await Promise.resolve();
+    });
+    await act(async () => {
+      result.current.stop();
+    });
+    expect(result.current.playing).toBe(false);
+    await act(async () => {
+      resolveDownload({ uri: 'file://first', remove: jest.fn() });
+      await Promise.resolve();
+    });
+
+    expect(mockCreateAudioPlayer).not.toHaveBeenCalled();
+  });
+
+  it('reports whether playback is available without starting an empty queue', async () => {
+    const empty = await renderHook(() => useRecordingPlayback([]));
+    expect(empty.result.current.canPlay).toBe(false);
+    act(() => empty.result.current.toggle());
+    expect(empty.result.current.playing).toBe(false);
+  });
+
+});

--- a/frontend/mobile/src/features/interview/__tests__/InterviewAssetService.coverage.test.ts
+++ b/frontend/mobile/src/features/interview/__tests__/InterviewAssetService.coverage.test.ts
@@ -1,0 +1,33 @@
+const files: any[] = [];
+jest.mock('expo-file-system', () => ({
+  File: jest.fn((_parent: string, name: string) => {
+    const file = { uri: `file://${name}`, exists: false, size: 0, create: jest.fn(), write: jest.fn(), delete: jest.fn() };
+    files.push(file);
+    return file;
+  }),
+  Paths: { document: 'document', cache: 'cache' },
+}));
+
+import { InterviewAssetService, InterviewRecordingClient } from '../InterviewAssetService';
+
+describe('Interview asset boundaries', () => {
+  it('validates asset and report response shapes', async () => {
+    const request = jest.fn()
+      .mockResolvedValueOnce([{ sceneId: 'scene-1', jobTitle: 'PM' }])
+      .mockResolvedValueOnce({ status: 'FAILED', failureReason: 'timeout' })
+      .mockResolvedValueOnce({ invalid: true });
+    const service = new InterviewAssetService({ request });
+    await expect(service.listAssets()).resolves.toHaveLength(1);
+    await expect(service.getReport('scene-1', 'session-1')).resolves.toMatchObject({ status: 'FAILED' });
+    await expect(service.listAssets()).rejects.toThrow('资产格式不正确');
+  });
+
+  it('downloads valid recordings, reuses local files and reports bad responses', async () => {
+    const tokenStore = { get: jest.fn().mockResolvedValue('token') };
+    const fetchImpl = jest.fn().mockResolvedValue({ ok: true, status: 200, arrayBuffer: async () => new Uint8Array(44).buffer });
+    const downloaded = await new InterviewRecordingClient('https://api.example.com/', tokenStore, fetchImpl).download('scene', 'session-2');
+    expect(fetchImpl).toHaveBeenCalledWith(expect.stringContaining('/api/interview-scenes/scene/sessions/session-2/recording'), expect.anything());
+    downloaded.remove();
+    await expect(new InterviewRecordingClient('https://api.example.com', tokenStore, jest.fn().mockResolvedValue({ ok: false, status: 404 })).download('scene', 'x')).rejects.toThrow('暂无可播放');
+  });
+});

--- a/frontend/mobile/src/features/interview/__tests__/InterviewSessionController.edgeCases.test.ts
+++ b/frontend/mobile/src/features/interview/__tests__/InterviewSessionController.edgeCases.test.ts
@@ -1,0 +1,89 @@
+import { InterviewSessionController } from '../InterviewSessionController';
+
+function fixture() {
+  let listener: ((event: any) => void) | null = null;
+  const transport = {
+    subscribe: jest.fn((next: (event: any) => void) => { listener = next; return () => { listener = null; }; }),
+    prepare: jest.fn(async () => undefined),
+    createOffer: jest.fn(async () => 'offer'),
+    applyAnswer: jest.fn(async () => undefined),
+    waitForDataChannel: jest.fn(async () => undefined),
+    sendProviderEvent: jest.fn(),
+    setAudioEnabled: jest.fn(),
+    close: jest.fn(),
+    emit: (event: any) => listener?.(event),
+  };
+  const recorder = {
+    start: jest.fn(async () => undefined), setInputEnabled: jest.fn(),
+    speechStarted: jest.fn(), speechStopped: jest.fn(),
+    takeTurn: jest.fn(async () => ({ uri: 'turn.wav', durationMs: 500 })),
+    discard: jest.fn(), appendAssistantAudio: jest.fn(), finishAssistantAudio: jest.fn(),
+    waitForAssistantAudioDrain: jest.fn(async () => undefined),
+    saveSessionRecording: jest.fn(() => 'file:///full.wav'), close: jest.fn(async () => undefined),
+  };
+  const sessionApi = {
+    startSession: jest.fn(async () => ({ sessionId: 'session-1', answerSdp: 'answer', voiceId: 'voice', systemPrompt: 'prompt' })),
+    submitTurn: jest.fn(async () => ({ state: { shouldEnd: false, completedTopicCount: 0, coveredTopicCount: 0, currentTopic: 'topic', controlInstruction: null }, reportStatus: 'PENDING' })),
+    end: jest.fn(async () => ({ sessionId: 'session-1', reportStatus: 'PROCESSING' })),
+  };
+  const sessionSocket = { connect: jest.fn(async () => undefined), bindProviderSession: jest.fn(async () => undefined), persistMessage: jest.fn(async () => undefined), close: jest.fn() };
+  return {
+    controller: new InterviewSessionController({ recorder, transport, sessionApi, sessionSocket, createEventId: () => 'event-1' } as any, { sceneId: 'scene', voice: 'voice', model: 'model' }),
+    recorder, transport, sessionApi, sessionSocket,
+  };
+}
+
+async function provider(test: ReturnType<typeof fixture>, event: unknown) {
+  await test.controller.handleProviderMessage(JSON.stringify(event));
+}
+
+async function activate(test: ReturnType<typeof fixture>) {
+  await test.controller.start();
+  await provider(test, { type: 'session.created' });
+  await provider(test, { type: 'session.updated' });
+  await provider(test, { type: 'response.done', response: { status: 'completed' } });
+}
+
+describe('InterviewSessionController edge cases', () => {
+  it('keeps the same turn open and requests a repeat when captured audio is too short', async () => {
+    const test = fixture();
+    test.recorder.takeTurn.mockResolvedValueOnce({ uri: 'short.wav', durationMs: 120 });
+    await activate(test);
+
+    await provider(test, { type: 'input_audio_buffer.speech_started', item_id: 'short-audio' });
+    await provider(test, { type: 'input_audio_buffer.speech_stopped', item_id: 'short-audio' });
+    await provider(test, { type: 'conversation.item.input_audio_transcription.completed', item_id: 'short-audio', transcript: 'A complete answer.' });
+
+    expect(test.sessionApi.submitTurn).not.toHaveBeenCalled();
+    expect(test.controller.getSnapshot()).toEqual(expect.objectContaining({ turnNo: 0, muted: false }));
+    expect(test.transport.sendProviderEvent).toHaveBeenLastCalledWith(expect.objectContaining({
+      type: 'response.create', response: expect.objectContaining({ instructions: expect.stringContaining('not captured reliably') }),
+    }));
+  });
+
+  it('persists interviewer text and cancels a response when the candidate barges in', async () => {
+    const test = fixture();
+    await activate(test);
+
+    await provider(test, { type: 'response.text.done', item_id: 'assistant-1', text: 'Tell me about yourself.' });
+    await provider(test, { type: 'input_audio_buffer.speech_started', item_id: 'candidate-1' });
+    await provider(test, { type: 'input_audio_buffer.speech_stopped', item_id: 'candidate-1' });
+
+    expect(test.controller.getSnapshot()).toEqual(expect.objectContaining({ currentQuestion: 'Tell me about yourself.' }));
+    expect(test.sessionSocket.persistMessage).toHaveBeenCalledWith({ owner: 0, content: 'Tell me about yourself.', providerMessageId: 'assistant-1' });
+    expect(test.recorder.speechStarted).toHaveBeenCalledTimes(1);
+    expect(test.recorder.speechStopped).toHaveBeenCalledTimes(1);
+    expect(test.transport.sendProviderEvent).toHaveBeenLastCalledWith(expect.objectContaining({ type: 'response.cancel' }));
+  });
+
+  it('cleans native resources when the backend omits required realtime parameters', async () => {
+    const test = fixture();
+    test.sessionApi.startSession.mockResolvedValueOnce({ sessionId: 'session-1', answerSdp: '', voiceId: 'voice', systemPrompt: '' });
+
+    await expect(test.controller.start()).rejects.toThrow('面试实时会话参数不完整');
+
+    expect(test.recorder.close).toHaveBeenCalledTimes(1);
+    expect(test.transport.close).toHaveBeenCalledTimes(1);
+    expect(test.controller.getSnapshot()).toEqual(expect.objectContaining({ state: 'error', error: expect.any(Error) }));
+  });
+});

--- a/frontend/mobile/src/features/interview/__tests__/useInterviewPreparation.test.tsx
+++ b/frontend/mobile/src/features/interview/__tests__/useInterviewPreparation.test.tsx
@@ -118,4 +118,21 @@ describe('useInterviewPreparation', () => {
     expect(result.current.error).toBe('服务器暂时不可用');
     expect(result.current.result).toBeNull();
   });
+
+  it('handles missing difficulty, successful file selection, and picker errors', async () => {
+    const { File } = jest.requireMock('expo-file-system') as { File: { pickFileAsync: jest.Mock } };
+    const service = createService();
+    const { result } = await renderHook(() => useInterviewPreparation(service));
+    await act(async () => result.current.start({ jobDescription: 'JD', difficulty: null }));
+    expect(result.current.error).toBe('请选择面试难度');
+    File.pickFileAsync.mockResolvedValueOnce({ canceled: false, result: { name: 'resume.pdf' } });
+    await act(async () => result.current.pickResume());
+    expect(result.current.resumeMode).toBe('file');
+    expect(result.current.resumeFileName).toBe('resume.pdf');
+    File.pickFileAsync.mockRejectedValueOnce(new Error('文件选择失败'));
+    await act(async () => result.current.pickResume());
+    expect(result.current.error).toBe('文件选择失败');
+    await act(async () => result.current.clearError());
+    expect(result.current.error).toBeNull();
+  });
 });

--- a/frontend/mobile/src/features/interview/__tests__/useInterviewSession.test.tsx
+++ b/frontend/mobile/src/features/interview/__tests__/useInterviewSession.test.tsx
@@ -1,0 +1,193 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react-native';
+
+import type { InterviewSessionSnapshot } from '../InterviewSessionController';
+import type { TrainingTracker } from '@/infrastructure/analytics/AnalyticsClient';
+
+let mockController: any;
+
+jest.mock('@siteed/audio-studio', () => ({
+  AudioStudioModule: { requestPermissionsAsync: jest.fn(async () => ({ granted: true })) },
+  useAudioRecorder: () => ({
+    startRecording: jest.fn(async () => undefined),
+    stopRecording: jest.fn(async () => undefined),
+  }),
+}));
+jest.mock('../InterviewSessionController', () => ({
+  InterviewSessionController: jest.fn().mockImplementation(() => mockController),
+}));
+jest.mock('@/features/audio/ContinuousTurnRecorder', () => ({
+  ContinuousTurnRecorder: jest.fn(),
+}));
+jest.mock('@/features/realtime/ReactNativeWebRTCTransport', () => ({
+  ReactNativeWebRTCTransport: jest.fn(),
+}));
+jest.mock('@/features/realtime/SessionMessageSocket', () => ({
+  SessionMessageSocket: jest.fn(),
+}));
+jest.mock('@/infrastructure/auth/SecureTokenStore', () => ({
+  SecureTokenStore: jest.fn(),
+}));
+jest.mock('@/infrastructure/config/runtimeConfig', () => ({
+  getRuntimeConfig: () => ({ backendUrl: 'https://api.example.test' }),
+}));
+jest.mock('@/infrastructure/http/ApiClient', () => ({
+  ApiClient: jest.fn(),
+}));
+jest.mock('../InterviewSessionApi', () => ({
+  InterviewSessionApi: jest.fn(),
+}));
+
+import { useInterviewSession } from '../useInterviewSession';
+
+const idleSnapshot: InterviewSessionSnapshot = {
+  state: 'idle',
+  status: 'idle',
+  sessionId: null,
+  transcripts: [],
+  muted: true,
+  userMuted: false,
+  turnNo: 0,
+  interviewState: null,
+  reportStatus: null,
+  currentQuestion: '',
+  error: null,
+};
+
+function createController() {
+  let snapshot = idleSnapshot;
+  const listeners = new Set<(next: InterviewSessionSnapshot) => void>();
+  const controller = {
+    getSnapshot: () => snapshot,
+    subscribe: jest.fn((listener: (next: InterviewSessionSnapshot) => void) => {
+      listeners.add(listener);
+      listener(snapshot);
+      return () => listeners.delete(listener);
+    }),
+    start: jest.fn(async () => undefined),
+    setMuted: jest.fn(),
+    end: jest.fn(async () => ({ reportStatus: 'PROCESSING' })),
+    emit(next: InterviewSessionSnapshot) {
+      snapshot = next;
+      listeners.forEach((listener) => listener(snapshot));
+    },
+  };
+  mockController = controller;
+  return controller;
+}
+
+function analyticsFixture(): TrainingTracker {
+  return {
+    attempt: jest.fn(),
+    started: jest.fn(),
+    fail: jest.fn(),
+    pause: jest.fn(),
+    resume: jest.fn(),
+    setVisible: jest.fn(),
+    settle: jest.fn(),
+    complete: jest.fn(),
+    abandon: jest.fn(),
+    isStarted: jest.fn(() => true),
+    start: jest.fn(),
+    stop: jest.fn(),
+  } as unknown as TrainingTracker;
+}
+
+describe('useInterviewSession', () => {
+  afterEach(async () => {
+    jest.useRealTimers();
+    await cleanup();
+    mockController = undefined;
+    jest.clearAllMocks();
+  });
+
+  it('starts, reflects active snapshots, tracks elapsed time, and delegates mute/end', async () => {
+    const controller = createController();
+    const analytics = analyticsFixture();
+    jest.useFakeTimers();
+    const { result } = await renderHook(() =>
+      useInterviewSession({ sceneId: 'scene-1', voice: 'Harvey' }, analytics),
+    );
+
+    await waitFor(() => expect(controller.start).toHaveBeenCalledTimes(1));
+    expect(analytics.attempt).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe('idle');
+    expect(result.current.elapsed).toBe(0);
+
+    await act(async () => {
+      controller.emit({
+        ...idleSnapshot,
+        state: 'active',
+        status: 'active',
+        sessionId: 'interview-1',
+        currentQuestion: 'Tell me about yourself.',
+        muted: false,
+      });
+    });
+    expect(result.current.sessionId).toBe('interview-1');
+    expect(result.current.currentQuestion).toBe('Tell me about yourself.');
+    expect(analytics.started).toHaveBeenCalled();
+    expect(analytics.resume).toHaveBeenCalled();
+
+    await act(async () => {
+      jest.advanceTimersByTime(2_000);
+    });
+    expect(result.current.elapsed).toBe(2);
+    await act(async () => {
+      result.current.setMuted(true);
+    });
+    expect(controller.setMuted).toHaveBeenCalledWith(true);
+
+    await act(async () => {
+      await result.current.end();
+      await result.current.end();
+    });
+    expect(controller.end).toHaveBeenCalledTimes(1);
+    expect(analytics.complete).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails analytics when startup rejects and abandons an active error', async () => {
+    const controller = createController();
+    controller.start.mockRejectedValueOnce(new Error('start failed'));
+    const analytics = analyticsFixture();
+    const { result } = await renderHook(() =>
+      useInterviewSession({ sceneId: 'scene-2', voice: 'Aiden', model: 'custom-model' }, analytics),
+    );
+
+    await waitFor(() => expect(analytics.fail).toHaveBeenCalledWith('REALTIME_ERROR'));
+    expect(result.current.state).toBe('idle');
+    await act(async () => {
+      controller.emit({ ...idleSnapshot, state: 'error', status: 'error', error: new Error('peer failed') });
+    });
+    expect(analytics.abandon).toHaveBeenCalledWith('REALTIME_ERROR');
+  });
+
+  it('abandons and performs idempotent cleanup on unmount', async () => {
+    const controller = createController();
+    const analytics = analyticsFixture();
+    const { unmount } = await renderHook(() =>
+      useInterviewSession({ sceneId: 'scene-3', voice: 'Mione' }, analytics),
+    );
+
+    await unmount();
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    await waitFor(() => expect(controller.end).toHaveBeenCalledTimes(1));
+    expect(controller.subscribe).toHaveBeenCalledTimes(1);
+    expect(analytics.abandon).toHaveBeenCalledWith('USER_EXIT');
+  });
+
+  it('reports end failures and abandons when analytics has started', async () => {
+    const controller = createController();
+    controller.end.mockRejectedValueOnce(new Error('end failed'));
+    const analytics = analyticsFixture();
+    const { result } = await renderHook(() =>
+      useInterviewSession({ sceneId: 'scene-4', voice: 'Maia' }, analytics),
+    );
+
+    await waitFor(() => expect(controller.start).toHaveBeenCalled());
+    await expect(result.current.end()).rejects.toThrow('end failed');
+    expect(analytics.abandon).toHaveBeenCalledWith('REALTIME_ERROR');
+  });
+});

--- a/frontend/mobile/src/infrastructure/auth/__tests__/AuthTokenCoordinator.coverage.test.ts
+++ b/frontend/mobile/src/infrastructure/auth/__tests__/AuthTokenCoordinator.coverage.test.ts
@@ -1,0 +1,27 @@
+import { AuthTokenCoordinator } from '../AuthTokenCoordinator';
+
+describe('AuthTokenCoordinator', () => {
+  it('reads, saves and clears legacy token stores', async () => {
+    const store = { get: jest.fn().mockReturnValue('old'), set: jest.fn(), clear: jest.fn() };
+    const coordinator = new AuthTokenCoordinator(store as any);
+    await expect(coordinator.getAccessToken()).resolves.toBe('old');
+    await expect(coordinator.saveTokens({ accessToken: 'new' })).resolves.toBe('new');
+    expect(store.set).toHaveBeenCalledWith('new');
+    await coordinator.clear();
+    expect(store.clear).toHaveBeenCalled();
+  });
+
+  it('refreshes once for concurrent callers and handles missing/failed refresh', async () => {
+    const store = { get: jest.fn(), getRefreshToken: jest.fn().mockResolvedValue('refresh'), setTokens: jest.fn() };
+    const refresh = jest.fn().mockResolvedValue({ accessToken: 'fresh' });
+    const coordinator = new AuthTokenCoordinator(store as any, { refresh });
+    await expect(Promise.all([coordinator.refreshAccessToken(), coordinator.refreshAccessToken()])).resolves.toEqual(['fresh', 'fresh']);
+    expect(refresh).toHaveBeenCalledTimes(1);
+    const missing = new AuthTokenCoordinator({ getRefreshToken: jest.fn().mockResolvedValue(null) } as any, { refresh });
+    await expect(missing.refreshAccessToken()).resolves.toBeNull();
+    const onFailure = jest.fn();
+    const failed = new AuthTokenCoordinator({ getRefreshToken: jest.fn().mockResolvedValue('r') } as any, { refresh: jest.fn().mockRejectedValue(new Error('bad')), onRefreshFailure: onFailure });
+    await expect(failed.refreshAccessToken()).resolves.toBeNull();
+    expect(onFailure).toHaveBeenCalled();
+  });
+});

--- a/frontend/mobile/src/infrastructure/auth/__tests__/SecureTokenStore.coverage.test.ts
+++ b/frontend/mobile/src/infrastructure/auth/__tests__/SecureTokenStore.coverage.test.ts
@@ -1,0 +1,24 @@
+import { WebTokenStorage, SecureTokenStore, createPlatformTokenStorage } from '../SecureTokenStore';
+
+describe('token storage adapters', () => {
+  it('uses web storage and stores/clears access and refresh tokens', async () => {
+    const values = new Map<string, string>();
+    const storage = new WebTokenStorage(() => ({ getItem: (key) => values.get(key) ?? null, setItem: (key, value) => { values.set(key, value); }, removeItem: (key) => { values.delete(key); } }));
+    await storage.setItemAsync('a', '1');
+    await expect(storage.getItemAsync('a')).resolves.toBe('1');
+    await storage.deleteItemAsync('a');
+    await expect(storage.getItemAsync('a')).resolves.toBeNull();
+    const store = new SecureTokenStore(storage, 'access', 'refresh');
+    await store.setTokens({ accessToken: 'access-token', refreshToken: 'refresh-token' });
+    await expect(store.getAccessToken()).resolves.toBe('access-token');
+    await expect(store.getRefreshToken()).resolves.toBe('refresh-token');
+    await store.setTokens({ accessToken: 'next', refreshToken: null });
+    await store.clearTokens();
+    await expect(store.get()).resolves.toBeNull();
+  });
+
+  it('selects the platform storage implementation', () => {
+    expect(createPlatformTokenStorage('web')).toBeInstanceOf(WebTokenStorage);
+    expect(createPlatformTokenStorage('ios')).toBeDefined();
+  });
+});

--- a/frontend/mobile/src/infrastructure/telemetry/__tests__/MobileTelemetry.additional.test.ts
+++ b/frontend/mobile/src/infrastructure/telemetry/__tests__/MobileTelemetry.additional.test.ts
@@ -1,0 +1,117 @@
+const mockGetToken = jest.fn();
+const mockAppStateListener = jest.fn();
+const mockAddEventListener = jest.fn((_event: string, listener: (state: string) => void) => {
+  mockAppStateListener.mockImplementation(listener);
+  return { remove: jest.fn() };
+});
+const mockGetNetworkState = jest.fn();
+const mockSentry = { init: jest.fn(), setUser: jest.fn(), captureException: jest.fn(), wrap: jest.fn((component) => component) };
+const mockCrashlytics = { marker: 'crashlytics' };
+const mockCrashlyticsSdk = {
+  getCrashlytics: jest.fn(() => mockCrashlytics),
+  setCrashlyticsCollectionEnabled: jest.fn(async () => undefined),
+  setUserId: jest.fn(async () => undefined),
+  recordError: jest.fn(),
+};
+
+jest.mock('@/infrastructure/auth/SecureTokenStore', () => ({
+  SecureTokenStore: jest.fn(() => ({ get: mockGetToken })),
+}));
+jest.mock('@/infrastructure/config/runtimeConfig', () => ({
+  getRuntimeConfig: () => ({ backendUrl: 'https://api.example.test' }),
+}));
+jest.mock('expo-constants', () => ({
+  expoConfig: { version: '9.9.9', extra: { firebaseCrashlyticsIosConfigured: true } },
+  nativeAppVersion: null,
+}));
+jest.mock('expo-device', () => ({
+  brand: 'Apple', modelName: 'Simulator', osName: 'iOS', osVersion: '18', isDevice: false,
+}));
+jest.mock('expo-network', () => ({ getNetworkStateAsync: mockGetNetworkState }));
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios', Version: '18' },
+  AppState: { addEventListener: mockAddEventListener },
+}));
+jest.mock('@sentry/react-native', () => mockSentry, { virtual: true });
+jest.mock('@react-native-firebase/crashlytics', () => mockCrashlyticsSdk, { virtual: true });
+
+describe('mobile telemetry native integrations', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  const originalDsn = process.env.EXPO_PUBLIC_SENTRY_DSN;
+  const originalErrorUtils = (globalThis as typeof globalThis & { ErrorUtils?: unknown }).ErrorUtils;
+  const originalUnhandledRejection = globalThis.onunhandledrejection;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.useFakeTimers();
+    process.env.NODE_ENV = 'production';
+    process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://sentry.example/1';
+    mockGetToken.mockResolvedValue('access-token');
+    mockGetNetworkState.mockResolvedValue({ type: 'wifi', isConnected: true, isInternetReachable: true });
+    global.fetch = jest.fn().mockResolvedValue({ ok: true, status: 202 }) as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+    process.env.NODE_ENV = originalNodeEnv;
+    if (originalDsn === undefined) delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+    else process.env.EXPO_PUBLIC_SENTRY_DSN = originalDsn;
+    (globalThis as typeof globalThis & { ErrorUtils?: unknown }).ErrorUtils = originalErrorUtils;
+    globalThis.onunhandledrejection = originalUnhandledRejection;
+  });
+
+  it('initializes crash reporting, captures native failures, and records network context', async () => {
+    const previousHandler = jest.fn();
+    let installedHandler: ((error: Error, isFatal?: boolean) => void) | undefined;
+    (globalThis as typeof globalThis & { ErrorUtils?: unknown }).ErrorUtils = {
+      getGlobalHandler: () => previousHandler,
+      setGlobalHandler: (handler: (error: Error, isFatal?: boolean) => void) => { installedHandler = handler; },
+    };
+    const previousRejection = jest.fn();
+    globalThis.onunhandledrejection = previousRejection;
+
+    const { mobileTelemetry } = require('../MobileTelemetry') as typeof import('../MobileTelemetry');
+    mobileTelemetry.initialize();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockSentry.init).toHaveBeenCalledWith(expect.objectContaining({ enabled: true, release: 'mobile@9.9.9' }));
+    expect(mockCrashlyticsSdk.setCrashlyticsCollectionEnabled).toHaveBeenCalledWith(mockCrashlytics, true);
+    expect(mockCrashlyticsSdk.setUserId).toHaveBeenCalledWith(mockCrashlytics, 'anonymous');
+    expect(mockAddEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+
+    mobileTelemetry.setUser('user-42');
+    installedHandler!(new Error('native crash'), true);
+    globalThis.onunhandledrejection?.call(globalThis as unknown as Window, { reason: 'lost connection' } as PromiseRejectionEvent);
+    mockAppStateListener('background');
+    mobileTelemetry.captureException('plain failure', { eventType: 'mobile.manual_failure' });
+    await mobileTelemetry.recordApiRequest({ path: '/api/me?token=secret', method: 'GET', durationMs: 12, outcome: 'success', status: 200 });
+    mockGetNetworkState.mockRejectedValueOnce(new Error('network details unavailable'));
+    await mobileTelemetry.recordApiRequest({ path: '/api/score', method: 'POST', durationMs: 42, outcome: 'error', message: 'bad gateway' });
+    mobileTelemetry.setUser(null);
+    await mobileTelemetry.flush();
+
+    expect(previousHandler).toHaveBeenCalledWith(expect.any(Error), true);
+    expect(previousRejection).toHaveBeenCalledWith(expect.objectContaining({ reason: 'lost connection' }));
+    expect(mockCrashlyticsSdk.recordError).toHaveBeenCalledWith(mockCrashlytics, expect.any(Error), expect.any(String));
+    expect(mockSentry.captureException).toHaveBeenCalledWith(expect.objectContaining({ message: 'plain failure' }));
+    expect(mockSentry.setUser).toHaveBeenLastCalledWith(null);
+    const events = (global.fetch as jest.Mock).mock.calls.flatMap(([, request]) =>
+      JSON.parse(String((request as RequestInit).body)).events,
+    );
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ eventType: 'api.request', route: '/api/me', attributes: expect.objectContaining({ network_type: 'wifi', network_connected: true }) }),
+      expect.objectContaining({ eventType: 'api.request', route: '/api/score', severity: 'ERROR', attributes: expect.objectContaining({ network_type: 'unknown', network_connected: false }) }),
+      expect.objectContaining({ eventType: 'mobile.js_crash', severity: 'FATAL' }),
+      expect.objectContaining({ eventType: 'mobile.unhandled_rejection', severity: 'ERROR' }),
+    ]));
+  });
+
+  it('wraps roots through Sentry outside the test runtime', () => {
+    const { wrapTelemetryRoot } = require('../MobileTelemetry') as typeof import('../MobileTelemetry');
+    const Root = () => null;
+    expect(wrapTelemetryRoot(Root)).toBe(Root);
+    expect(mockSentry.wrap).toHaveBeenCalledWith(Root);
+  });
+});

--- a/frontend/mobile/src/infrastructure/telemetry/__tests__/MobileTelemetry.test.ts
+++ b/frontend/mobile/src/infrastructure/telemetry/__tests__/MobileTelemetry.test.ts
@@ -1,0 +1,104 @@
+const mockGetToken = jest.fn();
+
+jest.mock('@/infrastructure/auth/SecureTokenStore', () => ({
+  SecureTokenStore: jest.fn(() => ({ get: mockGetToken })),
+}));
+
+jest.mock('@/infrastructure/config/runtimeConfig', () => ({
+  getRuntimeConfig: () => ({ backendUrl: 'https://api.example.test' }),
+}));
+
+jest.mock('expo-constants', () => ({
+  expoConfig: { version: '1.2.3' },
+  nativeAppVersion: null,
+}));
+
+jest.mock('expo-device', () => ({
+  brand: 'Apple', modelName: 'Simulator', osName: 'iOS', osVersion: '18', isDevice: false,
+}));
+
+jest.mock('expo-network', () => ({}));
+jest.mock('@sentry/react-native', () => ({ init: jest.fn(), setUser: jest.fn() }), { virtual: true });
+
+describe('mobileTelemetry event delivery', () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+  let fetchMock: jest.Mock;
+  let mobileTelemetry: typeof import('../MobileTelemetry').mobileTelemetry;
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.useFakeTimers();
+    process.env.NODE_ENV = 'production';
+    mockGetToken.mockResolvedValue('access-token');
+    fetchMock = jest.fn().mockResolvedValue({ ok: true, status: 202 });
+    global.fetch = fetchMock as typeof fetch;
+    // Load after NODE_ENV is set: telemetry deliberately disables delivery in test mode.
+    ({ mobileTelemetry } = require('../MobileTelemetry') as typeof import('../MobileTelemetry'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    process.env.NODE_ENV = originalNodeEnv;
+    jest.clearAllMocks();
+  });
+
+  it('drops invalid event names and sends a scrubbed, authenticated event', async () => {
+    mobileTelemetry.record({ eventType: 'Not valid' });
+    mobileTelemetry.record({
+      eventType: 'mobile.session_finished',
+      route: 'https://app.example.test/conversation?token=secret',
+      message: 'a'.repeat(700),
+      stack: 'Error: bad?access_token=secret',
+      attributes: {
+        valid_key: 'x'.repeat(600),
+        invalidKey: 'discard',
+        nullable: null,
+        non_finite: Number.NaN,
+        retries: 2,
+      },
+    });
+
+    await mobileTelemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, request] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe('https://api.example.test/api/telemetry/events');
+    expect(request.headers).toEqual({ 'Content-Type': 'application/json', Authorization: 'Bearer access-token' });
+    const event = JSON.parse(String(request.body)).events[0];
+    expect(event.route).toBe('/conversation');
+    expect(event.message).toHaveLength(500);
+    expect(event.stack).toContain('access_token=[redacted]');
+    expect(event.attributes).toMatchObject({ valid_key: 'x'.repeat(500), retries: 2, app_version: '1.2.3' });
+    expect(event.attributes).not.toHaveProperty('invalidKey');
+    expect(event.attributes).not.toHaveProperty('nullable');
+    expect(event.attributes).not.toHaveProperty('non_finite');
+  });
+
+  it('retains a failed batch and successfully retries it', async () => {
+    fetchMock.mockResolvedValueOnce({ ok: false, status: 500 }).mockResolvedValueOnce({ ok: true, status: 202 });
+    mobileTelemetry.record({ eventType: 'mobile.network_failed' });
+
+    await mobileTelemetry.flush();
+    await mobileTelemetry.flush();
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(JSON.parse(String(fetchMock.mock.calls[1][1].body)).events).toHaveLength(1);
+  });
+
+  it('updates the anonymous/user identity and ignores empty flushes', async () => {
+    mobileTelemetry.setUser('user-42');
+    await mobileTelemetry.flush();
+    mobileTelemetry.setUser(null);
+    await mobileTelemetry.flush();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('installs production telemetry handlers and queues startup events', async () => {
+    process.env.EXPO_PUBLIC_SENTRY_DSN = 'https://sentry.example/1';
+    mobileTelemetry.initialize();
+    mobileTelemetry.record({ eventType: 'mobile.manual_check', severity: 'WARN', attributes: { enabled: true } });
+    await mobileTelemetry.flush();
+    expect(fetchMock).toHaveBeenCalled();
+    delete process.env.EXPO_PUBLIC_SENTRY_DSN;
+  });
+});

--- a/frontend/mobile/src/model/__tests__/providers.test.tsx
+++ b/frontend/mobile/src/model/__tests__/providers.test.tsx
@@ -1,0 +1,38 @@
+import { render } from '@testing-library/react-native';
+import { Text } from 'react-native';
+
+jest.mock('@/infrastructure/telemetry/MobileTelemetry', () => ({ mobileTelemetry: { setUser: jest.fn() } }));
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => ({ userId: 'user-1' }) }));
+jest.mock('expo-router', () => ({ usePathname: () => '/profile' }));
+
+import { AnalyticsProvider, useAnalytics } from '../AnalyticsProvider';
+import { TelemetryProvider } from '../TelemetryProvider';
+import { mobileTelemetry } from '@/infrastructure/telemetry/MobileTelemetry';
+
+const analytics = {
+  setDistinctId: jest.fn(), setAppVisible: jest.fn(), trackPageView: jest.fn(), trackModeSelection: jest.fn(),
+  trackLearningAsset: jest.fn(), training: jest.fn(),
+};
+
+function AnalyticsChild() {
+  const client = useAnalytics();
+  return <Text>{client === analytics ? 'ready' : 'missing'}</Text>;
+}
+
+describe('mobile providers', () => {
+  it('connects analytics context and tracks identity/page visibility', async () => {
+    const view = await render(<AnalyticsProvider analyticsClient={analytics}><AnalyticsChild /></AnalyticsProvider>);
+    expect(view.getByText('ready')).toBeTruthy();
+    expect(analytics.setDistinctId).toHaveBeenCalledWith('user-1');
+    expect(analytics.trackPageView).toHaveBeenCalledWith('/profile');
+    expect(analytics.setAppVisible).toHaveBeenCalled();
+    view.unmount();
+  });
+
+  it('sets the telemetry user from the app model', async () => {
+    const view = await render(<TelemetryProvider><Text>content</Text></TelemetryProvider>);
+    expect(view.getByText('content')).toBeTruthy();
+    expect(mobileTelemetry.setUser).toHaveBeenCalledWith('user-1');
+    view.unmount();
+  });
+});

--- a/frontend/mobile/src/navigation/__tests__/navigationHelpers.test.ts
+++ b/frontend/mobile/src/navigation/__tests__/navigationHelpers.test.ts
@@ -1,0 +1,25 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { forgetSpecialty, readRememberedSpecialty, rememberSpecialty } from '../specialtyMemory';
+import { routes } from '../routes';
+
+describe('navigation helpers', () => {
+  it('builds stable route hrefs', () => {
+    expect(routes.public.login).toBe('/login');
+    expect(routes.scenes.training('scene-1', 'speak')).toBe('/scenes/scene-1/training?stage=speak');
+    expect(routes.scenes.training('scene-1')).toBe('/scenes/scene-1/training');
+    expect(routes.specialty.interviewPractice('scene-1', 'PM')).toEqual({ pathname: '/interview', params: { sceneId: 'scene-1', jobTitle: 'PM', practice: '1' } });
+  });
+
+  it('persists only supported specialty values and tolerates storage failures', async () => {
+    await rememberSpecialty('ielts');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith('unispeaking.navigation.last-specialty.v1', 'ielts');
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('interview');
+    await expect(readRememberedSpecialty()).resolves.toBe('interview');
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce('other');
+    await expect(readRememberedSpecialty()).resolves.toBeNull();
+    await forgetSpecialty();
+    expect(AsyncStorage.removeItem).toHaveBeenCalled();
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValueOnce(new Error('offline'));
+    await expect(rememberSpecialty('interview')).resolves.toBeUndefined();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/AuthOnboarding.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/AuthOnboarding.test.tsx
@@ -1,0 +1,40 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+const mockSetLevel = jest.fn();
+const mockComplete = jest.fn(async () => undefined);
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => ({ level: 'starter', setLevel: mockSetLevel, teacher: { id: 'clara', name: 'Clara', voiceId: 'Mione', accent: '英式', image: 1 }, setTeacher: jest.fn(), completeOnboarding: mockComplete }) }));
+jest.mock('@/components/TeacherSwipeStack', () => ({ TeacherSwipeStack: () => null }));
+
+import { LevelOnboardingScreen, TeacherOnboardingScreen, WelcomeScreen } from '../AuthScreens';
+
+describe('auth onboarding screens', () => {
+  it('routes from welcome to login and signup', async () => {
+    const onLogin = jest.fn();
+    const onSignup = jest.fn();
+    const view = await render(<WelcomeScreen onLogin={onLogin} onSignup={onSignup} />);
+    await fireEvent.press(view.getByRole('button', { name: '登录' }));
+    await fireEvent.press(view.getByRole('button', { name: '注册' }));
+    expect(onLogin).toHaveBeenCalledTimes(1);
+    expect(onSignup).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  it('selects a level and advances onboarding', async () => {
+    const onNext = jest.fn();
+    const view = await render(<LevelOnboardingScreen onNext={onNext} />);
+    await fireEvent.press(view.getByText('可以简单交流'));
+    expect(mockSetLevel).toHaveBeenCalledWith('basic');
+    await fireEvent.press(view.getByRole('button', { name: '下一步' }));
+    expect(onNext).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  it('completes teacher onboarding after selecting the current teacher', async () => {
+    const onComplete = jest.fn();
+    const view = await render(<TeacherOnboardingScreen onComplete={onComplete} />);
+    expect(view.getByText('选择一位 AI 老师')).toBeTruthy();
+    await fireEvent.press(view.getByRole('button', { name: '选择这位老师' }));
+    expect(mockComplete).toHaveBeenCalled();
+    view.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/ConversationScreen.coverage.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ConversationScreen.coverage.test.tsx
@@ -1,0 +1,89 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockSession = {
+  elapsed: 12,
+  muted: false,
+  statusLabel: '可以开始说了',
+  state: 'ready',
+  error: null,
+  sessionId: 'session-1',
+  userTranscript: 'Hello',
+  assistantTranscript: 'How can I help?',
+  transcriptHistory: [],
+  toggleMuted: jest.fn(),
+  end: jest.fn(async () => undefined),
+};
+const mockTranslate = jest.fn();
+const mockSaveSettings = jest.fn(async () => undefined);
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true, default: { View }, cancelAnimation: jest.fn(),
+    Easing: { cubic: jest.fn(), ease: jest.fn(), linear: jest.fn(), inOut: (value: unknown) => value, out: (value: unknown) => value },
+    interpolate: (_value: number, _input: number[], output: number[]) => output[0], runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(), useSharedValue: (value: unknown) => ({ value }),
+    withDelay: (_delay: number, value: unknown) => value, withRepeat: (value: unknown) => value, withTiming: (value: unknown) => value,
+  };
+});
+
+jest.mock('@/features/conversation/useFreeChatSession', () => ({ useFreeChatSession: jest.fn(() => mockSession) }));
+jest.mock('@/features/conversation/TranscriptTranslationApi', () => ({ createTranscriptTranslationApi: () => ({ translateFreeChat: mockTranslate }) }));
+jest.mock('react-native-safe-area-context', () => {
+  const { View } = require('react-native');
+  return { SafeAreaView: View, useSafeAreaInsets: () => ({ top: 0, bottom: 0 }) };
+});
+jest.mock('@/model/AppModel', () => ({
+  useAppModel: () => ({
+    nickname: 'Ada', speed: '自然', level: 'starter', saveConversationSettings: mockSaveSettings,
+    teacher: { id: 'james', name: 'James', accent: 'American English', voiceId: 'Harvey', image: 1 },
+  }),
+}));
+
+import { CallExperience, CallScreen, ConversationScreen, selectCallCaption } from '../ConversationScreen';
+
+describe('ConversationScreen coverage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    Object.assign(mockSession, { error: null, sessionId: 'session-1', state: 'ready', muted: false });
+  });
+
+  it('selects error, speaking, and status captions without stale text', () => {
+    expect(selectCallCaption({ ...mockSession, error: { message: '连接失败' } } as any, 'James', '准备中')).toEqual({ speaker: '系统', text: '连接失败' });
+    expect(selectCallCaption({ ...mockSession, state: 'user_speaking', userTranscript: '' } as any, 'James', '正在聆听')).toEqual({ speaker: '你', text: '正在聆听' });
+    expect(selectCallCaption({ ...mockSession, state: 'assistant_speaking', assistantTranscript: '' } as any, 'James', 'AI 正在回答')).toEqual({ speaker: 'James', text: 'AI 正在回答' });
+  });
+
+  it('shows a translation failure and toggles subtitle visibility', async () => {
+    const screen = await render(<CallExperience onEnd={jest.fn()} onTranslate={jest.fn(async () => { throw new Error('翻译服务不可用'); })} transcriptEnglish="Would you like tea?" />);
+    await fireEvent.press(screen.getByLabelText('翻译'));
+    await waitFor(() => expect(screen.getByText('翻译服务不可用')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('关闭字幕'));
+    expect(screen.getByLabelText('打开字幕')).toBeTruthy();
+    screen.unmount();
+  });
+
+  it('binds CallScreen mute, translation, and end actions to the realtime session', async () => {
+    const onEnd = jest.fn();
+    mockTranslate.mockResolvedValue('你好');
+    const screen = await render(<CallScreen onEnd={onEnd} />);
+    await fireEvent.press(screen.getByLabelText('关闭麦克风'));
+    expect(mockSession.toggleMuted).toHaveBeenCalledTimes(1);
+    await fireEvent.press(screen.getByLabelText('结束当前会话'));
+    await waitFor(() => expect(mockSession.end).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(onEnd).toHaveBeenCalledTimes(1));
+    screen.unmount();
+  });
+
+  it('delegates externally started calls and saves settings from the home screen', async () => {
+    const onStartCall = jest.fn();
+    const screen = await render(<ConversationScreen onStartCall={onStartCall} />);
+    await fireEvent.press(screen.getByText('开始对话'));
+    expect(onStartCall).toHaveBeenCalledTimes(1);
+    await fireEvent.press(screen.getByLabelText('对话设置'));
+    await fireEvent.press(screen.getByText('慢一些'));
+    await fireEvent.press(screen.getByText('保存设置'));
+    await waitFor(() => expect(mockSaveSettings).toHaveBeenCalledWith(expect.objectContaining({ speed: '慢一些' })));
+    screen.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/MainApp.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/MainApp.test.tsx
@@ -1,0 +1,21 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+jest.mock('@/screens/ConversationScreen', () => ({ ConversationScreen: () => null }));
+jest.mock('@/screens/ScenesScreen', () => ({ ScenesScreen: () => null }));
+jest.mock('@/screens/AssetsScreen', () => ({ AssetsScreen: () => null }));
+jest.mock('@/screens/ProfileScreen', () => ({ ProfileScreen: () => null }));
+jest.mock('react-native-safe-area-context', () => ({ useSafeAreaInsets: () => ({ top: 0, right: 0, bottom: 8, left: 0 }) }));
+
+import { MainApp } from '../MainApp';
+
+describe('MainApp navigation shell', () => {
+  it('switches between all tabs and hides the tab bar for immersive conversation', async () => {
+    const view = await render(<MainApp />);
+    expect(view.getByLabelText('对话')).toBeTruthy();
+    await fireEvent.press(view.getByLabelText('场景'));
+    await fireEvent.press(view.getByLabelText('资产'));
+    await fireEvent.press(view.getByLabelText('我的'));
+    expect(view.getAllByRole('tab')).toHaveLength(4);
+    view.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/ProfileScreen.coverage.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ProfileScreen.coverage.test.tsx
@@ -1,0 +1,256 @@
+import { Alert } from 'react-native';
+import { cleanup, fireEvent, render, waitFor } from '@testing-library/react-native';
+
+import {
+  AccountSettings,
+  AboutProduct,
+  AssistantSettings,
+  HelpArticle,
+  HelpCategory,
+  HelpCenter,
+  Insights,
+  Membership,
+  Overview,
+  ProfileHome,
+} from '../ProfileScreen';
+
+const mockApi = {
+  getOverview: jest.fn(),
+  getAchievements: jest.fn(),
+  getInsights: jest.fn(),
+  updateWeeklyGoals: jest.fn(),
+  updateNickname: jest.fn(),
+  uploadAvatar: jest.fn(),
+  changePassword: jest.fn(),
+  getHelpCenter: jest.fn(),
+  getHelpCategory: jest.fn(),
+  getHelpArticle: jest.fn(),
+};
+
+const mockAppModel = {
+  nickname: 'Ada',
+  email: 'ada@example.com',
+  speed: '自然',
+  level: 'starter',
+  teacher: { id: 'clara', name: 'Clara' },
+  setNickname: jest.fn(),
+  saveSpeed: jest.fn(),
+  saveLevel: jest.fn(),
+  saveTeacher: jest.fn(),
+  signOut: jest.fn(),
+};
+const mockImagePicker = {
+  requestMediaLibraryPermissionsAsync: jest.fn(),
+  launchImageLibraryAsync: jest.fn(),
+};
+
+jest.mock('@/features/profile/ProfileApi', () => ({
+  ProfileApi: jest.fn(() => mockApi),
+}));
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => mockAppModel }));
+jest.mock('@/features/audio/useTeacherPreview', () => ({
+  useTeacherPreview: () => ({ playTeacher: jest.fn() }),
+}));
+jest.mock('expo-image-picker', () => ({ __esModule: true, ...mockImagePicker }));
+
+const overview = {
+  account: { userId: 'u1', email: 'ada@example.com', nickname: 'Ada', displayName: 'Ada', avatarUrl: null, avatarUrlExpiresAt: null },
+  statistics: {
+    weeklyPracticeSeconds: 3900,
+    trainingRecordCount: 8,
+    consecutiveLearningDays: 4,
+    lastSevenDays: [{ date: '2026-08-10', practiceSeconds: 600 }, { date: '2026-08-11', practiceSeconds: 0 }],
+  },
+  calendar: { month: '2026-08', checkedDates: ['2026-08-10'], checkedInToday: false },
+};
+const insights = {
+  weeklyGoals: {
+    weekStartsAt: '2026-08-10T00:00:00.000Z', weekEndsAt: '2026-08-17T00:00:00.000Z',
+    durationTargetMinutes: 120, completedDurationSeconds: 3600, remainingDurationSeconds: 3600,
+    durationProgress: 50, durationAchieved: false, trainingCountTarget: 5, completedTrainingCount: 2,
+    remainingTrainingCount: 3, countProgress: 40, countAchieved: false,
+  },
+  trainingTypeDistribution: [{ type: 'FREE_CHAT', durationSeconds: 3600, percentage: 100 }],
+  abilityTrends: [{ sessionId: 's1', completedAt: '2026-08-12', trainingType: 'FREE_CHAT', scores: { accuracy: 7.5, fluency: 6.5, grammar: null, vocabulary: null, naturalness: null } }],
+  weaknessAnalysis: { sampleCount: 3, minimumSampleCount: 2, reliable: true },
+  weaknesses: [{ dimension: 'fluency', rank: 1, averageScore: 6.5, recentChange: 0.2, basis: '停顿偏多' }],
+  recommendations: [{ dimension: 'fluency', trainingType: 'FREE_CHAT', reason: '每天练习' }],
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockApi.getOverview.mockResolvedValue(overview);
+  mockApi.getAchievements.mockResolvedValue({ series: [{ seriesId: 'a1', category: '练习', title: '开口新星', unit: '次', currentValue: 2, currentLevel: 1, currentTitle: '初阶', nextLevel: 2, nextTitle: '进阶', nextThreshold: 5, completed: false, milestones: [{ achievementId: 'a1', level: 1, title: '初阶', description: '完成两次', threshold: 2, unlocked: true, unlockedAt: '2026-08-10' }] }] });
+  mockApi.getInsights.mockResolvedValue(insights);
+  mockApi.updateWeeklyGoals.mockResolvedValue(insights);
+  mockApi.updateNickname.mockResolvedValue({ nickname: 'Grace', displayName: 'Grace' });
+  mockApi.uploadAvatar.mockResolvedValue({ avatarUrl: 'https://example.com/avatar.png', avatarUrlExpiresAt: '2026-08-30' });
+  mockApi.changePassword.mockResolvedValue({ reauthenticationRequired: true });
+  mockApi.getHelpCenter.mockResolvedValue({ categories: [{ id: 'account', title: '账号问题', description: '登录与安全', articleCount: 1 }] });
+  mockApi.getHelpCategory.mockResolvedValue({ id: 'account', title: '账号问题', description: '登录与安全', articles: [{ id: 'password', title: '如何修改密码', summary: '在账号设置中修改。' }] });
+  mockApi.getHelpArticle.mockResolvedValue({ id: 'password', categoryId: 'account', title: '如何修改密码', summary: '在账号设置中修改。', updatedAt: '2026-08-10' });
+  mockAppModel.saveSpeed.mockResolvedValue(undefined);
+  mockAppModel.saveLevel.mockResolvedValue(undefined);
+  mockAppModel.saveTeacher.mockResolvedValue(undefined);
+  mockImagePicker.requestMediaLibraryPermissionsAsync.mockResolvedValue({ granted: true });
+  mockImagePicker.launchImageLibraryAsync.mockResolvedValue({ canceled: false, assets: [{ uri: 'file:///avatar.png', mimeType: 'image/png', fileName: 'avatar.png', fileSize: 512 }] });
+  jest.spyOn(Alert, 'alert').mockImplementation(jest.fn());
+});
+
+afterEach(() => {
+  cleanup();
+  jest.restoreAllMocks();
+});
+
+describe('ProfileScreen exported pages', () => {
+  it('renders the about product page and returns to profile', async () => {
+    const onBack = jest.fn();
+    const view = await render(<AboutProduct onBack={onBack} />);
+    expect(view.getAllByText('关于 UniSpeaking').length).toBeGreaterThan(0);
+    await fireEvent.press(view.getByRole('button', { name: '返回' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  it('loads the profile home, routes menu items, and opens the edit modal', async () => {
+    const onOpen = jest.fn();
+    const onLogout = jest.fn();
+    const view = await render(<ProfileHome onOpen={onOpen} onLogout={onLogout} />);
+    await waitFor(() => expect(view.getByText('Ada')).toBeTruthy());
+    await fireEvent.press(view.getByText('学习目标与洞察'));
+    expect(onOpen).toHaveBeenCalledWith('insights');
+    await fireEvent.press(view.getByLabelText('编辑用户名和头像'));
+    expect(view.getByText('编辑个人资料')).toBeTruthy();
+    const nicknameInput = view.getByDisplayValue('Ada');
+    await fireEvent.changeText(nicknameInput, 'Grace');
+    await fireEvent.press(view.getByText('保存修改'));
+    await waitFor(() => expect(mockApi.updateNickname).toHaveBeenCalledWith('Grace'));
+    await fireEvent.press(view.getByLabelText('编辑用户名和头像'));
+    await fireEvent.changeText(view.getByDisplayValue('Ada'), '');
+    await fireEvent.press(view.getByText('保存修改'));
+    expect(view.getByText('用户名需为 1 到 32 个字符')).toBeTruthy();
+    await fireEvent.press(view.getByText('取消'));
+    await fireEvent.press(view.getByText('退出登录'));
+    expect(onLogout).toHaveBeenCalledTimes(1);
+    view.unmount();
+  });
+
+  it('keeps the profile form usable when the current client cannot load the photo picker', async () => {
+    const view = await render(<ProfileHome onOpen={jest.fn()} onLogout={jest.fn()} />);
+    await waitFor(() => expect(view.getByText('Ada')).toBeTruthy());
+    await fireEvent.press(view.getByLabelText('编辑用户名和头像'));
+
+    await fireEvent.press(view.getByText('选择新头像'));
+    await waitFor(() => expect(view.getByText('当前客户端不支持选择照片，请更新 Expo Go 或使用最新开发构建')).toBeTruthy());
+    expect(view.getByText('保存修改')).toBeTruthy();
+    view.unmount();
+  });
+
+
+  it('loads overview data, changes the calendar month, and exposes achievement retry failures', async () => {
+    const view = await render(<Overview onBack={jest.fn()} />);
+    await waitFor(() => expect(view.getByText('本周学习时长')).toBeTruthy());
+    expect(view.getByText('开口新星')).toBeTruthy();
+    fireEvent.press(view.getByLabelText('上个月'));
+    await waitFor(() => expect(mockApi.getOverview).toHaveBeenCalledTimes(2));
+
+    mockApi.getAchievements.mockRejectedValueOnce(new Error('成就服务暂不可用'));
+    const failed = await render(<Overview onBack={jest.fn()} />);
+    await waitFor(() => expect(failed.getByText('成就服务暂不可用')).toBeTruthy());
+    fireEvent.press(failed.getByText('重新加载'));
+    await waitFor(() => expect(mockApi.getAchievements).toHaveBeenCalledTimes(3));
+  });
+
+  it('shows and retries the overview request failure while retaining the achievement area', async () => {
+    mockApi.getOverview.mockReset();
+    mockApi.getOverview.mockRejectedValueOnce(new Error('概览暂不可用')).mockResolvedValue(overview);
+    const view = await render(<Overview onBack={jest.fn()} />);
+    await waitFor(() => expect(view.getByText('概览暂不可用')).toBeTruthy());
+    fireEvent.press(view.getByText('重新加载'));
+    await waitFor(() => expect(view.getByText('本周学习时长')).toBeTruthy());
+    view.unmount();
+  });
+
+  it('renders insights and persists valid weekly goals while validating invalid values', async () => {
+    const view = await render(<Insights onBack={jest.fn()} />);
+    await waitFor(() => expect(view.getByText('本周训练类型占比')).toBeTruthy());
+    fireEvent.press(view.getByText('调整目标'));
+    await waitFor(() => expect(view.getByText('调整每周目标')).toBeTruthy());
+    fireEvent.press(view.getByText('保存目标'));
+    await waitFor(() => expect(mockApi.updateWeeklyGoals).toHaveBeenCalledWith({ durationTargetMinutes: 120, trainingCountTarget: 5 }));
+  });
+
+  it('renders insights empty states and retries a failed request', async () => {
+    mockApi.getInsights.mockReset();
+    mockApi.getInsights.mockRejectedValueOnce(new Error('洞察暂不可用')).mockResolvedValue({
+      ...insights,
+      trainingTypeDistribution: [], abilityTrends: [],
+      weaknessAnalysis: { sampleCount: 1, minimumSampleCount: 3, reliable: false }, weaknesses: [], recommendations: [],
+    });
+    const view = await render(<Insights onBack={jest.fn()} />);
+    await waitFor(() => expect(view.getByText('洞察暂不可用')).toBeTruthy());
+    fireEvent.press(view.getByText('重新加载'));
+    await waitFor(() => expect(view.getByText('本周暂无有效训练记录')).toBeTruthy());
+    expect(view.getByText('完成训练后将显示能力趋势')).toBeTruthy();
+    expect(view.getByText(/至少需要/)).toBeTruthy();
+    view.unmount();
+  });
+
+  it('shows membership plans and synchronizes assistant setting success and failure paths', async () => {
+    const membership = await render(<Membership onBack={jest.fn()} />);
+    expect(membership.getByText('免费版')).toBeTruthy();
+    expect(membership.getByText('特训版')).toBeTruthy();
+    expect(membership.getAllByText('暂未开放')).toHaveLength(2);
+
+    const settings = await render(<AssistantSettings onBack={jest.fn()} />);
+    fireEvent.press(settings.getByText('慢一些'));
+    await waitFor(() => expect(mockAppModel.saveSpeed).toHaveBeenCalledWith('慢一些'));
+    mockAppModel.saveLevel.mockRejectedValueOnce(new Error('网络中断'));
+    fireEvent.press(settings.getByText('可以简单交流'));
+    await waitFor(() => expect(Alert.alert).toHaveBeenCalledWith('设置保存失败', '网络中断'));
+  });
+
+  it('updates account nickname, reports password validation, and signs out after a password change', async () => {
+    const logout = jest.fn().mockResolvedValue(undefined);
+    const view = await render(<AccountSettings onBack={jest.fn()} onLogout={logout} />);
+    fireEvent.press(view.getByText('展示用户名'));
+    await waitFor(() => expect(view.getByText('修改用户名')).toBeTruthy());
+    fireEvent.press(view.getByText('保存用户名'));
+    await waitFor(() => expect(mockApi.updateNickname).toHaveBeenCalledWith('Ada'));
+    expect(mockAppModel.setNickname).toHaveBeenCalledWith('Grace');
+
+    fireEvent.press(view.getByText('登录密码'));
+    await waitFor(() => expect(view.getByText('修改密码')).toBeTruthy());
+    fireEvent.press(view.getByText('确认修改'));
+    await waitFor(() => expect(view.getByText('密码长度需为 6 到 72 位')).toBeTruthy());
+    fireEvent.press(view.getByText('退出当前账号'));
+    expect(logout).toHaveBeenCalled();
+  });
+
+  it('loads an article and renders its refreshed timestamp and body', async () => {
+    mockApi.getHelpArticle.mockReset();
+    mockApi.getHelpArticle.mockResolvedValue({ id: 'password', categoryId: 'account', title: '如何修改密码', summary: '在账号设置中修改。', updatedAt: '2026-08-10' });
+    const article = await render(<HelpArticle articleId="password" onBack={jest.fn()} />);
+    await waitFor(() => expect(mockApi.getHelpArticle).toHaveBeenCalledWith('password'));
+    await waitFor(() => expect(article.getByText('如何修改密码')).toBeTruthy());
+    expect(article.getByText(/更新时间：2026-08-10/)).toBeTruthy();
+    expect(article.getByText('在账号设置中修改。')).toBeTruthy();
+  });
+
+  it('loads help center and category content and opens navigation targets', async () => {
+    const openCategory = jest.fn();
+    const center = await render(<HelpCenter onBack={jest.fn()} onOpenCategory={openCategory} />);
+    await waitFor(() => expect(center.getByText('账号问题')).toBeTruthy());
+    fireEvent.press(center.getByLabelText('打开账号问题'));
+    expect(openCategory).toHaveBeenCalledWith('account');
+
+    const openArticle = jest.fn();
+    const category = await render(<HelpCategory categoryId="account" onBack={jest.fn()} onOpenArticle={openArticle} />);
+    await waitFor(() => expect(category.getByText('如何修改密码')).toBeTruthy());
+    fireEvent.press(category.getByLabelText('打开如何修改密码'));
+    expect(openArticle).toHaveBeenCalledWith('password');
+
+  });
+
+
+});

--- a/frontend/mobile/src/screens/__tests__/ProfileScreen.coverage.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ProfileScreen.coverage.test.tsx
@@ -77,6 +77,12 @@ const insights = {
   recommendations: [{ dimension: 'fluency', trainingType: 'FREE_CHAT', reason: '每天练习' }],
 };
 
+const confirmLastLogout = () => {
+  const calls = (Alert.alert as jest.Mock).mock.calls;
+  const actions = calls[calls.length - 1]?.[2] as Array<{ text?: string; onPress?: () => void }> | undefined;
+  actions?.find((action) => action.text === '退出登录')?.onPress?.();
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockApi.getOverview.mockResolvedValue(overview);
@@ -131,7 +137,8 @@ describe('ProfileScreen exported pages', () => {
     expect(view.getByText('用户名需为 1 到 32 个字符')).toBeTruthy();
     await fireEvent.press(view.getByText('取消'));
     await fireEvent.press(view.getByText('退出登录'));
-    expect(onLogout).toHaveBeenCalledTimes(1);
+    confirmLastLogout();
+    await waitFor(() => expect(onLogout).toHaveBeenCalledTimes(1));
     view.unmount();
   });
 
@@ -224,7 +231,8 @@ describe('ProfileScreen exported pages', () => {
     fireEvent.press(view.getByText('确认修改'));
     await waitFor(() => expect(view.getByText('密码长度需为 6 到 72 位')).toBeTruthy());
     fireEvent.press(view.getByText('退出当前账号'));
-    expect(logout).toHaveBeenCalled();
+    confirmLastLogout();
+    await waitFor(() => expect(logout).toHaveBeenCalled());
   });
 
   it('loads an article and renders its refreshed timestamp and body', async () => {

--- a/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/ProfileScreen.test.tsx
@@ -1,7 +1,7 @@
 import { Alert } from 'react-native';
 import { fireEvent, render } from '@testing-library/react-native';
 
-import { CalendarCard, requestLogoutConfirmation } from '../ProfileScreen';
+import { CalendarCard, Membership, requestLogoutConfirmation } from '../ProfileScreen';
 
 const calendarFor = (month: string) => ({
   month,
@@ -65,5 +65,20 @@ describe('requestLogoutConfirmation', () => {
     actions?.find((action) => action.text === '取消')?.onPress?.();
     expect(logout).not.toHaveBeenCalled();
     alert.mockRestore();
+  });
+});
+
+describe('Membership', () => {
+  it('shows the plans without exposing a fake purchase action', async () => {
+    const onBack = jest.fn();
+    const view = await render(<Membership onBack={onBack} />);
+    expect(view.getByText('免费版')).toBeTruthy();
+    expect(view.getByText('专业版')).toBeTruthy();
+    expect(view.getByText('特训版')).toBeTruthy();
+    expect(view.getAllByText('暂未开放')).toHaveLength(2);
+    expect(view.getByRole('button', { name: '当前方案' })).toBeDisabled();
+    await fireEvent.press(view.getByRole('button', { name: '返回' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    view.unmount();
   });
 });

--- a/frontend/mobile/src/screens/__tests__/SpecialtyAssetsScreen.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/SpecialtyAssetsScreen.test.tsx
@@ -1,0 +1,87 @@
+import { fireEvent, render } from '@testing-library/react-native';
+
+import { useRecordingPlayback } from '@/features/ielts/useRecordingPlayback';
+
+import { IeltsAssetReport, InterviewAssetReport } from '../SpecialtyAssetsScreen';
+
+jest.mock('@/features/ielts/useRecordingPlayback', () => ({
+  useRecordingPlayback: jest.fn(),
+}));
+
+const mockedPlayback = jest.mocked(useRecordingPlayback);
+
+describe('specialty asset reports', () => {
+  beforeEach(() => {
+    mockedPlayback.mockReturnValue({
+      playing: false,
+      error: null,
+      canPlay: true,
+      toggle: jest.fn(),
+      stop: jest.fn(),
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('renders the real IELTS report, optional feedback, and recording control', async () => {
+    const toggle = jest.fn();
+    mockedPlayback.mockReturnValue({ playing: false, error: null, canPlay: true, toggle, stop: jest.fn() });
+    const onBack = jest.fn();
+    const screen = await render(
+      <IeltsAssetReport
+        onBack={onBack}
+        record={{
+          id: 'ielts-1', type: '完整模考', title: 'Food', date: '2026-08-24', duration: '14 分钟', result: '6.5',
+          estimatedBand: 6.5, summary: '表达完整。', recordingUrls: ['/recording.wav'],
+          strengths: ['观点清晰'], improvements: ['补充例子'], recommendedExpressions: ['From my perspective'],
+          bandScores: [6, 6.5, 7, 6], scoreReasons: ['衔接自然', '词汇准确', '句式丰富', '发音清楚'],
+        } as never}
+      />,
+    );
+
+    expect(screen.getByText('完整模考 · Food')).toBeTruthy();
+    expect(screen.getByText('6.5')).toBeTruthy();
+    expect(screen.getByText(/观点清晰/)).toBeTruthy();
+    expect(screen.getByText(/From my perspective/)).toBeTruthy();
+    await fireEvent.press(screen.getByRole('button', { name: '播放原始录音' }));
+    expect(toggle).toHaveBeenCalledTimes(1);
+    await fireEvent.press(screen.getByRole('button', { name: '返回' }));
+    expect(onBack).toHaveBeenCalledTimes(1);
+    screen.unmount();
+  });
+
+  it('uses report fallbacks and disables playback when an IELTS record has no audio', async () => {
+    mockedPlayback.mockReturnValue({ playing: false, error: '录音加载失败', canPlay: false, toggle: jest.fn(), stop: jest.fn() });
+    const screen = await render(
+      <IeltsAssetReport
+        onBack={jest.fn()}
+        record={{ id: 'ielts-2', type: 'Part 2', title: '旅行', date: '2026-08-23', duration: '8 分钟', result: '—' } as never}
+      />,
+    );
+
+    expect(screen.getByText('暂无录音')).toBeTruthy();
+    expect(screen.getByText(/本次报告暂无单独保存的优势说明。/)).toBeTruthy();
+    expect(screen.getByText(/本次报告暂无单独保存的改进建议。/)).toBeTruthy();
+    expect(screen.getByText('录音加载失败')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '播放原始录音' })).toBeDisabled();
+    screen.unmount();
+  });
+
+  it('renders interview scores including a missing overall score', async () => {
+    const screen = await render(
+      <InterviewAssetReport
+        onBack={jest.fn()}
+        record={{
+          role: '产品经理', company: 'UniSpeaking', date: '2026-08-22', duration: '22 分钟', score: null,
+          summary: '结构清晰但需量化结果。', scores: [81, 72, 66, 78, 75, 60],
+        }}
+      />,
+    );
+
+    expect(screen.getByText('产品经理')).toBeTruthy();
+    expect(screen.getByText('结构清晰但需量化结果。')).toBeTruthy();
+    expect(screen.getByText('能力 6')).toBeTruthy();
+    expect(screen.getByText('快速复练')).toBeTruthy();
+    screen.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/SpecialtyAssetsTabs.coverage.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/SpecialtyAssetsTabs.coverage.test.tsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockIelts = { historyRecords: [] as any[], settings: { targetScore: 7, latestEstimatedScore: 6.5, currentStreakDays: 3 }, refreshHistory: jest.fn() };
+const mockInterviewService = { listAssets: jest.fn(), getReport: jest.fn() };
+
+jest.mock('@/features/ielts/useIeltsFlowController', () => ({ useIeltsFlowController: () => mockIelts }));
+jest.mock('@/features/ielts/useRecordingPlayback', () => ({ useRecordingPlayback: () => ({ canPlay: true, playing: false, error: null, toggle: jest.fn() }) }));
+jest.mock('@/features/interview/InterviewAssetService', () => ({
+  InterviewAssetService: jest.fn(() => mockInterviewService),
+  InterviewRecordingClient: jest.fn(),
+}));
+jest.mock('@/navigation/specialtyMemory', () => ({ rememberSpecialty: jest.fn() }));
+
+import { SpecialtyAssetsScreen } from '../SpecialtyAssetsScreen';
+
+const baseProps = { onScenes: jest.fn(), onIelts: jest.fn(), onInterview: jest.fn(), onOpenRecord: jest.fn() };
+const ieltsRecords = Array.from({ length: 9 }, (_, index) => ({
+  id: `ielts-${index + 1}`, mode: 'MOCK_TEST', type: '完整模考', title: `IELTS ${index + 1}`,
+  date: `2026-08-${String(index + 10).padStart(2, '0')}`, duration: '12 分钟', result: '6.5', estimatedBand: 6.5,
+  startedAt: `2026-08-${String(index + 10).padStart(2, '0')}T10:00:00.000Z`, endedAt: `2026-08-${String(index + 10).padStart(2, '0')}T10:12:00.000Z`,
+  part: index % 2 ? 'PART_2' : 'PART_1', bandScores: [6, 6.5, 7, 6.5], partEvaluations: [{ part: 'PART_1' }],
+}));
+const interviewAssets = Array.from({ length: 9 }, (_, index) => ({
+  sceneId: `scene-${index + 1}`, jobTitle: `岗位 ${index + 1}`, difficulty: 'STANDARD', practiceCount: index + 1,
+  latestOverallScore: 70 + index, latestPracticedAt: `2026-08-${String(index + 10).padStart(2, '0')}T10:00:00.000Z`, createdAt: '2026-08-01T10:00:00.000Z',
+  latestSessionId: `session-${index + 1}`, latestReportStatus: 'COMPLETED',
+}));
+const report = { status: 'COMPLETED', report: { dimensions: [
+  { dimension: 'FLUENCY', score: 82 }, { dimension: 'PRONUNCIATION_INTELLIGIBILITY', score: 76 },
+  { dimension: 'LOGIC_COHERENCE', score: 70 }, { dimension: 'GRAMMAR_CONTROL', score: 75 }, { dimension: 'VOCABULARY_EXPRESSION', score: 78 },
+] } };
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockIelts.historyRecords = ieltsRecords;
+  mockInterviewService.listAssets.mockResolvedValue(interviewAssets);
+  mockInterviewService.getReport.mockResolvedValue(report);
+});
+
+describe('SpecialtyAssetsScreen tab entries', () => {
+  it('renders IELTS overview and routes to a saved record', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="ielts" tab="overview" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('最近一次完整模考')).toBeTruthy());
+    await fireEvent.press(view.getByText('IELTS 1'));
+    expect(baseProps.onOpenRecord).toHaveBeenCalledWith('ielts-1');
+    view.unmount();
+  });
+
+  it('paginates IELTS history and opens the final record', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="ielts" tab="history" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('9 条')).toBeTruthy());
+    expect(view.getByText('1 / 2')).toBeTruthy();
+    await fireEvent.press(view.getByLabelText('下一页'));
+    await waitFor(() => expect(view.getByText('IELTS 9')).toBeTruthy());
+    await fireEvent.press(view.getByText('IELTS 9'));
+    expect(baseProps.onOpenRecord).toHaveBeenCalledWith('ielts-9');
+    view.unmount();
+  });
+
+  it('renders IELTS trend chart and per-part recommendations', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="ielts" tab="trends" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('模考趋势')).toBeTruthy());
+    expect(view.getByText('四项能力平均分 · 最近 9 次训练')).toBeTruthy();
+    expect(view.getByText('回答长度更稳定')).toBeTruthy();
+    expect(view.getByText('内容组织正在改善')).toBeTruthy();
+    view.unmount();
+  });
+
+  it('renders interview overview with completed report insight and opens an asset', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="interview" tab="overview" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('最近一次完整面试')).toBeTruthy());
+    expect(view.getByText('逻辑连贯')).toBeTruthy();
+    await fireEvent.press(view.getByText('岗位 1'));
+    expect(baseProps.onOpenRecord).toHaveBeenCalledWith('scene-1');
+    view.unmount();
+  });
+
+  it('paginates interview history', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="interview" tab="history" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('9 条')).toBeTruthy());
+    await fireEvent.press(view.getByLabelText('下一页'));
+    await waitFor(() => expect(view.getByText('岗位 9')).toBeTruthy());
+    view.unmount();
+  });
+
+  it('renders interview trends and aggregates completed report dimensions', async () => {
+    const view = await render(<SpecialtyAssetsScreen kind="interview" tab="trends" {...baseProps} />);
+    await waitFor(() => expect(view.getByText('面试评分趋势')).toBeTruthy());
+    expect(view.getByText('五项能力平均表现')).toBeTruthy();
+    expect(view.getByText('岗位覆盖 9 个 · 已完成报告 9 个 · 累计练习 45 次')).toBeTruthy();
+    view.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/SpecialtyFlows.coverage.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/SpecialtyFlows.coverage.test.tsx
@@ -1,0 +1,227 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockIelts = {
+  settingsLoading: false, settings: null, categories: [] as any[], topics: [] as any[], topicsLoading: false, topicsError: null,
+  topicTotal: 0, topicTotalPages: 0, generated: null as any, latestEvaluation: null as any, training: null as any, sessionBusy: false, sessionError: null,
+  loadTopics: jest.fn(), refreshSettings: jest.fn(), finalizeEvaluation: jest.fn(), saveTargetScore: jest.fn(async () => undefined),
+  prepareSession: jest.fn(), formatBand: (value: number) => String(value), practiceTypeLabel: () => '暂无记录',
+};
+const mockSaveLevel = jest.fn(async () => undefined);
+const mockInterviewStart = jest.fn(async () => undefined);
+const mockAppModel: any = { addIeltsRecord: jest.fn(), hasCompletedOnboarding: false, level: 'starter', saveLevel: mockSaveLevel, signOut: jest.fn() };
+const mockIeltsSnapshot: any = { state: 'ready', error: null, userTranscript: '', assistantTranscript: '', transcriptHistory: [], ieltsCompletionReady: false, ieltsDialogueState: null };
+const mockPreparedInterview = {
+  scene: null,
+  material: {
+    jobTitle: '产品经理', otherJobInformation: '', responsibilities: ['负责产品策略'], qualificationRequirements: [],
+    requiredSkills: [], education: [], workExperiences: [], projectExperiences: [], skillsAndAbilities: [], interviewableExperienceClues: [],
+  },
+  jobTitle: '产品经理',
+};
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true, default: { View }, cancelAnimation: jest.fn(),
+    Easing: { cubic: jest.fn(), ease: jest.fn(), linear: jest.fn(), inOut: (value: unknown) => value, out: (value: unknown) => value },
+    interpolate: (_value: number, _input: number[], output: number[]) => output[0], runOnJS: (fn: (...args: unknown[]) => unknown) => fn,
+    useAnimatedStyle: (factory: () => unknown) => factory(), useSharedValue: (value: unknown) => ({ value }),
+    withDelay: (_delay: number, value: unknown) => value, withRepeat: (value: unknown) => value, withTiming: (value: unknown) => value,
+  };
+});
+jest.mock('@/features/ielts/useIeltsFlowController', () => ({ useIeltsFlowController: () => mockIelts }));
+jest.mock('@/features/ielts/useIeltsSession', () => ({
+  useIeltsSession: () => ({
+    snapshot: mockIeltsSnapshot,
+    statusLabel: '可以开始说了', sessionId: 'session-1', end: jest.fn(async () => undefined),
+    waitForTurnEvaluations: jest.fn(async () => undefined), forcePart3Timeout: jest.fn(async () => undefined),
+  }),
+}));
+jest.mock('@/features/interview/useInterviewPreparation', () => ({
+  useInterviewPreparation: () => ({ resumeFileName: null, resumeText: '', resumeMode: 'text', setResumeText: jest.fn(), setResumeMode: jest.fn(), isPreparing: false, error: '材料解析失败', pickResume: jest.fn(), start: mockInterviewStart, confirm: jest.fn() }),
+}));
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => mockAppModel }));
+jest.mock('@/navigation/learningStage', () => ({ useLearningStage: () => ({ setImmersiveLearning: jest.fn() }) }));
+jest.mock('@/navigation/specialtyMemory', () => ({ rememberSpecialty: jest.fn() }));
+jest.mock('react-native-safe-area-context', () => { const { View } = require('react-native'); return { SafeAreaView: View }; });
+
+import { IeltsFlow, InterviewFlow } from '../SpecialtyFlows';
+
+describe('IeltsFlow intake', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIelts.settings = null;
+    mockIelts.settingsLoading = false;
+    mockIelts.topics = [];
+    mockIelts.topicsLoading = false;
+    mockIelts.topicsError = null;
+    mockIelts.topicTotal = 0;
+    mockIelts.topicTotalPages = 0;
+    mockIelts.generated = null;
+    mockIelts.latestEvaluation = null;
+    mockIelts.training = null;
+    mockAppModel.addIeltsRecord = jest.fn();
+  });
+
+  it('persists selected target and language level before opening the IELTS home', async () => {
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    expect(screen.getByText('目标 7.0')).toBeTruthy();
+    await fireEvent.press(screen.getByText('目标 6.5'));
+    await fireEvent.press(screen.getByText('下一步'));
+    await waitFor(() => expect(screen.getByText('可以简单交流')).toBeTruthy());
+    await fireEvent.press(screen.getByText('可以简单交流'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await waitFor(() => expect(mockIelts.saveTargetScore).toHaveBeenCalledWith('6.5'));
+    await waitFor(() => expect(mockSaveLevel).toHaveBeenCalledWith('basic'));
+    await waitFor(() => expect(screen.getByText('完整模拟一场 IELTS 口语考试')).toBeTruthy());
+    screen.unmount();
+  });
+
+  it('shows the settings loading overlay before the first intake choice is available', async () => {
+    mockIelts.settingsLoading = true;
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    expect(screen.getByText('正在读取你的 IELTS 学习设置…')).toBeTruthy();
+    screen.unmount();
+  });
+
+
+  it('moves from home to a topic and examiner, then keeps the chooser open when preparation fails', async () => {
+    mockIelts.topics = [{
+      id: 'topic-1', title: 'Food', categoryLabel: '事物', questionCount: 5,
+      practiceCount: 0, latestPerformanceScore: null, latestPerformanceSummary: null, latestPracticeType: null,
+    }];
+    mockIelts.topicTotal = 1;
+    mockIelts.topicTotalPages = 1;
+    mockIelts.prepareSession.mockRejectedValueOnce(new Error('实时会话不可用'));
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(screen.getByText('下一步'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await waitFor(() => expect(screen.getByText('快速开始训练')).toBeTruthy());
+    await fireEvent.press(screen.getByText('日常问答'));
+    await waitFor(() => expect(screen.getByText('选择一个话题，正式开始后才会由考官揭晓具体问题。')).toBeTruthy());
+    await waitFor(() => expect(mockIelts.loadTopics).toHaveBeenCalledWith('p1', 'ALL', '', 1));
+    await fireEvent.press(screen.getByLabelText('Food，暂无记录'));
+    await waitFor(() => expect(screen.getByText('选择本次考官')).toBeTruthy());
+    await fireEvent.press(screen.getByText('确认考官并开始'));
+    await waitFor(() => expect(mockIelts.prepareSession).toHaveBeenCalledWith(expect.objectContaining({ part: 'p1', topicId: 'topic-1', random: false })));
+    expect(screen.getByText('选择本次考官')).toBeTruthy();
+    screen.unmount();
+  });
+
+  it('opens the Part 1 realtime session after a successful examiner confirmation', async () => {
+    mockIelts.topics = [{ id: 'topic-2', title: 'Work', categoryLabel: '生活', questionCount: 4, practiceCount: 0, latestPerformanceScore: null, latestPerformanceSummary: null, latestPracticeType: null }];
+    mockIelts.topicTotal = 1;
+    mockIelts.topicTotalPages = 1;
+    mockIelts.generated = { ieltsId: 'ielts-2', title: 'Work' };
+    mockIelts.prepareSession.mockResolvedValueOnce(mockIelts.generated);
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(screen.getByText('下一步'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await waitFor(() => expect(screen.getByText('快速开始训练')).toBeTruthy());
+    await fireEvent.press(screen.getByText('日常问答'));
+    await waitFor(() => expect(screen.getByLabelText('Work，暂无记录')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('Work，暂无记录'));
+    await waitFor(() => expect(screen.getByText('选择本次考官')).toBeTruthy());
+    await fireEvent.press(screen.getByText('确认考官并开始'));
+    await waitFor(() => expect(screen.getByLabelText('结束本题并进入下一题')).toBeTruthy());
+    screen.unmount();
+  });
+
+  it('filters, searches, paginates, and starts a random topic without selecting a row', async () => {
+    mockIelts.categories = [{ code: 'LIFE', label: '生活' }];
+    mockIelts.topics = [{
+      id: 'topic-3', title: 'Travel', categoryLabel: '生活', questionCount: 4, practiceCount: 2,
+      latestPerformanceScore: 6.5, latestPerformanceSummary: '回答组织完整，表达自然。', latestPracticeType: 'PART_PRACTICE',
+    }];
+    mockIelts.topicTotal = 12;
+    mockIelts.topicTotalPages = 3;
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(screen.getByText('下一步'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await fireEvent.press(screen.getByText('日常问答'));
+    await waitFor(() => expect(screen.getByLabelText('搜索话题')).toBeTruthy());
+    await fireEvent.press(screen.getAllByText('生活')[0]);
+    await waitFor(() => expect(mockIelts.loadTopics).toHaveBeenCalledWith('p1', 'LIFE', '', 1), { timeout: 800 });
+    await fireEvent.changeText(screen.getByLabelText('搜索话题'), 'travel');
+    await fireEvent.press(screen.getByLabelText('清空搜索'));
+    await fireEvent.press(screen.getByLabelText('第 3 页'));
+    await fireEvent.press(screen.getByLabelText('上一页'));
+    await fireEvent.press(screen.getByLabelText('下一页'));
+    await fireEvent.press(screen.getByLabelText('随机练习'));
+    await waitFor(() => expect(screen.getByText('选择本次考官')).toBeTruthy());
+    screen.unmount();
+  });
+
+  it('shows a completed Part 1 score and records it when returning home', async () => {
+    const addIeltsRecord = jest.fn();
+    mockAppModel.addIeltsRecord = addIeltsRecord;
+    mockIelts.topics = [{ id: 'topic-4', title: 'Music', categoryLabel: '生活', questionCount: 4, practiceCount: 0, latestPerformanceScore: null, latestPerformanceSummary: null, latestPracticeType: null }];
+    mockIelts.topicTotal = 1;
+    mockIelts.topicTotalPages = 1;
+    mockIelts.generated = { ieltsId: 'ielts-4', title: 'Music' };
+    mockIelts.prepareSession.mockResolvedValueOnce(mockIelts.generated);
+    mockIelts.finalizeEvaluation.mockImplementationOnce(async () => {
+      mockIelts.latestEvaluation = {
+        overallBandScore: 7, fluencyCoherenceScore: 7, lexicalResourceScore: 6.5,
+        grammaticalRangeAccuracyScore: 6, pronunciationScore: 7.5, summary: '表现稳定',
+        strengths: ['表达清晰'], improvements: ['增加细节'], recommendedExpressions: ['From my perspective'],
+      };
+    });
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(screen.getByText('下一步'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await fireEvent.press(screen.getByText('日常问答'));
+    await waitFor(() => expect(screen.getByLabelText('Music，暂无记录')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('Music，暂无记录'));
+    await fireEvent.press(screen.getByText('确认考官并开始'));
+    await waitFor(() => expect(screen.getByLabelText('结束本题并进入下一题')).toBeTruthy());
+    await fireEvent.press(screen.getByLabelText('结束本题并进入下一题'));
+    await waitFor(() => expect(screen.getByText('本次专项表现')).toBeTruthy());
+    await fireEvent.press(screen.getByText('返回训练中心'));
+    expect(addIeltsRecord).toHaveBeenCalledWith(expect.objectContaining({ title: 'Music', estimatedBand: 7, type: 'Part 1' }));
+    screen.unmount();
+  });
+
+});
+
+describe('InterviewFlow input', () => {
+  it('collects JD and difficulty, exposes preparation failure, and exits through its header', async () => {
+    const onExit = jest.fn();
+    const screen = await render(<InterviewFlow onExit={onExit} />);
+    expect(screen.getByText('材料解析失败')).toBeTruthy();
+    await fireEvent.changeText(screen.getByLabelText('岗位 JD'), '负责产品策略');
+    await fireEvent.press(screen.getByText('标准'));
+    await fireEvent.press(screen.getByText('整理面试材料'));
+    await waitFor(() => expect(mockInterviewStart).toHaveBeenCalledWith({ jobDescription: '负责产品策略', difficulty: 'standard' }));
+    await fireEvent.press(screen.getByLabelText('退出英文面试'));
+    expect(onExit).toHaveBeenCalledTimes(1);
+    screen.unmount();
+  });
+
+  it('reviews prepared interview material and supports returning to input', async () => {
+    mockInterviewStart.mockImplementationOnce(async () => mockPreparedInterview as any);
+    const screen = await render(<InterviewFlow onExit={jest.fn()} />);
+    await fireEvent.changeText(screen.getByLabelText('岗位 JD'), '负责产品策略');
+    await fireEvent.press(screen.getByText('标准'));
+    await fireEvent.press(screen.getByText('整理面试材料'));
+    await waitFor(() => expect(screen.getByText('确认面试材料')).toBeTruthy());
+    expect(screen.getByText(/请补充：任职要求/)).toBeTruthy();
+    await fireEvent.changeText(screen.getByLabelText('任职要求'), '熟悉用户研究');
+    expect(screen.queryByText(/请补充：任职要求/)).toBeNull();
+    await fireEvent.press(screen.getByText('返回修改输入'));
+    expect(screen.getByText('填写岗位 JD')).toBeTruthy();
+    screen.unmount();
+  });
+
+  it('keeps the IELTS home available when full mock preparation fails', async () => {
+    mockIelts.prepareSession.mockRejectedValueOnce(new Error('模考准备失败'));
+    const screen = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(screen.getByText('下一步'));
+    await fireEvent.press(screen.getByText('进入 IELTS 专项'));
+    await waitFor(() => expect(screen.getByText('开始模考')).toBeTruthy());
+    await fireEvent.press(screen.getByText('开始模考'));
+    await waitFor(() => expect(mockIelts.prepareSession).toHaveBeenCalledWith(expect.objectContaining({ part: 'mock', random: true, topicId: null })));
+    expect(screen.getByText('完整模拟一场 IELTS 口语考试')).toBeTruthy();
+    screen.unmount();
+  });
+});

--- a/frontend/mobile/src/screens/__tests__/SpecialtyFlows.error.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/SpecialtyFlows.error.test.tsx
@@ -1,0 +1,26 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+jest.mock('react-native-reanimated', () => { const { View } = require('react-native'); return { __esModule: true, default: { View }, Easing: { cubic: jest.fn(), ease: jest.fn(), linear: jest.fn(), out: (v: unknown) => v }, interpolate: (_: unknown, _i: number[], o: number[]) => o[0], useAnimatedStyle: (f: () => unknown) => f(), useSharedValue: (v: unknown) => ({ value: v }), withTiming: (_: unknown, v: unknown) => v, runOnJS: (f: unknown) => f }; });
+const mockController: any = {
+  settingsLoading: false, settings: null, categories: [], topics: [], topicsLoading: false, topicsError: '题库服务不可用', topicTotal: 0, topicTotalPages: 1, generated: null, sessionBusy: false, sessionError: null,
+  loadTopics: jest.fn(), refreshSettings: jest.fn(), finalizeEvaluation: jest.fn(), saveTargetScore: jest.fn(async () => undefined), prepareSession: jest.fn(), formatBand: (v: number) => String(v), practiceTypeLabel: () => '暂无记录',
+};
+jest.mock('@/features/ielts/useIeltsFlowController', () => ({ useIeltsFlowController: () => mockController }));
+jest.mock('@/features/ielts/useIeltsSession', () => ({ useIeltsSession: () => ({ snapshot: { state: 'ready', error: null, userTranscript: '', assistantTranscript: '', transcriptHistory: [] }, statusLabel: 'ready', sessionId: 's', end: jest.fn(), waitForTurnEvaluations: jest.fn(), forcePart3Timeout: jest.fn() }) }));
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => ({ level: 'starter', hasCompletedOnboarding: false, saveLevel: jest.fn(), addIeltsRecord: jest.fn() }) }));
+jest.mock('@/navigation/learningStage', () => ({ useLearningStage: () => ({ setImmersiveLearning: jest.fn() }) }));
+jest.mock('@/navigation/specialtyMemory', () => ({ rememberSpecialty: jest.fn() }));
+jest.mock('@/features/interview/useInterviewPreparation', () => ({ useInterviewPreparation: () => ({ resumeFileName: null, resumeText: '', resumeMode: 'text', setResumeText: jest.fn(), setResumeMode: jest.fn(), isPreparing: false, error: null, pickResume: jest.fn(), start: jest.fn(), confirm: jest.fn() }) }));
+jest.mock('react-native-safe-area-context', () => { const { View } = require('react-native'); return { SafeAreaView: View }; });
+
+import { IeltsFlow } from '../SpecialtyFlows';
+
+it('keeps the topic chooser visible and reports backend topic errors', async () => {
+  const view = await render(<IeltsFlow onExit={jest.fn()} />);
+  await fireEvent.press(view.getByText('下一步'));
+  await fireEvent.press(view.getByText('可以简单交流'));
+  await fireEvent.press(view.getByText('进入 IELTS 专项'));
+  await fireEvent.press(view.getByText('日常问答'));
+  await waitFor(() => expect(view.getByText('题库服务不可用')).toBeTruthy());
+  view.unmount();
+});

--- a/frontend/mobile/src/screens/__tests__/SpecialtyFlows.states.test.tsx
+++ b/frontend/mobile/src/screens/__tests__/SpecialtyFlows.states.test.tsx
@@ -1,0 +1,32 @@
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+
+const mockIelts: any = {
+  settingsLoading: false, settings: null, categories: [], topics: [], topicsLoading: true, topicsError: null,
+  topicTotal: 0, topicTotalPages: 1, generated: null, sessionBusy: false, sessionError: null,
+  loadTopics: jest.fn(), refreshSettings: jest.fn(), finalizeEvaluation: jest.fn(), saveTargetScore: jest.fn(async () => undefined),
+  prepareSession: jest.fn(), formatBand: (value: number) => String(value), practiceTypeLabel: () => '暂无记录',
+};
+jest.mock('react-native-reanimated', () => { const { View } = require('react-native'); return { __esModule: true, default: { View }, Easing: { cubic: jest.fn(), ease: jest.fn(), linear: jest.fn(), out: (v: unknown) => v }, interpolate: (_: unknown, _i: number[], o: number[]) => o[0], useAnimatedStyle: (f: () => unknown) => f(), useSharedValue: (v: unknown) => ({ value: v }), withTiming: (_: unknown, v: unknown) => v, runOnJS: (f: unknown) => f }; });
+jest.mock('@/features/ielts/useIeltsFlowController', () => ({ useIeltsFlowController: () => mockIelts }));
+jest.mock('@/features/ielts/useIeltsSession', () => ({ useIeltsSession: () => ({ snapshot: { state: 'ready', error: null, userTranscript: '', assistantTranscript: '', transcriptHistory: [] }, statusLabel: '可以开始说了', sessionId: 's', end: jest.fn(async () => undefined), waitForTurnEvaluations: jest.fn(async () => undefined), forcePart3Timeout: jest.fn(async () => undefined) }) }));
+jest.mock('@/features/interview/useInterviewPreparation', () => ({ useInterviewPreparation: () => ({ resumeFileName: null, resumeText: '', resumeMode: 'text', setResumeText: jest.fn(), setResumeMode: jest.fn(), isPreparing: false, error: null, pickResume: jest.fn(), start: jest.fn(), confirm: jest.fn() }) }));
+jest.mock('@/features/interview/useInterviewSession', () => ({ createInterviewApi: jest.fn(() => ({})), useInterviewSession: () => ({ state: 'starting', sessionId: null, elapsed: 2, userMuted: false, error: null, interviewState: { currentTopic: '自我介绍' }, currentQuestion: '请介绍自己', end: jest.fn(async () => undefined), setMuted: jest.fn() }) }));
+jest.mock('@/model/AppModel', () => ({ useAppModel: () => ({ addIeltsRecord: jest.fn(), hasCompletedOnboarding: false, level: 'starter', saveLevel: jest.fn(), teacher: { voiceId: 'Harvey', name: 'Sophia', image: 1 } }) }));
+jest.mock('@/navigation/learningStage', () => ({ useLearningStage: () => ({ setImmersiveLearning: jest.fn() }) }));
+jest.mock('@/navigation/specialtyMemory', () => ({ rememberSpecialty: jest.fn() }));
+jest.mock('react-native-safe-area-context', () => { const { View } = require('react-native'); return { SafeAreaView: View }; });
+
+import { IeltsFlow, InterviewFlow } from '../SpecialtyFlows';
+
+describe('IELTS topic state presentation', () => {
+  it('renders loading and empty/error topic states after entering a part', async () => {
+    const loading = await render(<IeltsFlow onExit={jest.fn()} />);
+    await fireEvent.press(loading.getByText('下一步'));
+    await fireEvent.press(loading.getByText('可以简单交流'));
+    await fireEvent.press(loading.getByText('进入 IELTS 专项'));
+    await fireEvent.press(loading.getByText('日常问答'));
+    await waitFor(() => expect(loading.getByText('正在读取题库…')).toBeTruthy());
+    loading.unmount();
+  });
+
+});


### PR DESCRIPTION
## Summary

- Add an independent Jest coverage gate for `frontend/mobile`
- Enforce 80% global line coverage
- Add mobile LCOV/JSON coverage artifacts in CI
- Add a dedicated main-branch Codecov workflow with `mobile` flag
- Add the mobile coverage badge and CI documentation
- Update coverage tests after rebasing onto the latest upstream

## Validation

- `npx tsc --noEmit --pretty false`
- `npm run test:ci`
  - 83 test suites passed
  - 356 tests passed
  - Lines: 80.78%
- `EXPO_OFFLINE=1 npx expo export --platform web`

## Scope

This PR only changes mobile coverage, tests, CI configuration, and related documentation. Backend, Web, and OCR implementation are not modified.