### PR TITLE
ci: preserve backend and mobile Codecov coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - backend/**
       - .github/workflows/coverage.yml
+      - codecov.yml
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/mobile-coverage.yml
+++ b/.github/workflows/mobile-coverage.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - frontend/mobile/**
       - .github/workflows/mobile-coverage.yml
+      - codecov.yml
   workflow_dispatch:
 
 permissions:

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+flags:
+  backend:
+    paths:
+      - backend/**
+    carryforward: true
+
+  mobile:
+    paths:
+      - frontend/mobile/src/**
+    carryforward: true


### PR DESCRIPTION
## Summary

- Add Codecov carryforward configuration for `backend` and `mobile`
- Preserve each platform’s latest coverage when the other platform changes
- Trigger both coverage workflows when Codecov configuration changes
- Keep backend and mobile coverage fully independent

## Validation

- Codecov YAML validation passed
- Git diff check passed
- No application source code changed

## Expected behavior

- Backend-only changes refresh backend coverage
- Mobile-only changes refresh mobile coverage
- The unchanged platform keeps its latest successful coverage report
- README backend and mobile badges remain independently visible