### PR TITLE
feat(web): adapt authentication pages for mobile browsers

### DIFF
--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -15,6 +15,7 @@
     "check:profile-overview": "node scripts/check-profile-overview-refresh.mjs",
     "check:feedback-invitation": "node scripts/check-feedback-invitation.mjs",
     "check:realtime-events": "node scripts/check-realtime-events.mjs",
+    "check:mobile-responsive": "node scripts/check-mobile-responsive.mjs",
     "check:routes": "node scripts/check-routes.mjs",
     "generate:teacher-previews": "node scripts/generate-teacher-previews.mjs",
     "preview": "vite preview"

--- a/frontend/web/scripts/check-mobile-responsive.mjs
+++ b/frontend/web/scripts/check-mobile-responsive.mjs
@@ -1,0 +1,13 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+const stylesSource = await readFile(new URL("../src/common/styles.css", import.meta.url), "utf8");
+
+assert.match(stylesSource, /@media \(max-width: 760px\)[\s\S]*?\.auth-layout \{[\s\S]*?grid-template-columns: 1fr;/, "Authentication must collapse to one column on mobile");
+assert.match(stylesSource, /\.auth-panel \{[\s\S]*?width: min\(100%, 520px\);/, "Authentication panel must fit narrow screens");
+assert.match(stylesSource, /\.auth-panel input \{[\s\S]*?font-size: 16px;/, "Authentication inputs must avoid mobile browser zoom");
+assert.match(stylesSource, /env\(safe-area-inset-bottom/, "Authentication must respect the device safe area");
+assert.doesNotMatch(stylesSource, /\.mobile-tabbar/, "Authenticated application navigation must remain desktop-only");
+assert.doesNotMatch(stylesSource, /Phase-two mobile web/, "Authenticated personal pages must not have dedicated mobile overrides");
+
+console.log("Mobile authentication responsive contract passed: 6 assertions");

--- a/frontend/web/src/common/styles.css
+++ b/frontend/web/src/common/styles.css
@@ -3873,3 +3873,40 @@ button.ielts-training-cta:not(:disabled) svg { color: #fff !important; }
   .interview-assets-layout > article > header { align-items: flex-start; flex-direction: column; gap: 14px; }
   .interview-assets-report { grid-template-columns: 1fr; }
 }
+
+/* Mobile authentication only */
+@media (max-width: 760px) {
+  #root { min-height: 100dvh; }
+
+  .auth-layout {
+    min-height: 100vh;
+    min-height: 100dvh;
+    grid-template-columns: 1fr;
+  }
+  .auth-layout__aside {
+    min-height: 72px;
+    padding: 16px 20px;
+    justify-content: center;
+  }
+  .auth-layout__aside > div:not(.brand),
+  .auth-layout__aside > p { display: none; }
+  .auth-layout__aside .brand { gap: 9px; }
+  .auth-layout__aside .brand__mark { width: 38px; height: 38px; border-radius: 10px; }
+  .auth-layout__aside .brand__wordmark { width: 128px; }
+  .auth-panel {
+    width: min(100%, 520px);
+    margin: 0 auto;
+    padding: 34px 20px calc(42px + env(safe-area-inset-bottom, 0px));
+  }
+  .back-link { min-height: 44px; margin-bottom: 32px; }
+  .auth-panel__heading h1,
+  .verify-panel h1 { font-size: 36px; }
+  .auth-panel form { margin-top: 30px; gap: 18px; }
+  .auth-panel input { min-height: 52px; font-size: 16px; }
+  .auth-help { align-items: flex-start; flex-direction: column; }
+  .verify-panel { padding-top: 48px; }
+}
+
+@media (max-width: 380px) {
+  .auth-panel { padding-inline: 16px; }
+}


### PR DESCRIPTION
## Summary

- adapt Web registration, login, verification, and password recovery screens for mobile browser widths
- collapse the authentication layout to one column and preserve mobile safe-area spacing
- keep authentication inputs at 16px to prevent automatic browser zoom
- leave all authenticated application pages on their existing desktop-only layout
- add a focused responsive contract check for the authentication flow

## Verification

- mobile authentication responsive contract: 6 assertions passed
- route contract: 77 assertions passed
- Web authentication tests: 22 passed
- Web production build passed
- browser checks passed at 390px and 1440px without horizontal overflow