### PR TITLE
feat(ci):为 Web 前端建立自动化测试并设置 85% 覆盖率门禁  

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -115,6 +115,11 @@ jobs:
               frontend/web/package.json|frontend/web/package-lock.json)
                 dependencies=true
                 ;;
+              codecov.yml|scripts/check-codecov-coverage.py)
+                backend=true
+                frontend=true
+                mobile=true
+                ;;
               frontend/mobile/package.json|frontend/mobile/package-lock.json)
                 dependencies=true
                 ;;
@@ -370,7 +375,7 @@ jobs:
           retention-days: 30
 
   frontend:
-    name: Web 前端依赖与生产构建
+    name: Web 前端测试、覆盖率与生产构建
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -399,6 +404,30 @@ jobs:
 
       - name: 检查 Realtime 事件
         run: npm run check:realtime-events
+
+      - name: 运行 Web 静态检查
+        run: npm run test:checks
+
+      - name: 生成 Web LCOV 覆盖率
+        run: npm run test:coverage
+
+      - name: 检查 Web Codecov 口径覆盖率
+        run: |
+          python3 ../../scripts/check-codecov-coverage.py \
+            --format lcov \
+            --input coverage/lcov.info \
+            --minimum 85
+
+      - name: 保存 Web 覆盖率报告
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: web-coverage-${{ inputs.pr_number }}
+          path: |
+            frontend/web/coverage/lcov.info
+            frontend/web/coverage/coverage-summary.json
+          if-no-files-found: warn
+          retention-days: 30
 
       - name: 生产构建
         run: npm run build

--- a/.github/workflows/web-coverage.yml
+++ b/.github/workflows/web-coverage.yml
@@ -1,0 +1,79 @@
+name: Web Coverage
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - frontend/web/**
+      - .github/workflows/ci-core.yml
+      - .github/workflows/web-coverage.yml
+      - codecov.yml
+      - scripts/check-codecov-coverage.py
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: web-coverage-main
+  cancel-in-progress: true
+
+jobs:
+  web:
+    name: 生成并发布 Web 覆盖率
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        working-directory: frontend/web
+    steps:
+      - name: 检出 main
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+
+      - name: 配置 Node.js 22
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "22"
+          cache: npm
+          cache-dependency-path: frontend/web/package-lock.json
+
+      - name: 安装锁定依赖
+        run: npm ci
+
+      - name: 运行 Web 现有测试
+        run: npm run test:checks
+
+      - name: 生成 Web LCOV 覆盖率
+        run: npm run test:coverage
+
+      - name: 检查 Web Codecov 口径覆盖率
+        run: |
+          python3 ../../scripts/check-codecov-coverage.py \
+            --format lcov \
+            --input coverage/lcov.info \
+            --minimum 85
+
+      - name: 上传 Web LCOV 到 Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
+        with:
+          use_oidc: true
+          files: frontend/web/coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
+          flags: web
+          name: web-unit
+
+      - name: 保存 Web 覆盖率报告
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: web-main-coverage
+          path: |
+            frontend/web/coverage/lcov.info
+            frontend/web/coverage/coverage-summary.json
+          if-no-files-found: warn
+          retention-days: 30

--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@
 
 移动端： [![移动端覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=mobile)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
 
-后端与移动端 Codecov 使用独立的 `backend`、`mobile` flag，分别统计后端 JaCoCo 合并测试和移动端 Jest 报告；覆盖率门禁按 Codecov 的 `hits / (hits + partials + misses)` 口径计算，两个 flag 均要求超过 90%。
+Web 前端： [![Web 覆盖率](https://codecov.io/gh/1024XEngineer/UniSpeaking/branch/main/graph/badge.svg?flag=web)](https://codecov.io/gh/1024XEngineer/UniSpeaking)
+
+后端、移动端与 Web 使用独立的 `backend`、`mobile`、`web` Codecov flag；覆盖率门禁按 Codecov 的 `hits / (hits + partials + misses)` 口径计算，后端与移动端要求至少 90%，Web 要求至少 85%。Web 使用 Vitest + V8 生成覆盖率报告。
 
 UniSpeaking 是一个面向英语口语训练的 AI 实时陪练系统。仓库包含 Spring Boot 后端、
 React Web 客户端、React Native 移动端、PostgreSQL 数据模型以及 Docker/Nginx 部署配置。
@@ -343,6 +345,19 @@ cd frontend/web
 npm run build
 npm run check:routes
 npm run check:realtime-events
+```
+
+Web 覆盖率检查：
+
+```bash
+cd frontend/web
+npm ci
+npm run test:checks
+npm run test:coverage
+python3 ../../scripts/check-codecov-coverage.py \
+  --format lcov \
+  --input coverage/lcov.info \
+  --minimum 85
 ```
 
 移动端检查：

--- a/codecov.yml
+++ b/codecov.yml
@@ -9,6 +9,11 @@ flags:
       - frontend/mobile/src/**
     carryforward: true
 
+  web:
+    paths:
+      - frontend/web/src/**
+    carryforward: true
+
 coverage:
   status:
     project:
@@ -23,5 +28,10 @@ coverage:
         threshold: 0%
         flags:
           - mobile
+      web:
+        target: 85%
+        threshold: 0%
+        flags:
+          - web
     patch:
       default: off

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -18,6 +18,7 @@
 | `cd-verify.yml` | 仅在 Fork 的 CD 分支构建并推送隔离验证镜像，不连接生产服务器 |
 | `coverage.yml` | `main` 后端变更后生成 JaCoCo 聚合报告并通过 OIDC 上传到 Codecov |
 | `mobile-coverage.yml` | `main` 移动端变更后运行 Jest 覆盖率门禁并通过 OIDC 上传到 Codecov |
+| `web-coverage.yml` | `main` Web 变更后运行 Vitest 覆盖率门禁并通过 OIDC 上传到 Codecov |
 
 同一 PR 的核心检查使用 `ci-pr-<PR 编号>` 并发组。出现新提交或 `main` 更新时，旧检查
 会自动取消；不同 PR 可以并行执行。PR 工作流只使用只读权限，不接收仓库 Secrets。
@@ -26,7 +27,7 @@
 工作流文件本身发生变化时会强制运行全部检查。其他变更按路径执行：
 
 - 后端：编译、单元测试、打包、PostgreSQL/Redis 集成测试、Codecov partial-line 口径 91% 门禁和镜像构建；
-- Web 前端：Node.js 22、`npm ci`、路由与 Realtime 事件检查、生产构建和镜像构建；
+- Web 前端：Node.js 22、`npm ci`、现有 Node 测试、Vitest 测试、LCOV 生成、Codecov partial-line 口径 85% 门禁、路由与 Realtime 事件检查、生产构建和镜像构建；覆盖率检查在现有 `frontend` job 中执行，因此由 `required` 汇总任务阻断合并；
 - Admin：Admin 变更识别、Docker 镜像构建和静态服务检查；
 - 移动端：Node.js 22、`npm ci`、TypeScript 检查、Jest 报告与 Codecov partial-line 口径 91% 门禁和 Expo Web 静态导出；
 - Compose、环境模板或 Nginx：配置解析或 `nginx -t`；
@@ -75,6 +76,19 @@ npm run check:realtime-events
 npm run build
 ```
 
+Web 覆盖率命令：
+
+```bash
+cd frontend/web
+npm ci
+npm run test:checks
+npm run test:coverage
+python3 ../../scripts/check-codecov-coverage.py \
+  --format lcov \
+  --input coverage/lcov.info \
+  --minimum 85
+```
+
 移动端：
 
 ```bash
@@ -97,13 +111,14 @@ GitHub Actions 在对应运行的 Artifacts 中保留以下内容 30 天：
 - Failsafe 集成测试报告和必要日志；
 - JaCoCo 单元、集成及合并覆盖率报告。
 - 移动端 Jest 的 LCOV 与 JSON summary 覆盖率报告。
+- Web 的 LCOV 与 JSON summary 覆盖率报告。
 
 PR 不上传后端 JAR、前端 `dist` 或 Docker 镜像。用于在任务间合并覆盖率和校验 merge SHA
 的临时数据只保留 1 天。
 
-根目录 README 显示 `main` 分支的后端测试状态、后端 Codecov 覆盖率和移动端 Codecov 覆盖率。覆盖率合并单元测试
+根目录 README 显示 `main` 分支的后端测试状态、后端 Codecov 覆盖率、移动端 Codecov 覆盖率和 Web Codecov 覆盖率。覆盖率合并单元测试
 及 PostgreSQL、Redis 集成测试所执行的后端 Java 代码；它不是数据库表或 SQL 语句的
-覆盖率。Web 前端尚未建立自动化测试覆盖率，因此 README 不显示 Web 覆盖率；移动端和后端使用独立的 `backend`、`mobile` flag，并以 `scripts/check-codecov-coverage.py` 按命中、partial、未命中三类计算 91% 本地门禁。普通 Jest/JaCoCo 行覆盖率仅作为辅助报告。
+覆盖率。后端、移动端和 Web 使用独立的 `backend`、`mobile`、`web` flag；Web 本地门禁以 `scripts/check-codecov-coverage.py` 的 Codecov partial-line 口径要求至少 85%，后端与移动端保持现有本地门禁。Web 使用 Vitest + V8 生成 LCOV；普通 Jest/JaCoCo/LCOV 行覆盖率仅作为辅助报告，实际门禁以该脚本的 Codecov 口径为准。
 `coverage.yml` 上传的是 JaCoCo 聚合报告
 `backend/unispeaking-server/target/site/jacoco-aggregate/jacoco.xml`，同时使用
 `backend` flag 标记报告。上传通过 GitHub OIDC 鉴权，不需要配置 `CODECOV_TOKEN`。
@@ -113,9 +128,13 @@ PR 不上传后端 JAR、前端 `dist` 或 Docker 镜像。用于在任务间合
 `src/app/**` 装配层、测试文件和声明文件；上传通过 GitHub OIDC 鉴权，不需要配置
 `CODECOV_TOKEN`。首次上传成功前，根 README 的移动端徽章可能显示 `unknown`。
 
+`web-coverage.yml` 上传的是 `frontend/web/coverage/lcov.info`，使用 `web` flag；PR 中同样的
+覆盖率检查在 `ci-core.yml` 的现有 `frontend` job 内执行，并由 `required` 汇总任务纳入必要检查。
+首次上传成功前，根 README 的 Web 徽章可能显示 `unknown`。
+
 首次启用前，仓库管理员需要在 Codecov 中安装 GitHub App 并激活
 `1024XEngineer/UniSpeaking`。工作流合入 `main` 后会自动进行首次上传；也可以在
-Actions 的 Coverage 或 Mobile Coverage 工作流中手动运行。首次上传成功前，README 徽章可能显示
+Actions 的 `Coverage`、`Mobile Coverage` 或 `Web Coverage` 工作流中手动运行。首次上传成功前，README 徽章可能显示
 `unknown`。
 
 ## 首次启用与分支保护

--- a/frontend/web/package-lock.json
+++ b/frontend/web/package-lock.json
@@ -10,12 +10,56 @@
       "dependencies": {
         "@phosphor-icons/react": "^2.1.10",
         "@sentry/react": "^10.70.0",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "5.0.4",
+        "@vitest/coverage-v8": "^3.2.4",
+        "jsdom": "^26.1.0",
         "lucide-react": "^1.25.0",
         "react": "19.2.0",
         "react-dom": "19.2.0",
-        "vite": "6.4.3"
+        "vite": "6.4.3",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.7",
@@ -235,6 +279,15 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.29.7",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
@@ -278,6 +331,125 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -696,6 +868,32 @@
         "node": ">=18"
       }
     },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -752,6 +950,16 @@
       "peerDependencies": {
         "react": ">= 16.8",
         "react-dom": ">= 16.8"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1230,6 +1438,98 @@
         "node": ">=18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.6",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.6.tgz",
+      "integrity": "sha512-Jbs9FpkkIDw8FgSc6kOVsOv8JuuqGAL7J4X1oot77JxAoDlkNn2GRkd0aYRVuQ+pVQAiHWVkE4rX/dkF5fBiCw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1271,6 +1571,22 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1297,6 +1613,222 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-3.2.7.tgz",
+      "integrity": "sha512-NEGWJS2XNu2PfRLQwOO3CTKj1tTETxNBdk454vDxVBhxJYhPaA/eS0nAI0c+1El1P7a60z8+i+ZrQoGESweGKg==",
+      "license": "MIT",
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^1.0.2",
+        "ast-v8-to-istanbul": "^0.3.3",
+        "debug": "^4.4.1",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.17",
+        "magicast": "^0.3.5",
+        "std-env": "^3.9.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "3.2.7",
+        "vitest": "3.2.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "0.3.12",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-0.3.12.tgz",
+      "integrity": "sha512-BRRC8VRZY2R4Z4lFIL35MwNXmwVqBityvOIwETtsCSwvjl0IdgFsy9NhdaA6j74nUdtJJlIypeRhpDam19Wq3g==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.43.tgz",
@@ -1307,6 +1839,18 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1342,6 +1886,15 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -1362,11 +1915,100 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "license": "MIT"
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -1385,11 +2027,72 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.393",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
       "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "license": "ISC"
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.25.12",
@@ -1441,6 +2144,24 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1456,6 +2177,22 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "license": "ISC",
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/fsevents": {
@@ -1481,11 +2218,261 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "license": "ISC",
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "license": "MIT"
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "26.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
+      "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.2.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.5.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.16",
+        "parse5": "^7.2.1",
+        "rrweb-cssom": "^0.8.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.1.1",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.1.1",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -1511,6 +2498,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1527,6 +2520,96 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.8"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/ms": {
@@ -1560,6 +2643,76 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "license": "MIT"
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "license": "BlueOak-1.0.0"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/path-scurry/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "license": "ISC"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -1608,6 +2761,30 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "19.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.0.tgz",
@@ -1629,6 +2806,13 @@
         "react": "^19.2.0"
       }
     },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1636,6 +2820,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/rollup": {
@@ -1682,6 +2879,30 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -1697,6 +2918,45 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "license": "ISC"
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -1705,6 +2965,182 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "license": "MIT"
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi/node_modules/ansi-regex": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.3.0.tgz",
+      "integrity": "sha512-WpDfL7NO6j7tH88IDBNVdUJxDh9nmCteAVW9dsep846XdwF4naCBK+/tGLX3KJgcpgMRXCFlTM2hKGoK9FsdrQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "license": "ISC",
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "license": "MIT"
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
@@ -1720,6 +3156,75 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1825,6 +3330,317 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/frontend/web/package.json
+++ b/frontend/web/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
+    "test": "vitest run",
+    "test:coverage": "vitest run --coverage",
+    "test:checks": "npm run check:routes && npm run check:realtime-events && npm run test:auth && npm run test:analytics && npm run test:telemetry && npm run test:assets && npm run test:pronunciation && npm run check:call-timer && npm run check:profile-overview && npm run check:feedback-invitation && npm run check:mobile-responsive",
     "test:auth": "node --test scripts/check-auth-contract.mjs scripts/check-captcha-config.mjs scripts/check-api-client-auth.mjs",
     "test:analytics": "node --test scripts/check-umami-config.mjs scripts/check-analytics-client.mjs scripts/check-analytics-wiring.mjs",
     "test:telemetry": "node --test scripts/check-telemetry.mjs",
@@ -27,6 +30,12 @@
     "lucide-react": "^1.25.0",
     "react": "19.2.0",
     "react-dom": "19.2.0",
-    "vite": "6.4.3"
+    "vite": "6.4.3",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
+    "@vitest/coverage-v8": "^3.2.4",
+    "jsdom": "^26.1.0",
+    "vitest": "^3.2.4"
   }
 }

--- a/frontend/web/src/__tests__/HumanVerification.test.jsx
+++ b/frontend/web/src/__tests__/HumanVerification.test.jsx
@@ -1,0 +1,54 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { HumanVerification } from "../HumanVerification.jsx";
+
+afterEach(() => {
+  cleanup();
+  delete window.initAliyunCaptcha;
+  delete window.AliyunCaptchaConfig;
+  document.head.querySelectorAll("script").forEach((script) => script.remove());
+  vi.unstubAllEnvs();
+});
+
+describe("HumanVerification", () => {
+  it("does nothing in development mode", () => {
+    render(<HumanVerification buttonId="signup" onVerify={vi.fn()} />);
+    expect(window.initAliyunCaptcha).toBeUndefined();
+    expect(document.head.querySelector("script")).toBeNull();
+  });
+
+  it("initializes an existing captcha SDK and forwards callback results", async () => {
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_AUTH_CAPTCHA_PROVIDER", "aliyun");
+    vi.stubEnv("VITE_ALIYUN_CAPTCHA_SCENE_ID", "scene-test");
+    const onVerify = vi.fn(async (params) => ({ captchaResult: params.token === "ok", bizResult: true }));
+    const instance = { destroy: vi.fn() };
+    let config;
+    window.initAliyunCaptcha = vi.fn((next) => {
+      config = next;
+      next.getInstance(instance);
+    });
+    const { unmount } = render(<HumanVerification buttonId="signup" onVerify={onVerify} />);
+    expect(window.AliyunCaptchaConfig).toMatchObject({ region: "cn" });
+    expect(window.initAliyunCaptcha).toHaveBeenCalledWith(expect.objectContaining({ SceneId: "scene-test", button: "#signup" }));
+    await expect(config.captchaVerifyCallback({ token: "ok" })).resolves.toEqual({ captchaResult: true, bizResult: true });
+    await expect(config.captchaVerifyCallback(null)).resolves.toEqual({ captchaResult: false, bizResult: false });
+    unmount();
+    expect(instance.destroy).toHaveBeenCalled();
+  });
+
+  it("loads the captcha script once and initializes on load", () => {
+    vi.stubEnv("DEV", false);
+    vi.stubEnv("VITE_AUTH_CAPTCHA_PROVIDER", "aliyun");
+    const init = vi.fn();
+    window.initAliyunCaptcha = undefined;
+    const { unmount } = render(<HumanVerification buttonId="login" onVerify={vi.fn()} />);
+    const script = document.head.querySelector("script");
+    expect(script.async).toBe(true);
+    expect(script.defer).toBe(true);
+    Object.defineProperty(window, "initAliyunCaptcha", { configurable: true, value: init });
+    script.dispatchEvent(new Event("load"));
+    expect(init).toHaveBeenCalled();
+    unmount();
+  });
+});

--- a/frontend/web/src/__tests__/basic-modules.test.js
+++ b/frontend/web/src/__tests__/basic-modules.test.js
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from "vitest";
+import { resolvePublicCaptchaEnv, getAliyunCaptchaCdnServers, getAliyunCaptchaScriptUrl } from "../captchaConfig.js";
+import { findHelpArticle, getRelatedHelpArticles, searchHelpArticles } from "../component/help/helpUtils.js";
+import { markFeedbackStarted, recordFeedbackPractice } from "../component/help/feedbackInvitation.js";
+import { classifyScoredWord } from "../domain/pronunciationScore.js";
+import { summarizeRtcStats } from "../telemetry/rtcTelemetry.js";
+
+function storage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+    dump: () => Object.fromEntries(values),
+  };
+}
+
+describe("basic web modules", () => {
+  it("resolves public captcha settings without leaking private backend values", () => {
+    const result = resolvePublicCaptchaEnv(
+      { VITE_AUTH_CAPTCHA_PROVIDER: "", VITE_ALIYUN_CAPTCHA_REGION: "cn" },
+      {
+        AUTH_CAPTCHA_PROVIDER: "aliyun",
+        ALIYUN_CAPTCHA_SCENE_ID: "scene-1",
+        ALIYUN_CAPTCHA_ACCESS_KEY_ID: "private",
+      },
+    );
+    expect(result).toMatchObject({
+      VITE_AUTH_CAPTCHA_PROVIDER: "aliyun",
+      VITE_ALIYUN_CAPTCHA_SCENE_ID: "scene-1",
+      VITE_ALIYUN_CAPTCHA_REGION: "cn",
+    });
+    expect(Object.keys(result).some((key) => key.includes("ACCESS_KEY"))).toBe(false);
+    expect(getAliyunCaptchaCdnServers("https://cdn.example.com/")).toEqual(["https://cdn.example.com"]);
+    expect(getAliyunCaptchaScriptUrl(" ")).toMatch(/^https:\/\/o\.alicdn\.com\//);
+  });
+
+  it("searches help content and bounds related results", () => {
+    const article = findHelpArticle("start-free-conversation");
+    expect(article).not.toBeNull();
+    expect(searchHelpArticles("  ")).toEqual([]);
+    expect(searchHelpArticles(article.title.slice(0, 3))).toContainEqual(article);
+    expect(getRelatedHelpArticles(null)).toEqual([]);
+    expect(getRelatedHelpArticles(article, 0)).toEqual([]);
+    expect(getRelatedHelpArticles(article, 1)).toHaveLength(1);
+  });
+
+  it("records invitations once per session and stops after feedback starts", () => {
+    const store = storage();
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "free", sessionId: "s-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "free", sessionId: "s-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "invalid", sessionId: "s-2" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "free", sessionId: "s-2" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "free", sessionId: "s-3" })).toBe(true);
+    expect(markFeedbackStarted(store, "user/1")).toBe(true);
+    expect(recordFeedbackPractice(store, { userId: "user/1", practiceType: "scene", sessionId: "s-4" })).toBe(false);
+  });
+
+  it("classifies strong, weak-form, malformed, and missing pronunciation results", () => {
+    expect(classifyScoredWord("the", { wordScore: 80 })).toBe("is-correct");
+    expect(classifyScoredWord("a", { wordScore: 0, phonemes: [{ expectedPhoneme: "eɪ", actualPhoneme: " Eɪ " }] })).toBe("is-review");
+    expect(classifyScoredWord("a", { wordScore: 0, phonemes: [{ expectedPhoneme: "eɪ", actualPhoneme: "ʌ" }] })).toBe("is-incorrect");
+    expect(classifyScoredWord("contract", null)).toBe("is-incorrect");
+    expect(classifyScoredWord("for", { wordScore: "not-a-number" })).toBe("is-incorrect");
+  });
+
+  it("summarizes RTC stats from selected transport and safe fallbacks", () => {
+    const report = new Map([
+      ["transport", { id: "transport", type: "transport", selectedCandidatePairId: "pair" }],
+      ["pair", { id: "pair", type: "candidate-pair", currentRoundTripTime: 0.08, localCandidateId: "local", remoteCandidateId: "remote", availableOutgoingBitrate: 1000 }],
+      ["local", { id: "local", type: "local-candidate", candidateType: "relay", networkType: "wifi" }],
+      ["remote", { id: "remote", type: "remote-candidate", candidateType: "srflx" }],
+      ["audio", { id: "audio", type: "inbound-rtp", kind: "audio", jitter: 0.01, packetsReceived: 195, packetsLost: 5 }],
+    ]);
+    expect(summarizeRtcStats(report, { packetsReceived: 100, packetsLost: 0 })).toMatchObject({
+      attributes: { rtt_ms: 80, jitter_ms: 10, packet_loss_pct: 5, turn_used: true, local_candidate_type: "relay" },
+      totals: { packetsReceived: 195, packetsLost: 5 },
+    });
+    expect(summarizeRtcStats(null)).toMatchObject({
+      attributes: { packet_loss_pct: 0, local_candidate_type: "unknown", remote_candidate_type: "unknown", turn_used: false },
+      totals: { packetsReceived: 0, packetsLost: 0 },
+    });
+  });
+
+  it("keeps the test environment free of accidental timers", () => {
+    expect(vi.isMockFunction(setTimeout)).toBe(false);
+  });
+});

--- a/frontend/web/src/__tests__/userAuthApi.test.js
+++ b/frontend/web/src/__tests__/userAuthApi.test.js
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  buildAuthApiUrl,
+  issueEmailChallenge,
+  issuePasswordResetChallenge,
+  loginWithPassword,
+  logoutUser,
+  registerWithEmail,
+  resetPasswordWithEmail,
+  UserAuthApiError,
+  validateRegistrationCredentials,
+} from "../userAuthApi.js";
+
+const authHelpers = vi.hoisted(() => ({
+  save: vi.fn(),
+  revoke: vi.fn(),
+  clear: vi.fn(),
+}));
+
+vi.mock("../infrastructure/http/apiClient.js", () => ({
+  saveAuthSession: authHelpers.save,
+  revokeWebSession: authHelpers.revoke,
+  clearAuthSession: authHelpers.clear,
+}));
+
+describe("user auth API", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    authHelpers.save.mockReset();
+    authHelpers.revoke.mockReset();
+    authHelpers.clear.mockReset();
+  });
+
+  it("normalizes URLs and validates registration credentials", () => {
+    expect(buildAuthApiUrl("/api/test", "https://api.example.com/")).toBe("https://api.example.com/api/test");
+    expect(validateRegistrationCredentials("", "long-password-123")).toBe("INVALID_EMAIL");
+    expect(validateRegistrationCredentials("user@example.com", "short")).toBe("WEAK_PASSWORD");
+    expect(validateRegistrationCredentials("user@example.com", "long-password-123", " ")).toBe("INVALID_NICKNAME");
+    expect(validateRegistrationCredentials(" user@example.com ", "long-password-123", "User")).toBeNull();
+  });
+
+  it("sends challenge requests with JSON and maps server errors", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      JSON.stringify({ success: true, data: { challengeId: "challenge-1" } }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    await expect(issueEmailChallenge("user@example.com", "captcha-token")).resolves.toEqual({ challengeId: "challenge-1" });
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/email/challenges", expect.objectContaining({
+      method: "POST",
+      credentials: "include",
+      body: JSON.stringify({ email: "user@example.com", humanVerificationToken: "captcha-token" }),
+    }));
+
+    fetchMock.mockResolvedValueOnce(new Response(
+      JSON.stringify({ success: false, error: { code: "WEAK_PASSWORD", message: "invalid" } }),
+      { status: 400, headers: { "Content-Type": "application/json" } },
+    ));
+    await expect(loginWithPassword("user@example.com", "bad", "captcha-token"))
+      .rejects.toMatchObject({ name: "UserAuthApiError", code: "WEAK_PASSWORD", message: "密码至少需要 12 位。" });
+  });
+
+  it("supports password reset and registration flows", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    fetchMock
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { challengeId: "reset-1" } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { reset: true } }), { status: 200 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ success: true, data: { accessToken: "registered" } }), { status: 200 }));
+
+    await expect(issuePasswordResetChallenge("user@example.com", "human-token")).resolves.toEqual({ challengeId: "reset-1" });
+    await expect(resetPasswordWithEmail({ email: "user@example.com", password: "long-password-123", challengeId: "reset-1", code: "123456" }))
+      .resolves.toEqual({ reset: true });
+    await expect(registerWithEmail({ email: "user@example.com", password: "long-password-123", nickname: "User", challengeId: "challenge-1", code: "654321" }))
+      .resolves.toEqual({ accessToken: "registered" });
+    expect(authHelpers.save).toHaveBeenCalledWith({ accessToken: "registered" });
+    expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
+      "/api/auth/email/password-reset/challenges",
+      "/api/auth/email/password-reset",
+      "/api/auth/email/register/token",
+    ]);
+  });
+
+  it("maps validation, known, unknown, malformed, and empty responses", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+    const response = (body, status = 400, headers = { "Content-Type": "application/json" }) =>
+      new Response(body === null ? null : JSON.stringify(body), { status, headers });
+
+    fetchMock.mockResolvedValueOnce(response({ success: false, error: { code: "VALIDATION_ERROR", message: "invalid password" } }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ code: "VALIDATION_ERROR", message: "密码至少需要 12 位。" });
+    fetchMock.mockResolvedValueOnce(response({ success: false, error: { code: "VALIDATION_ERROR", message: "invalid email" } }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ message: "请输入有效邮箱地址。" });
+    fetchMock.mockResolvedValueOnce(response({ success: false, error: { code: "HUMAN_VERIFICATION_REQUIRED" } }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ message: "请先完成人机验证。" });
+    fetchMock.mockResolvedValueOnce(response({ success: false, error: { code: "UNLISTED", message: "server detail" } }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ code: "UNLISTED", message: "server detail" });
+    fetchMock.mockResolvedValueOnce(response({ error: { code: "IDENTITY_NOT_FOUND" } }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ message: "该邮箱尚未注册，请先创建账号。" });
+    fetchMock.mockResolvedValueOnce(response("not-json", 500, { "Content-Type": "text/plain" }));
+    await expect(issueEmailChallenge("x", "y")).rejects.toMatchObject({ code: "AUTH_REQUEST_FAILED", message: "请求失败，请稍后重试。" });
+    fetchMock.mockResolvedValueOnce(response(null, 204));
+    await expect(issueEmailChallenge("x", "y")).resolves.toBeUndefined();
+    expect(validateRegistrationCredentials("user@example.com", 123)).toBe("WEAK_PASSWORD");
+    expect(validateRegistrationCredentials("user@example.com", "x".repeat(201))).toBe("WEAK_PASSWORD");
+  });
+
+  it("always clears the session when logout succeeds or fails", async () => {
+    authHelpers.revoke.mockResolvedValueOnce(undefined);
+    await expect(logoutUser()).resolves.toBeUndefined();
+    expect(authHelpers.clear).toHaveBeenCalledTimes(1);
+
+    authHelpers.clear.mockClear();
+    authHelpers.revoke.mockRejectedValueOnce(new Error("revoke failed"));
+    await expect(logoutUser()).rejects.toThrow("revoke failed");
+    expect(authHelpers.clear).toHaveBeenCalledTimes(1);
+  });
+
+  it("exposes a typed error for failed auth calls", () => {
+    const error = new UserAuthApiError("CODE", "message");
+    expect(error).toBeInstanceOf(Error);
+    expect(error.name).toBe("UserAuthApiError");
+    expect(error.code).toBe("CODE");
+  });
+});

--- a/frontend/web/src/analytics/__tests__/analytics-foundations.test.js
+++ b/frontend/web/src/analytics/__tests__/analytics-foundations.test.js
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { createActivityTimer } from "../activityTimer.js";
+import { normalizeTrackedPath, pageForPath } from "../pageCatalog.js";
+import { injectUmamiScript, resolveUmamiConfig } from "../umamiConfig.js";
+
+const validEnv = {
+  VITE_UMAMI_ENABLED: "true",
+  VITE_UMAMI_SCRIPT_URL: "https://analytics.example.com/script.js",
+  VITE_UMAMI_WEBSITE_ID: "website-123",
+  VITE_UMAMI_DOMAINS: "example.com,localhost",
+};
+
+describe("analytics foundations", () => {
+  it("maps known pages and protects unknown pages", () => {
+    expect(pageForPath("/interview")).toMatchObject({ pageCode: "interview-training", mode: "INTERVIEW" });
+    expect(pageForPath("/interview/assets/history")).toMatchObject({ pageCode: "interview-assets", assetType: "REPORT" });
+    expect(pageForPath("/ielts")).toMatchObject({ pageCode: "ielts-training", mode: "IELTS" });
+    expect(pageForPath("/ielts/assets/history")).toMatchObject({ pageCode: "ielts-assets", assetType: "REPORT" });
+    expect(pageForPath("/assets/history")).toMatchObject({ pageCode: "scene-assets", assetType: "REPORT" });
+    expect(pageForPath("/scenes/scene-1/session")).toMatchObject({ pageCode: "scene-training", mode: "SCENE" });
+    expect(pageForPath("/conversation/private-session")).toMatchObject({ pageCode: "conversation", mode: "FREE_CHAT" });
+    expect(pageForPath("/settings")).toEqual({ pageCode: "other" });
+  });
+
+  it("normalizes identifiers and strips query/hash values", () => {
+    expect(normalizeTrackedPath("/conversation/private-session?token=secret#top")).toBe("/conversation/session");
+    expect(normalizeTrackedPath("/scenes/a%20scene/session/s-1/result")).toBe("/scenes/session/result");
+    expect(normalizeTrackedPath("/scenes/a%20scene/session/s-1")).toBe("/scenes/session");
+    expect(normalizeTrackedPath("/scenes/a%20scene/word")).toBe("/scenes/word");
+    expect(normalizeTrackedPath("/scenes/a%20scene/phrase")).toBe("/scenes/phrase");
+    expect(normalizeTrackedPath("/scenes/a%20scene/sentence")).toBe("/scenes/sentence");
+    expect(normalizeTrackedPath("/scenes/a%20scene/assets")).toBe("/scenes/assets");
+    expect(normalizeTrackedPath("/interview/scenes/job-1/session")).toBe("/interview/session");
+    expect(normalizeTrackedPath("/interview/scenes/job-1/session/s-1/report")).toBe("/interview/session/report");
+    expect(normalizeTrackedPath("/ielts/part1/topic-1/setup")).toBe("/ielts/part1/selection/setup");
+    expect(normalizeTrackedPath("/ielts/part2/topic-1/session")).toBe("/ielts/part2/selection/session");
+    expect(normalizeTrackedPath("/ielts/part3/topic-1/analysis")).toBe("/ielts/part3/selection/analysis");
+    expect(normalizeTrackedPath("/ielts/part1/topic-1/report")).toBe("/ielts/part1/selection/report");
+    expect(normalizeTrackedPath("/ielts/part2/topic-1")).toBe("/ielts/part2/selection");
+    expect(normalizeTrackedPath("/help/article/change-password")).toBe("/help/article");
+    expect(normalizeTrackedPath("/help/category/audio")).toBe("/help/category");
+    expect(normalizeTrackedPath("/unknown/?q=1")).toBe("/unknown");
+    expect(normalizeTrackedPath("")).toBe("/");
+  });
+
+  it("tracks only active time and handles repeated lifecycle calls", () => {
+    let current = 0;
+    const timer = createActivityTimer({ now: () => current });
+    timer.start();
+    timer.start();
+    current = 2_500;
+    timer.setVisible(false);
+    current = 9_500;
+    timer.setVisible(true);
+    current = 12_000;
+    timer.pause();
+    current = 20_000;
+    timer.pause();
+    timer.resume();
+    current = 25_000;
+    expect(timer.stop()).toBe(10);
+    expect(timer.isStarted()).toBe(false);
+  });
+
+  it("validates Umami configuration and injects one safe script", () => {
+    expect(resolveUmamiConfig({})).toEqual({ enabled: false });
+    expect(resolveUmamiConfig({ ...validEnv, VITE_UMAMI_SCRIPT_URL: "http://analytics.example.com/script.js" })).toEqual({ enabled: false });
+    expect(resolveUmamiConfig(validEnv)).toEqual({
+      enabled: true,
+      scriptUrl: validEnv.VITE_UMAMI_SCRIPT_URL,
+      websiteId: validEnv.VITE_UMAMI_WEBSITE_ID,
+      domains: validEnv.VITE_UMAMI_DOMAINS,
+    });
+
+    const html = "<html><head></head><body></body></html>";
+    const injected = injectUmamiScript(html, validEnv);
+    expect(injected).toContain('data-auto-track="false"');
+    expect(injected).toContain('data-umami-tracker');
+    expect(injectUmamiScript(injected, validEnv)).toBe(injected);
+    expect(injectUmamiScript(html, {})).toBe(html);
+  });
+});

--- a/frontend/web/src/analytics/__tests__/analyticsClient.test.js
+++ b/frontend/web/src/analytics/__tests__/analyticsClient.test.js
@@ -1,0 +1,157 @@
+import { describe, expect, it, vi } from "vitest";
+import { createAnalyticsClient } from "../analyticsClient.js";
+
+function eventTarget() {
+  const listeners = new Map();
+  return {
+    addEventListener: vi.fn((name, listener) => listeners.set(name, listener)),
+    dispatch(name) { listeners.get(name)?.(); },
+  };
+}
+
+function trackerRecorder() {
+  const events = [];
+  const identities = [];
+  return {
+    events,
+    identities,
+    tracker: {
+      identify: (value) => identities.push(value),
+      track: (builder) => events.push(builder({ hostname: "example.com", title: "old", url: "/old" })),
+    },
+  };
+}
+
+describe("analyticsClient", () => {
+  it("does nothing when analytics is disabled or the tracker is missing", () => {
+    const disabled = createAnalyticsClient({ enabled: false });
+    expect(() => {
+      disabled.trackPageView("/private");
+      disabled.trackModeSelection({ mode: "SCENE" });
+      disabled.trackLearningAsset({ mode: "IELTS" });
+    }).not.toThrow();
+
+    const unavailable = createAnalyticsClient({ enabled: true, tracker: () => null });
+    expect(() => unavailable.trackModeSelection({ mode: "SCENE" })).not.toThrow();
+  });
+
+  it("queues events until the tracker becomes available and flushes on load", () => {
+    const calls = [];
+    const target = eventTarget();
+    let currentTracker = null;
+    const client = createAnalyticsClient({
+      enabled: true,
+      tracker: () => currentTracker,
+      eventTarget: target,
+      schedule: () => undefined,
+      initialPath: "/scenes/private-scene/session/session-1/result",
+    });
+
+    client.trackPageView("/conversation/private-session");
+    client.trackModeSelection({ mode: "FREE_CHAT", pageCode: "conversation", email: "secret" }, "sidebar");
+    expect(calls).toEqual([]);
+
+    currentTracker = {
+      track: (builder) => calls.push(builder({ url: "/private", title: "old" })),
+      identify: vi.fn(),
+    };
+    target.dispatch("load");
+    expect(calls).toHaveLength(2);
+    expect(calls[0]).toMatchObject({ url: "/conversation/session", title: "UniSpeaking" });
+    expect(calls[1]).toMatchObject({
+      name: "mode_selected",
+      data: { mode: "FREE_CHAT", page_code: "conversation", source: "sidebar" },
+    });
+    expect(calls[1].data.email).toBeUndefined();
+  });
+
+  it("filters invalid identity values and tracks approved page and asset data", () => {
+    const { events, identities, tracker } = trackerRecorder();
+    const client = createAnalyticsClient({ enabled: true, tracker: () => tracker, initialPath: "/" });
+
+    client.setDistinctId("user-123");
+    client.setDistinctId("user-123");
+    client.setDistinctId(123);
+    client.trackPageView("/interview/scenes/private/session/session-1/report?token=secret");
+    client.trackLearningAsset({ mode: "INTERVIEW", pageCode: "interview-assets", sessionId: "secret" }, "REPORT");
+    client.trackModeSelection({ mode: "UNKNOWN", pageCode: "bad" });
+
+    expect(identities).toEqual(["user-123", ""]);
+    expect(events[0]).toMatchObject({ id: undefined, url: "/interview/session/report", title: "UniSpeaking" });
+    expect(events[1]).toMatchObject({
+      name: "learning_asset_view",
+      data: { mode: "INTERVIEW", page_code: "interview-assets", asset_type: "REPORT" },
+    });
+    expect(events[1].data.sessionId).toBeUndefined();
+  });
+
+  it("records valid training lifecycle events and ignores duplicate terminal actions", () => {
+    let current = 0;
+    const { events, tracker } = trackerRecorder();
+    const client = createAnalyticsClient({ enabled: true, tracker: () => tracker, now: () => current });
+    const training = client.training({ mode: "SCENE", pageCode: "scene-training" });
+
+    training.attempt();
+    training.started();
+    training.started();
+    current = 3_600;
+    training.setVisible(false);
+    current = 9_600;
+    training.setVisible(true);
+    current = 12_200;
+    training.pause();
+    current = 20_000;
+    training.resume();
+    current = 24_500;
+    training.heartbeat();
+    training.complete();
+    training.complete();
+    training.abandon();
+
+    expect(events.map(({ name, data }) => ({ name, data }))).toEqual([
+      { name: "training_start_attempt", data: { mode: "SCENE", page_code: "scene-training" } },
+      { name: "training_started", data: { mode: "SCENE", page_code: "scene-training" } },
+      { name: "training_completed", data: { mode: "SCENE", page_code: "scene-training", effective_duration_seconds: 11 } },
+    ]);
+    expect(training.isStarted()).toBe(false);
+  });
+
+  it("emits failed and abandoned starts, while rejecting invalid training modes", () => {
+    let current = 0;
+    const { events, tracker } = trackerRecorder();
+    const client = createAnalyticsClient({ enabled: true, tracker: () => tracker, now: () => current });
+    const failed = client.training({ mode: "IELTS", pageCode: "ielts-training" });
+    failed.attempt();
+    failed.fail("NETWORK");
+    failed.started();
+
+    const invalid = client.training({ mode: "INVALID", pageCode: "other" });
+    invalid.attempt();
+    invalid.started();
+
+    const abandoned = client.training({ mode: "FREE_CHAT", pageCode: "conversation" });
+    abandoned.started();
+    current = 4_100;
+    abandoned.abandon("USER_EXIT");
+    abandoned.pause();
+
+    expect(events.map(({ name, data }) => ({ name, data }))).toEqual([
+      { name: "training_start_attempt", data: { mode: "IELTS", page_code: "ielts-training" } },
+      { name: "training_start_failed", data: { mode: "IELTS", page_code: "ielts-training", reason: "NETWORK" } },
+      { name: "training_started", data: { mode: "FREE_CHAT", page_code: "conversation" } },
+      { name: "training_abandoned", data: { mode: "FREE_CHAT", page_code: "conversation", reason: "USER_EXIT", effective_duration_seconds: 4 } },
+    ]);
+  });
+
+  it("does not let tracker exceptions break product calls", () => {
+    const schedule = vi.fn();
+    const client = createAnalyticsClient({
+      enabled: true,
+      tracker: () => { throw new Error("tracker down"); },
+      schedule,
+    });
+    expect(() => client.setDistinctId("user")).not.toThrow();
+    expect(() => client.trackPageView("/conversation")).not.toThrow();
+    expect(schedule).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/web/src/component/achievement/__tests__/AchievementNotifications.test.jsx
+++ b/frontend/web/src/component/achievement/__tests__/AchievementNotifications.test.jsx
@@ -1,0 +1,115 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AchievementNotificationProvider, useAchievementNotifications } from "../AchievementNotifications.jsx";
+
+const mockApi = vi.hoisted(() => ({
+  acknowledgeAchievementUnlock: vi.fn(),
+  syncAchievementUnlocks: vi.fn(),
+}));
+
+vi.mock("../../../infrastructure/http/apiClient.js", () => mockApi);
+
+function Harness() {
+  const { synchronizeAchievements, clearAchievementNotifications } = useAchievementNotifications();
+  return (
+    <div>
+      <button onClick={() => void synchronizeAchievements({ revealNotifications: true })}>同步并展示</button>
+      <button onClick={() => void synchronizeAchievements()}>后台同步</button>
+      <button onClick={clearAchievementNotifications}>清空通知</button>
+    </div>
+  );
+}
+
+const notification = {
+  achievementId: "achievement-1",
+  title: "连续开口",
+  description: "完成连续练习",
+  category: "练习习惯",
+  seriesTitle: "坚持练习",
+  level: 2,
+};
+
+describe("AchievementNotificationProvider", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    mockApi.acknowledgeAchievementUnlock.mockReset();
+    mockApi.syncAchievementUnlocks.mockReset();
+    mockApi.acknowledgeAchievementUnlock.mockResolvedValue(undefined);
+    mockApi.syncAchievementUnlocks.mockResolvedValue({ pendingNotifications: [notification] });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
+  it("reveals queued achievements, shows remaining count, and acknowledges dismissal", async () => {
+    const second = { ...notification, achievementId: "achievement-2", title: "第二个成就" };
+    mockApi.syncAchievementUnlocks.mockResolvedValue({ pendingNotifications: [notification, second] });
+    render(<AchievementNotificationProvider><Harness /></AchievementNotificationProvider>);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "同步并展示" })[0]);
+    expect(await screen.findByRole("status", { name: "成就已达成：连续开口" })).toBeInTheDocument();
+    expect(screen.getByText("还有 1 个成就待展示")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "关闭成就通知" }));
+    await waitFor(() => expect(mockApi.acknowledgeAchievementUnlock).toHaveBeenCalledWith("achievement-1"));
+    expect(await screen.findByRole("status", { name: "成就已达成：第二个成就" })).toBeInTheDocument();
+
+    fireEvent.keyDown(window, { key: "Escape" });
+    await waitFor(() => expect(mockApi.acknowledgeAchievementUnlock).toHaveBeenCalledWith("achievement-2"));
+  });
+
+  it("deduplicates notifications already shown in the current session", async () => {
+    render(<AchievementNotificationProvider><Harness /></AchievementNotificationProvider>);
+    fireEvent.click(screen.getAllByRole("button", { name: "同步并展示" })[0]);
+    expect(await screen.findByRole("status", { name: "成就已达成：连续开口" })).toBeInTheDocument();
+    const syncCountAfterReveal = mockApi.syncAchievementUnlocks.mock.calls.length;
+    fireEvent.click(screen.getAllByRole("button", { name: "同步并展示" })[0]);
+    await waitFor(() => expect(mockApi.syncAchievementUnlocks.mock.calls.length).toBeGreaterThan(syncCountAfterReveal));
+    expect(screen.getAllByRole("status", { name: "成就已达成：连续开口" })).toHaveLength(1);
+    fireEvent.click(screen.getByRole("button", { name: "关闭成就通知" }));
+    await waitFor(() => expect(mockApi.acknowledgeAchievementUnlock).toHaveBeenCalledWith("achievement-1"));
+  });
+
+  it("auto dismisses a popup after five seconds", async () => {
+    vi.useFakeTimers();
+    render(<AchievementNotificationProvider><Harness /></AchievementNotificationProvider>);
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "同步并展示" }));
+      await Promise.resolve();
+    });
+    expect(screen.getByRole("status", { name: "成就已达成：连续开口" })).toBeInTheDocument();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+    expect(screen.queryByRole("status", { name: "成就已达成：连续开口" })).not.toBeInTheDocument();
+  });
+
+  it("retries failed acknowledgements on the next synchronization and clears stale state", async () => {
+    mockApi.acknowledgeAchievementUnlock
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValue(undefined);
+    render(<AchievementNotificationProvider><Harness /></AchievementNotificationProvider>);
+    fireEvent.click(screen.getAllByRole("button", { name: "同步并展示" })[0]);
+    expect(await screen.findByRole("status", { name: "成就已达成：连续开口" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "关闭成就通知" }));
+    await waitFor(() => expect(mockApi.acknowledgeAchievementUnlock).toHaveBeenCalled());
+    const acknowledgementCount = mockApi.acknowledgeAchievementUnlock.mock.calls.length;
+    fireEvent.click(screen.getByRole("button", { name: "后台同步" }));
+    await waitFor(() => expect(mockApi.acknowledgeAchievementUnlock.mock.calls.length).toBeGreaterThan(acknowledgementCount));
+    fireEvent.click(screen.getByRole("button", { name: "清空通知" }));
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("does not render a popup before synchronization and rejects missing provider context", () => {
+    render(<AchievementNotificationProvider><Harness /></AchievementNotificationProvider>);
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    expect(() => render(<ProbeOutsideProvider />)).toThrow("useAchievementNotifications must be used within AchievementNotificationProvider");
+  });
+});
+
+function ProbeOutsideProvider() {
+  useAchievementNotifications();
+  return null;
+}

--- a/frontend/web/src/component/common/__tests__/common-components.test.jsx
+++ b/frontend/web/src/component/common/__tests__/common-components.test.jsx
@@ -1,0 +1,47 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { EvaluationLoader } from "../EvaluationLoader.jsx";
+import { Modal } from "../Modal.jsx";
+import { NewtonsCradle } from "../NewtonsCradle.jsx";
+
+afterEach(() => cleanup());
+
+describe("common loading and modal components", () => {
+  it("renders modal content, wide styling, and both close paths", () => {
+    const onClose = vi.fn();
+    const { rerender } = render(
+      <Modal onClose={onClose} wide className="custom-modal">
+        <p>内容</p>
+      </Modal>,
+    );
+
+    expect(screen.getByRole("dialog")).toHaveClass("modal", "modal--wide", "custom-modal");
+    expect(screen.getByText("内容")).toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole("dialog"));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "关闭" }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+    fireEvent.mouseDown(screen.getByRole("dialog").parentElement);
+    expect(onClose).toHaveBeenCalledTimes(2);
+
+    rerender(<Modal onClose={onClose} dismissible={false}>不可关闭</Modal>);
+    expect(screen.queryByRole("button", { name: "关闭" })).not.toBeInTheDocument();
+    fireEvent.mouseDown(screen.getByRole("dialog").parentElement);
+    expect(onClose).toHaveBeenCalledTimes(2);
+  });
+
+  it("renders the evaluation loader with its six animation elements", () => {
+    const { container } = render(<EvaluationLoader />);
+    expect(container.firstChild).toHaveAttribute("aria-hidden", "true");
+    expect(container.querySelectorAll(".ielts-evaluation-loader__circle")).toHaveLength(3);
+    expect(container.querySelectorAll(".ielts-evaluation-loader__shadow")).toHaveLength(3);
+  });
+
+  it("applies Newton's cradle defaults and custom visual properties", () => {
+    render(<NewtonsCradle size={72} speed="2s" color="red" label="请稍候" className="extra" />);
+    const status = screen.getByRole("status", { name: "请稍候" });
+    expect(status).toHaveClass("newtons-cradle", "extra");
+    expect(status).toHaveStyle({ "--uib-size": "72px", "--uib-speed": "2s", "--uib-color": "red" });
+    expect(status.querySelectorAll(".newtons-cradle__dot")).toHaveLength(4);
+  });
+});

--- a/frontend/web/src/component/help/__tests__/feedbackInvitation.test.js
+++ b/frontend/web/src/component/help/__tests__/feedbackInvitation.test.js
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { markFeedbackStarted, recordFeedbackPractice } from "../feedbackInvitation.js";
+
+function storage(initial = {}) {
+  const values = new Map(Object.entries(initial));
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    dump: () => Object.fromEntries(values),
+  };
+}
+
+function throwingStorage() {
+  return {
+    getItem: vi.fn(() => null),
+    setItem: vi.fn(() => { throw new Error("storage unavailable"); }),
+  };
+}
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("feedback invitation progress", () => {
+  it("rejects incomplete practice records and feedback starts", () => {
+    const store = storage();
+    expect(recordFeedbackPractice(null, { userId: "user-1", practiceType: "free", sessionId: "s-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "", practiceType: "free", sessionId: "s-2" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user-1", practiceType: "free", sessionId: "" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "user-1", practiceType: "other", sessionId: "s-3" })).toBe(false);
+    expect(markFeedbackStarted(null, "user-1")).toBe(false);
+    expect(markFeedbackStarted(store, "")).toBe(false);
+  });
+
+  it("recovers from malformed progress and normalizes legacy stored values", () => {
+    const corrupt = storage({ "unispeaking.feedbackInvitation.v1.user-1": "not-json" });
+    expect(recordFeedbackPractice(corrupt, { userId: "user-1", practiceType: "scene", sessionId: "s-1" })).toBe(false);
+
+    const legacy = storage({
+      "unispeaking.feedbackInvitation.v1.user-2": JSON.stringify({
+        freeConversationCount: -4,
+        scenePracticeCount: "2",
+        prompted: true,
+        practicesSinceLastInvitation: -1,
+        recordedSessionIds: ["old", 123, "new"],
+        feedbackStarted: 0,
+      }),
+    });
+    expect(recordFeedbackPractice(legacy, { userId: "user-2", practiceType: "scene", sessionId: "s-2" })).toBe(false);
+    const saved = JSON.parse(legacy.dump()["unispeaking.feedbackInvitation.v1.user-2"]);
+    expect(saved).toMatchObject({
+      freeConversationCount: 0,
+      scenePracticeCount: 3,
+      invitationCount: 1,
+      practicesSinceLastInvitation: 1,
+      recordedSessionIds: ["old", "new", "scene:s-2"],
+      feedbackStarted: false,
+    });
+  });
+
+  it("invites after three scene practices and ignores duplicate session ids", () => {
+    const store = storage();
+    expect(recordFeedbackPractice(store, { userId: "scene-user", practiceType: "scene", sessionId: "scene-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "scene-user", practiceType: "scene", sessionId: "scene-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "scene-user", practiceType: "scene", sessionId: "scene-2" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "scene-user", practiceType: "scene", sessionId: "scene-3" })).toBe(true);
+  });
+
+  it("supports the follow-up invitation threshold and caps session history", () => {
+    const store = storage();
+    expect(recordFeedbackPractice(store, { userId: "follow-up", practiceType: "free", sessionId: "free-1" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "follow-up", practiceType: "free", sessionId: "free-2" })).toBe(false);
+    expect(recordFeedbackPractice(store, { userId: "follow-up", practiceType: "free", sessionId: "free-3" })).toBe(true);
+    for (let index = 4; index <= 22; index += 1) {
+      expect(recordFeedbackPractice(store, {
+        userId: "follow-up",
+        practiceType: index % 2 === 0 ? "scene" : "free",
+        sessionId: `session-${index}`,
+      })).toBe(index === 13);
+    }
+    const saved = JSON.parse(store.dump()["unispeaking.feedbackInvitation.v1.follow-up"]);
+    expect(saved.invitationCount).toBe(2);
+    expect(saved.practicesSinceLastInvitation).toBe(9);
+    expect(saved.recordedSessionIds).toHaveLength(20);
+    expect(saved.recordedSessionIds[0]).toBe("free:free-3");
+  });
+
+  it("returns false when storage cannot be written", () => {
+    const store = throwingStorage();
+    expect(recordFeedbackPractice(store, { userId: "user-1", practiceType: "free", sessionId: "s-1" })).toBe(false);
+    expect(markFeedbackStarted(store, "user-1")).toBe(false);
+  });
+
+  it("stops recording after feedback has started", () => {
+    const store = storage({
+      "unispeaking.feedbackInvitation.v1.started": JSON.stringify({
+        feedbackStarted: true,
+        recordedSessionIds: [],
+      }),
+    });
+    expect(recordFeedbackPractice(store, { userId: "started", practiceType: "free", sessionId: "s-1" })).toBe(false);
+  });
+});

--- a/frontend/web/src/component/help/__tests__/help-components.test.jsx
+++ b/frontend/web/src/component/help/__tests__/help-components.test.jsx
@@ -1,0 +1,142 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExternalFeedbackLink } from "../ExternalFeedbackLink.jsx";
+import { HelpArticle } from "../HelpArticle.jsx";
+import { HelpCategory } from "../HelpCategory.jsx";
+import { HelpCenter } from "../HelpCenter.jsx";
+import { HelpLayout } from "../HelpLayout.jsx";
+import { helpCategories, helpArticles } from "../helpData.js";
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllEnvs();
+});
+
+const navigate = vi.fn();
+const article = helpArticles[0];
+const category = helpCategories[0];
+
+describe("help center components", () => {
+  it("renders the public shell and intercepts internal navigation", () => {
+    render(<HelpLayout onNavigate={navigate}><p>帮助内容</p></HelpLayout>);
+    expect(screen.getByRole("banner")).toBeInTheDocument();
+    expect(screen.getByAltText("UniSpeaking")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: "登录" }));
+    expect(navigate).toHaveBeenCalledWith("/login");
+    fireEvent.click(screen.getByRole("link", { name: /开始使用/ }));
+    expect(navigate).toHaveBeenCalledWith("/signup");
+  });
+
+  it("supports help home search, clear, empty state, and result navigation", () => {
+    render(<HelpCenter route={{ screen: "home" }} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: "热门问题" })).toBeInTheDocument();
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "麦克风" } });
+    expect(screen.getByRole("heading", { name: "搜索结果" })).toBeInTheDocument();
+    expect(screen.getByText(/找到 \d+ 篇/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "清空帮助搜索" }));
+    expect(screen.getByRole("heading", { name: "热门问题" })).toBeInTheDocument();
+    fireEvent.change(input, { target: { value: "绝对不存在的帮助关键词" } });
+    expect(screen.getByRole("status")).toHaveTextContent("暂时没有找到相关内容");
+    fireEvent.click(screen.getByRole("button", { name: "浏览全部分类" }));
+    expect(screen.getByRole("heading", { name: "按主题查找" })).toBeInTheDocument();
+    fireEvent.change(screen.getByRole("searchbox"), { target: { value: article.title.slice(0, 4) } });
+    fireEvent.click(screen.getAllByRole("link", { name: new RegExp(article.title) })[0]);
+    expect(navigate).toHaveBeenCalled();
+  });
+
+  it("renders category, feedback callout, article steps and ratings", () => {
+    render(<HelpCategory category={{ ...category, id: "feedback", title: "问题反馈" }} articles={[article]} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: "问题反馈" })).toBeInTheDocument();
+    expect(screen.getByText("已经完成基础排查？")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: new RegExp(article.title) }));
+    expect(navigate).toHaveBeenCalled();
+
+    cleanup();
+    render(<HelpArticle article={article} category={category} relatedArticles={[helpArticles[1]]} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: article.title })).toBeInTheDocument();
+    expect(screen.getAllByRole("listitem")).toHaveLength(article.steps.length + 1);
+    fireEvent.click(screen.getByRole("button", { name: "解决了" }));
+    expect(screen.getByRole("status")).toHaveTextContent("谢谢你的反馈");
+
+    cleanup();
+    render(<HelpArticle article={article} category={category} relatedArticles={[]} onNavigate={navigate} />);
+    fireEvent.click(screen.getByRole("button", { name: "仍有问题" }));
+    expect(screen.getByRole("status")).toHaveTextContent("我们继续帮你排查");
+  });
+
+  it("shows not-found routes and keeps external feedback link semantic", () => {
+    render(<HelpCenter route={{ screen: "category", categoryId: "missing" }} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: "没有找到这项帮助内容" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: /返回帮助中心/ }));
+    expect(navigate).toHaveBeenCalledWith("/help");
+
+    cleanup();
+    render(<ExternalFeedbackLink className="custom">反馈</ExternalFeedbackLink>);
+    const link = screen.getByRole("link", { name: "反馈" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveClass("external-feedback-link", "custom");
+    cleanup();
+    render(<ExternalFeedbackLink>{(configured) => configured ? "已配置" : "未配置"}</ExternalFeedbackLink>);
+    expect(screen.getByText("已配置")).toBeInTheDocument();
+  });
+
+  it("renders valid category and article routes", () => {
+    cleanup();
+    render(<HelpCenter route={{ screen: "category", categoryId: category.id }} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: category.title })).toBeInTheDocument();
+
+    cleanup();
+    render(<HelpCenter route={{ screen: "article", articleId: article.id }} onNavigate={navigate} />);
+    expect(screen.getByRole("heading", { name: article.title })).toBeInTheDocument();
+  });
+
+  it("renders feedback callouts from the help home and article unresolved state", () => {
+    cleanup();
+    render(<HelpCenter route={{ screen: "home" }} onNavigate={navigate} />);
+    const feedbackLinks = screen.getAllByRole("link").filter((link) => link.getAttribute("href")?.startsWith("http"));
+    expect(feedbackLinks).toHaveLength(1);
+    expect(feedbackLinks[0]).toHaveTextContent("问题反馈");
+
+    cleanup();
+    render(<HelpArticle article={article} category={category} relatedArticles={[]} onNavigate={navigate} />);
+    fireEvent.click(screen.getByRole("button", { name: "仍有问题" }));
+    expect(screen.getByRole("link", { name: "仍未解决，提交反馈" })).toHaveAttribute("target", "_blank");
+  });
+
+  it("handles keyboard search submission and Escape reset", () => {
+    render(<HelpCenter route={{ screen: "home" }} onNavigate={navigate} />);
+    const input = screen.getByRole("searchbox");
+    fireEvent.change(input, { target: { value: "密码" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(input).toHaveValue("");
+    fireEvent.change(input, { target: { value: "麦克风" } });
+    fireEvent.submit(input.closest("form"));
+    expect(screen.getByRole("heading", { name: "搜索结果" })).toBeInTheDocument();
+    expect(document.activeElement).toBe(screen.getByRole("region", { name: "搜索结果" }));
+  });
+
+  it("disables the feedback entry when its configured URL is invalid", async () => {
+    vi.resetModules();
+    vi.stubEnv("VITE_FEEDBACK_URL", "javascript:alert(1)");
+    const { ExternalFeedbackLink: DisabledFeedbackLink, feedbackUrl: disabledUrl } = await import("../ExternalFeedbackLink.jsx");
+
+    expect(disabledUrl).toBe("");
+    render(<DisabledFeedbackLink className="custom">{(configured) => configured ? "已配置" : "未配置"}</DisabledFeedbackLink>);
+    const disabled = screen.getByText("未配置").closest("span");
+    expect(disabled).toHaveAttribute("aria-disabled", "true");
+    expect(disabled).toHaveAttribute("title", "反馈问卷链接尚未配置");
+    expect(disabled).toHaveClass("external-feedback-link", "custom", "is-disabled");
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+
+    vi.resetModules();
+    vi.stubEnv("VITE_FEEDBACK_URL", "not a URL");
+    const { feedbackUrl: malformedUrl } = await import("../ExternalFeedbackLink.jsx");
+    expect(malformedUrl).toBe("");
+
+    vi.resetModules();
+    vi.stubEnv("VITE_FEEDBACK_URL", "   ");
+    const { feedbackUrl: emptyUrl } = await import("../ExternalFeedbackLink.jsx");
+    expect(emptyUrl).toBe("");
+  });
+});

--- a/frontend/web/src/component/ielts/__tests__/IeltsModule.test.jsx
+++ b/frontend/web/src/component/ielts/__tests__/IeltsModule.test.jsx
@@ -1,0 +1,538 @@
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../infrastructure/http/apiClient.js", () => ({
+  createIeltsSceneFlow: vi.fn(),
+  fetchAuthenticatedMedia: vi.fn(),
+  generateIeltsScene: vi.fn(),
+  generateIeltsEvaluation: vi.fn(),
+  getIeltsEvaluationHistory: vi.fn(),
+  getIeltsSettings: vi.fn(),
+  getIeltsTopics: vi.fn(),
+  getIeltsTraining: vi.fn(),
+  updateIeltsSettings: vi.fn(),
+}));
+vi.mock("../../../websocket/realtimeClient.js", () => ({ createRealtimeClient: vi.fn() }));
+vi.mock("../../../analytics/analyticsClient.js", () => ({
+  analytics: { training: vi.fn(() => ({ attempt: vi.fn(), started: vi.fn(), complete: vi.fn(), abandon: vi.fn(), fail: vi.fn(), setVisible: vi.fn(), pause: vi.fn(), resume: vi.fn() })) },
+}));
+
+import {
+  createIeltsSceneFlow,
+  fetchAuthenticatedMedia,
+  generateIeltsScene,
+  generateIeltsEvaluation,
+  getIeltsEvaluationHistory,
+  getIeltsSettings,
+  getIeltsTopics,
+  getIeltsTraining,
+  updateIeltsSettings,
+} from "../../../infrastructure/http/apiClient.js";
+import { createRealtimeClient } from "../../../websocket/realtimeClient.js";
+import {
+  IeltsAssets,
+  IeltsHeader,
+  IeltsTrainingCenter,
+  SimpleCta,
+  TrainingCta,
+  TrendLineChart,
+} from "../IeltsModule.jsx";
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+  cleanup();
+});
+beforeEach(() => {
+  vi.clearAllMocks();
+  createRealtimeClient.mockReset();
+  window.localStorage.clear();
+  getIeltsSettings.mockResolvedValue({ targetScore: 6.5, currentStreakDays: 3, todayCompletedCount: 2 });
+  getIeltsEvaluationHistory.mockResolvedValue([]);
+  getIeltsTopics.mockResolvedValue({ categories: [], topics: [], total: 0, totalPages: 0 });
+  getIeltsTraining.mockResolvedValue({ topicId: "topic-1", questions: [] });
+  updateIeltsSettings.mockResolvedValue({ targetScore: 7 });
+  generateIeltsScene.mockResolvedValue({ ieltsId: "ielts-scene", voiceId: "Harvey" });
+  createIeltsSceneFlow.mockResolvedValue({});
+});
+
+function mockIeltsRealtimeClient(overrides = {}) {
+  const client = {
+    start: vi.fn().mockResolvedValue({ sessionId: "ielts-session" }),
+    stop: vi.fn().mockResolvedValue({}),
+    setMuted: vi.fn(),
+    transitionIeltsPart2: vi.fn().mockResolvedValue({}),
+    forceIeltsPart3TurnTimeout: vi.fn().mockResolvedValue({}),
+    waitForEvaluations: vi.fn().mockResolvedValue(),
+    ...overrides,
+  };
+  createRealtimeClient.mockImplementation((options) => {
+    client.options = options;
+    return client;
+  });
+  return client;
+}
+
+function mockCanvas() {
+  const context = {
+    scale: vi.fn(), clearRect: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(),
+    stroke: vi.fn(), fill: vi.fn(), closePath: vi.fn(), arc: vi.fn(), fillText: vi.fn(),
+    createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getBoundingClientRect").mockReturnValue({ width: 320, height: 160 });
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(context);
+  return context;
+}
+
+describe("IELTS exported presentation components", () => {
+  it("renders CTA and header variants and wires actions", () => {
+    const onClick = vi.fn();
+    const onBack = vi.fn();
+    render(<><SimpleCta onClick={onClick}>普通 CTA</SimpleCta><TrainingCta onClick={onClick} disabled>训练 CTA</TrainingCta><IeltsHeader eyebrow="EYEBROW" title="标题" subtitle="副标题" onBack={onBack} leadAction={<span>lead</span>} action={<button>action</button>} /></>);
+    expect(screen.getByRole("button", { name: /普通 CTA/ })).toHaveClass("ielts-cta");
+    expect(screen.getByRole("button", { name: /训练 CTA/ })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: /普通 CTA/ }));
+    fireEvent.click(screen.getByRole("button", { name: /返回/ }));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onBack).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("副标题")).toBeInTheDocument();
+  });
+
+  it("draws empty, sparse and scored trend data, including resize redraw", () => {
+    const context = mockCanvas();
+    const { rerender } = render(<TrendLineChart values={[]} ariaLabel="空趋势" />);
+    expect(screen.getByLabelText("空趋势")).toBeInTheDocument();
+    rerender(<TrendLineChart values={[6, null, 7.5]} />);
+    fireEvent(window, new Event("resize"));
+    expect(context.getContext ? context.getContext : context.scale).toHaveBeenCalled();
+    expect(context.createLinearGradient).toHaveBeenCalled();
+    expect(context.fillText).toHaveBeenCalledWith("--", expect.any(Number), expect.any(Number));
+  });
+});
+
+const reports = [
+  {
+    sessionId: "report-1", mode: "MOCK_TEST", part: "PART_1", topicTitles: { PART_1: "Daily life" },
+    startedAt: "2026-08-25T10:00:00Z", endedAt: "2026-08-25T10:12:00Z", overallBandScore: 6.5,
+    fluencyCoherenceScore: 6, lexicalResourceScore: 6.5, grammaticalRangeAccuracyScore: 7, pronunciationScore: 6,
+    summary: "表现稳定", strengths: ["流畅"], improvements: ["展开"], recommendedExpressions: ["for example"],
+    recordingUrls: [], topicSelectionMethod: "RANDOM", partEvaluations: [],
+  },
+];
+
+describe("IeltsAssets", () => {
+  it("covers loading, successful overview, tabs, menu navigation and trends", async () => {
+    let resolveSettings;
+    getIeltsSettings.mockReturnValueOnce(new Promise((resolve) => { resolveSettings = resolve; }));
+    getIeltsEvaluationHistory.mockReturnValueOnce(new Promise(() => {}));
+    render(<IeltsAssets route={{ tab: "overview" }} onNavigate={vi.fn()} onBack={vi.fn()} onBackToAssets={vi.fn()} onBackToInterview={vi.fn()} onTraining={vi.fn()} />);
+    expect(screen.getByRole("status", { name: /正在读取后端评分记录/ })).toBeInTheDocument();
+    resolveSettings({ targetScore: 7 });
+    cleanup();
+
+    const onNavigate = vi.fn();
+    getIeltsSettings.mockResolvedValue({ targetScore: 7, currentStreakDays: 2, todayCompletedCount: 1 });
+    getIeltsEvaluationHistory.mockResolvedValue(reports);
+    const callbacks = { onBack: vi.fn(), onBackToAssets: vi.fn(), onBackToInterview: vi.fn(), onTraining: vi.fn() };
+    render(<IeltsAssets route={{ tab: "overview" }} onNavigate={onNavigate} {...callbacks} />);
+    await waitFor(() => expect(screen.getByText("最近一次完整模考")).toBeInTheDocument());
+    expect(screen.getByText("预估 6.5")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "能力趋势" }));
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith("/ielts/assets/trends"));
+
+    cleanup();
+    render(<IeltsAssets route={{ tab: "history" }} onNavigate={onNavigate} {...callbacks} />);
+    await waitFor(() => expect(screen.getByText("训练记录")).toBeInTheDocument());
+    expect(screen.getAllByText("Daily life").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: /能力趋势/ }));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/assets/trends");
+    fireEvent.click(screen.getByRole("button", { name: "切换学习资产模块" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /面试学习资产/ }));
+    expect(callbacks.onBackToInterview).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /返回训练中心/ }));
+    expect(callbacks.onTraining).toHaveBeenCalled();
+  });
+
+  it("shows asset loading errors", async () => {
+    getIeltsSettings.mockRejectedValue(new Error("asset down"));
+    getIeltsEvaluationHistory.mockResolvedValue([]);
+    render(<IeltsAssets route={{ tab: "overview" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "学习资产加载失败" })).toBeInTheDocument());
+    expect(screen.getByText("asset down")).toBeInTheDocument();
+  });
+
+  it("renders the empty trends state when there is no mock or training score", async () => {
+    getIeltsSettings.mockResolvedValue({ targetScore: null, currentStreakDays: 0, todayCompletedCount: 0 });
+    getIeltsEvaluationHistory.mockResolvedValue([]);
+    render(<IeltsAssets route={{ tab: "trends" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("暂无模考趋势")).toBeInTheDocument());
+    expect(screen.getByText("暂无能力评分")).toBeInTheDocument();
+    expect(screen.getByText("完成至少两次完整模考后生成折线图。")).toBeInTheDocument();
+  });
+
+  it("recovers when an authenticated recording cannot be played", async () => {
+    const recording = {
+      sessionId: "recording-error",
+      mode: "PART_PRACTICE",
+      part: "PART_1",
+      endedAt: "2026-08-25T10:05:00Z",
+      startedAt: "2026-08-25T10:00:00Z",
+      recordingUrls: ["unplayable-clip"],
+      topicSelectionMethod: "SELECTED",
+      strengths: [], improvements: [], recommendedExpressions: [],
+    };
+    const mediaUrl = { createObjectURL: vi.fn(() => "blob:unplayable"), revokeObjectURL: vi.fn() };
+    vi.stubGlobal("URL", mediaUrl);
+    window.URL = mediaUrl;
+    vi.stubGlobal("Audio", vi.fn(() => ({
+      play: vi.fn().mockRejectedValue(new Error("autoplay blocked")),
+      pause: vi.fn(), onended: null, onerror: null,
+    })));
+    fetchAuthenticatedMedia.mockResolvedValue(new Blob(["audio"]));
+    getIeltsEvaluationHistory.mockResolvedValue([recording]);
+    render(<IeltsAssets route={{ tab: "history" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("训练记录")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "播放原始录音" }));
+    await waitFor(() => expect(fetchAuthenticatedMedia).toHaveBeenCalledWith("unplayable-clip"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "播放原始录音" })).toBeInTheDocument());
+    expect(mediaUrl.revokeObjectURL).toHaveBeenCalledWith("blob:unplayable");
+  });
+});
+
+describe("IeltsTrainingCenter", () => {
+  it("loads the home, navigates to topics and supports the intake flow", async () => {
+    const onNavigate = vi.fn();
+    render(<IeltsTrainingCenter route={{ screen: "home" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "雅思口语" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "开始模考" }));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/mock/setup");
+    fireEvent.click(screen.getByRole("button", { name: /Part 1/ }));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/part1");
+  });
+
+  it("covers intake, topic loading/error, setup start and setup error", async () => {
+    getIeltsSettings.mockResolvedValueOnce({});
+    const onNavigate = vi.fn();
+    render(<IeltsTrainingCenter route={{ screen: "home" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("这次备考，你希望达到多少分？")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /目标 6.5/ }));
+    fireEvent.click(screen.getByRole("button", { name: "下一步" }));
+    fireEvent.click(screen.getByRole("button", { name: /约 5.5/ }));
+    fireEvent.click(screen.getByRole("button", { name: "进入训练中心" }));
+    await waitFor(() => expect(updateIeltsSettings).toHaveBeenCalledWith({ targetScore: 6.5 }));
+
+    cleanup();
+    getIeltsTopics.mockResolvedValue({ categories: [{ code: "WORK", label: "工作" }], topics: [{ id: "t1", categoryLabel: "工作", title: "My work", questionCount: 3, practiceCount: 0 }], total: 1, totalPages: 1 });
+    render(<IeltsTrainingCenter route={{ screen: "topics", part: "p1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("My work")).toBeInTheDocument(), { timeout: 1000 });
+    fireEvent.click(screen.getByText("My work"));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/part1/t1/setup");
+    fireEvent.click(screen.getByRole("button", { name: "工作" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "搜索话题" }), { target: { value: "x" } });
+
+    cleanup();
+    getIeltsTopics.mockRejectedValue(new Error("topics down"));
+    render(<IeltsTrainingCenter route={{ screen: "topics", part: "p1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("topics down")).toBeInTheDocument());
+  });
+
+  it("loads a selected topic setup, starts the session, and handles setup failures", async () => {
+    const onNavigate = vi.fn();
+    getIeltsTopics.mockResolvedValue({ categories: [], topics: [{ id: "t1", title: "Travel", categoryLabel: "生活", questionCount: 2 }], total: 1, totalPages: 1 });
+    render(<IeltsTrainingCenter route={{ screen: "topics", part: "p1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Travel")).toBeInTheDocument());
+    fireEvent.click(screen.getByText("Travel"));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/part1/t1/setup");
+
+    cleanup();
+    getIeltsTraining.mockResolvedValue({ topicId: "t1", questions: [{ question: "Describe a trip" }] });
+    render(<IeltsTrainingCenter route={{ screen: "setup", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 1/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalledWith({ mode: "PART_PRACTICE", part: "PART_1", topicId: "t1" }));
+    expect(createIeltsSceneFlow).toHaveBeenCalledWith("ielts-scene");
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/part1/t1/session");
+
+    cleanup();
+    updateIeltsSettings.mockRejectedValueOnce(new Error("settings failed"));
+    render(<IeltsTrainingCenter route={{ screen: "setup", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 1/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(screen.getByText("settings failed")).toBeInTheDocument());
+  });
+
+  it("shows training loading errors and retries the topic request", async () => {
+    getIeltsTraining.mockRejectedValueOnce(new Error("training unavailable"));
+    render(<IeltsTrainingCenter route={{ screen: "setup", part: "p2", selection: "t2" }} onNavigate={vi.fn()} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "题目加载失败" })).toBeInTheDocument());
+    expect(screen.getByText("training unavailable")).toBeInTheDocument();
+    getIeltsTraining.mockResolvedValueOnce({ topicId: "t2", questions: [] });
+    fireEvent.click(screen.getByRole("button", { name: "重新加载" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 2/ })).toBeInTheDocument());
+  });
+
+  it("covers IELTS session events, part two preparation, finish, exit, and report states", async () => {
+    const client = mockIeltsRealtimeClient();
+    const onNavigate = vi.fn();
+    generateIeltsScene.mockResolvedValue({ ieltsId: "scene-p2", voiceId: "Harvey" });
+    getIeltsTraining.mockResolvedValue({ topicId: "t2", questions: [{ questionText: "Describe a book", cuePoints: ["what", "why"] }] });
+    const view = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p2", selection: "t2" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 2/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(createIeltsSceneFlow).toHaveBeenCalledWith("scene-p2"));
+    view.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p2", selection: "t2" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByLabelText("Part 2 答题笔记")).toBeInTheDocument());
+    await waitFor(() => expect(client.options).toBeDefined());
+    client.options.onEvent({ type: "local.connecting" });
+    client.options.onEvent({ type: "local.connected" });
+    client.options.onEvent({ type: "response.created" });
+    client.options.onEvent({ type: "response.audio_transcript.delta", item_id: "a1", delta: "Hello" });
+    client.options.onEvent({ type: "local.transcript.final", owner: 0, itemId: "a1", text: "Hello there" });
+    client.options.onEvent({ type: "response.done" });
+    await waitFor(() => expect(screen.getByText(/准备时间/)).toBeInTheDocument());
+    fireEvent.change(screen.getByLabelText("Part 2 答题笔记"), { target: { value: "key points" } });
+    fireEvent.click(screen.getByRole("button", { name: "结束准备并开始作答" }));
+    await waitFor(() => expect(client.transitionIeltsPart2).toHaveBeenCalledWith("PREPARATION_COMPLETE"));
+    client.options.onEvent({ type: "local.ielts_input_ready" });
+    await waitFor(() => expect(screen.getByText(/作答时间/)).toBeInTheDocument());
+    vi.useFakeTimers();
+    client.options.onEvent({ type: "input_audio_buffer.speech_stopped" });
+    await act(async () => { vi.advanceTimersByTime(3000); });
+    expect(client.transitionIeltsPart2).toHaveBeenCalledWith("ANSWER_COMPLETE");
+    vi.useRealTimers();
+    client.options.onEvent({ type: "local.ielts_part2_state", state: { completed: true } });
+    fireEvent.click(screen.getByRole("button", { name: "退出训练" }));
+    fireEvent.click(screen.getByRole("button", { name: "继续训练" }));
+    fireEvent.click(screen.getByRole("button", { name: "退出训练" }));
+    fireEvent.click(screen.getByRole("button", { name: "确认退出" }));
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith("/ielts"));
+
+    cleanup();
+    const reportNavigate = vi.fn();
+    render(<IeltsTrainingCenter route={{ screen: "analysis", part: "mock", selection: "random" }} onNavigate={reportNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("有效回答不足，暂时无法评分")).toBeInTheDocument());
+    cleanup();
+    render(<IeltsTrainingCenter route={{ screen: "report", part: "mock", selection: "random" }} onNavigate={reportNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    expect(screen.getByText("本次有效英文回答不足")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "重新练习" }));
+    expect(reportNavigate).toHaveBeenCalledWith("/ielts/mock/setup");
+  });
+
+  it("covers a Part 1 session, live subtitles, state events, and a complete analysis/report", async () => {
+    const client = mockIeltsRealtimeClient();
+    const onNavigate = vi.fn();
+    const evaluation = {
+      assessmentType: "FINAL",
+      overallBandScore: 7.1,
+      fluencyCoherenceScore: 7,
+      lexicalResourceScore: 7.5,
+      grammaticalRangeAccuracyScore: 6.5,
+      pronunciationScore: 7,
+      summary: "回答自然，观点展开清楚。",
+      strengths: ["回答完整", "表达自然"],
+      improvements: ["增加例子", "减少重复"],
+      recommendedExpressions: ["from my perspective", "for instance"],
+      partEvaluations: [
+        { part: "PART_1", fluencyCoherenceScore: 7, lexicalResourceScore: 7, grammaticalRangeAccuracyScore: 6.5, pronunciationScore: 7 },
+        { part: "PART_2", fluencyCoherenceScore: 7.5, lexicalResourceScore: 7, grammaticalRangeAccuracyScore: 7, pronunciationScore: 7 },
+        { part: "PART_3", fluencyCoherenceScore: 6.5, lexicalResourceScore: 7.5, grammaticalRangeAccuracyScore: 6, pronunciationScore: 7 },
+      ],
+    };
+    generateIeltsEvaluation.mockResolvedValueOnce(evaluation);
+    getIeltsTraining.mockResolvedValue({ topicId: "t1", questions: [{ questionText: "Where do you live?" }] });
+    const view = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 1/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalled());
+
+    view.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(client.options).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: "开启字幕" }));
+    await waitFor(() => expect(screen.getByLabelText("实时会话字幕")).toBeInTheDocument());
+    client.options.onEvent({ type: "local.connecting" });
+    client.options.onEvent({ type: "local.connected" });
+    client.options.onEvent({ type: "response.created" });
+    client.options.onEvent({ type: "response.audio_transcript.delta", response_id: "response-1", delta: "How are" });
+    await act(async () => { await new Promise((resolve) => requestAnimationFrame(resolve)); });
+    expect(screen.getByText("How are")).toBeInTheDocument();
+    client.options.onEvent({ type: "response.audio_transcript.delta", response_id: "response-1", delta: " you?" });
+    client.options.onEvent({ type: "local.transcript.final", owner: 0, itemId: "response-1", text: "How are you?" });
+    client.options.onEvent({ type: "local.ielts_input_ready" });
+    client.options.onEvent({ type: "local.ielts_state", state: { answeredQuestions: 1, totalQuestions: 4 } });
+    await waitFor(() => expect(screen.getByText("已完成 1 / 4 题")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "关闭字幕" }));
+    expect(screen.getByRole("button", { name: "开启字幕" })).toBeInTheDocument();
+    client.options.onEvent({ type: "local.ielts_state_error", message: "题目推进失败" });
+    client.options.onEvent({ type: "local.backend_warning" });
+    client.options.onEvent({ type: "local.mic_error", message: "麦克风被占用" });
+    client.options.onEvent({ type: "local.error", error: { message: "socket closed" } });
+    await waitFor(() => expect(screen.getByText("socket closed")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByRole("button", { name: "开启字幕" }));
+    fireEvent.click(screen.getByRole("button", { name: "结束本次训练" }));
+    await waitFor(() => expect(generateIeltsEvaluation).toHaveBeenCalledWith("ielts-scene", "ielts-session"));
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith("/ielts/part1/t1/analysis"));
+
+    view.rerender(<IeltsTrainingCenter route={{ screen: "analysis", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    expect(screen.getByText("本次评分已完成")).toBeInTheDocument();
+    expect(screen.getByText("完整模考预估")).toBeInTheDocument();
+    expect(screen.getByText("7.1")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "查看详细报告" }));
+    expect(onNavigate).toHaveBeenCalledWith("/ielts/part1/t1/report");
+
+    view.rerender(<IeltsTrainingCenter route={{ screen: "report", part: "p1", selection: "t1" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    expect(screen.getByText("from my perspective")).toBeInTheDocument();
+    expect(screen.getByText("7.5")).toBeInTheDocument();
+    view.rerender(<IeltsTrainingCenter route={{ screen: "report", part: "mock", selection: "random" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    expect(screen.getByText("回答自然，观点展开清楚。")).toBeInTheDocument();
+    expect(screen.getByText("回答完整")).toBeInTheDocument();
+    expect(screen.getByText("增加例子")).toBeInTheDocument();
+  });
+
+  it("covers Part 3 turn timeout, transcription reset, completion, and realtime errors", async () => {
+    const client = mockIeltsRealtimeClient();
+    getIeltsTraining.mockResolvedValue({ topicId: "t3", questions: [{ questionText: "Should cities have more parks?" }] });
+    const view = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p3", selection: "t3" }} onNavigate={vi.fn()} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 3/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalled());
+    view.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p3", selection: "t3" }} onNavigate={vi.fn()} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(client.options).toBeDefined());
+
+    vi.useFakeTimers();
+    await act(async () => {
+      client.options.onEvent({ type: "local.connected" });
+      client.options.onEvent({ type: "local.ielts_input_ready" });
+    });
+    expect(screen.getByText("01:00")).toBeInTheDocument();
+    await act(async () => {
+      client.options.onEvent({ type: "conversation.item.input_audio_transcription.completed" });
+    });
+    await act(async () => { vi.advanceTimersByTime(60_000); });
+    expect(client.forceIeltsPart3TurnTimeout).not.toHaveBeenCalled();
+
+    await act(async () => { client.options.onEvent({ type: "local.ielts_input_ready" }); });
+    await act(async () => { vi.advanceTimersByTime(60_000); });
+    expect(client.forceIeltsPart3TurnTimeout).toHaveBeenCalledTimes(1);
+    expect(screen.getAllByText("单题回答已到 60 秒，考官正在切换下一题").length).toBeGreaterThan(0);
+
+    await act(async () => { client.options.onEvent({ type: "local.ielts_state", state: { completed: true } }); });
+    expect(client.setMuted).toHaveBeenCalledWith(true);
+    await act(async () => { client.options.onEvent({ type: "local.ielts_state_error", message: "状态更新失败" }); });
+    await act(async () => { client.options.onEvent({ type: "local.backend_warning" }); });
+    await act(async () => { client.options.onEvent({ type: "local.mic_error" }); });
+    expect(screen.getByText("无法访问麦克风")).toBeInTheDocument();
+    await act(async () => { client.options.onEvent({ type: "error", message: "provider error" }); });
+    expect(screen.getByText("provider error")).toBeInTheDocument();
+  });
+
+  it("handles Part 2 transition retries and silence-finish failures", async () => {
+    const client = mockIeltsRealtimeClient();
+    const onNavigate = vi.fn();
+    getIeltsTraining.mockResolvedValue({ topicId: "p2-errors", questions: [{ question: "Describe a useful object" }] });
+    client.transitionIeltsPart2.mockRejectedValueOnce(new Error("preparation transition failed"));
+    const view = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p2", selection: "p2-errors" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 2/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalled());
+    view.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p2", selection: "p2-errors" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(client.options).toBeDefined());
+    await act(async () => {
+      client.options.onEvent({ type: "local.connected" });
+      client.options.onEvent({ type: "response.done" });
+    });
+    await waitFor(() => expect(screen.getByRole("button", { name: "结束准备并开始作答" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "结束准备并开始作答" }));
+    await waitFor(() => expect(screen.getByText("preparation transition failed")).toBeInTheDocument());
+
+    client.transitionIeltsPart2.mockResolvedValueOnce({});
+    fireEvent.click(screen.getByRole("button", { name: "结束准备并开始作答" }));
+    await waitFor(() => expect(client.transitionIeltsPart2).toHaveBeenCalledWith("PREPARATION_COMPLETE"));
+    client.options.onEvent({ type: "local.ielts_input_ready" });
+    await waitFor(() => expect(screen.getByText(/作答时间/)).toBeInTheDocument());
+
+    client.transitionIeltsPart2.mockRejectedValueOnce(new Error("silence finish failed"));
+    vi.useFakeTimers();
+    await act(async () => {
+      client.options.onEvent({ type: "input_audio_buffer.speech_stopped" });
+      vi.advanceTimersByTime(3_000);
+    });
+    vi.useRealTimers();
+    await waitFor(() => expect(screen.getByText("silence finish failed")).toBeInTheDocument());
+  });
+
+  it("shows realtime start and stop errors and tolerates an unavailable evaluation", async () => {
+    const client = mockIeltsRealtimeClient({ start: vi.fn().mockRejectedValue(new Error("realtime start failed")) });
+    const onNavigate = vi.fn();
+    getIeltsTraining.mockResolvedValue({ topicId: "p1-failures", questions: [{ questionText: "Tell me about your home" }] });
+    const view = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p1", selection: "p1-failures" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 1/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalled());
+    view.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p1", selection: "p1-failures" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("realtime start failed")).toBeInTheDocument());
+
+    cleanup();
+    const stopClient = mockIeltsRealtimeClient({ stop: vi.fn().mockRejectedValue(new Error("stop failed")) });
+    generateIeltsEvaluation.mockRejectedValueOnce(new Error("evaluation unavailable"));
+    const stopView = render(<IeltsTrainingCenter route={{ screen: "setup", part: "p1", selection: "p1-failures" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: /准备 Part 1/ })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "确认并开始" }));
+    await waitFor(() => expect(generateIeltsScene).toHaveBeenCalled());
+    stopView.rerender(<IeltsTrainingCenter route={{ screen: "session", part: "p1", selection: "p1-failures" }} onNavigate={onNavigate} onExit={vi.fn()} onAssets={vi.fn()} />);
+    await waitFor(() => expect(stopClient.options).toBeDefined());
+    stopClient.options.onEvent({ type: "local.connected" });
+    fireEvent.click(screen.getByRole("button", { name: "结束本次训练" }));
+    await waitFor(() => expect(screen.getByText("结束练习失败，请稍后重试")).toBeInTheDocument());
+  });
+
+  it("renders rich trends and exercises history recording playback and fallbacks", async () => {
+    const trendReports = [
+      { sessionId: "mock-new", mode: "MOCK_TEST", part: "PART_1", endedAt: "2026-08-25T10:12:00Z", startedAt: "2026-08-25T10:00:00Z", overallBandScore: 7, fluencyCoherenceScore: 7, lexicalResourceScore: 7, grammaticalRangeAccuracyScore: 7, pronunciationScore: 7, partEvaluations: [{ part: "PART_1" }, { part: "PART_3" }] },
+      { sessionId: "mock-old", mode: "MOCK_TEST", part: "PART_2", endedAt: "2026-08-24T10:12:00Z", startedAt: "2026-08-24T10:00:00Z", overallBandScore: 6, fluencyCoherenceScore: 5, lexicalResourceScore: 6, grammaticalRangeAccuracyScore: 7, pronunciationScore: 8 },
+      { sessionId: "part-one", mode: "PART_PRACTICE", part: "PART_1", topicTitles: { PART_1: "Home" }, endedAt: "2026-08-23T10:05:00Z", startedAt: "2026-08-23T10:00:00Z", recordingUrls: ["clip-1", "clip-2"], topicSelectionMethod: "SELECTED", summary: "", strengths: [], improvements: [], recommendedExpressions: [] },
+      { sessionId: "empty-report", mode: "PART_PRACTICE", part: "PART_3", endedAt: "2026-08-22T10:05:00Z", startedAt: "2026-08-22T10:00:00Z", recordingUrls: [] },
+    ];
+    getIeltsEvaluationHistory.mockResolvedValue(trendReports);
+    const onNavigate = vi.fn();
+    const context = mockCanvas();
+    render(<IeltsAssets route={{ tab: "trends" }} onNavigate={onNavigate} onBack={vi.fn()} onBackToAssets={vi.fn()} onBackToInterview={vi.fn()} onTraining={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("最近 2 次变化 +1.0 分")).toBeInTheDocument());
+    expect(screen.getByText("回答长度更稳定")).toBeInTheDocument();
+    expect(screen.getByText("暂无专项评分")).toBeInTheDocument();
+    expect(context.createLinearGradient).toHaveBeenCalled();
+
+    const audios = [];
+    const mediaUrl = { createObjectURL: vi.fn(() => "blob:clip"), revokeObjectURL: vi.fn() };
+    vi.stubGlobal("URL", mediaUrl);
+    window.URL = mediaUrl;
+    vi.stubGlobal("Audio", vi.fn((url) => {
+      const audio = { url, play: vi.fn().mockResolvedValue(undefined), pause: vi.fn(), onended: null, onerror: null };
+      audios.push(audio);
+      return audio;
+    }));
+    fetchAuthenticatedMedia.mockResolvedValue(new Blob(["audio"]));
+    cleanup();
+    render(<IeltsAssets route={{ tab: "history" }} onNavigate={onNavigate} onBack={vi.fn()} onBackToAssets={vi.fn()} onBackToInterview={vi.fn()} onTraining={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Home")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /Part 1 · Home/ }));
+    await waitFor(() => expect(screen.getByRole("button", { name: "播放原始录音" })).toBeInTheDocument());
+    const playButton = screen.getByRole("button", { name: "播放原始录音" });
+    fireEvent.click(playButton);
+    await waitFor(() => expect(fetchAuthenticatedMedia).toHaveBeenCalledWith("clip-1"));
+    await waitFor(() => expect(screen.getByRole("button", { name: "暂停录音" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "暂停录音" }));
+    expect(audios[0].pause).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "播放原始录音" }));
+    await waitFor(() => expect(audios.length).toBeGreaterThan(1));
+    audios[1].onended();
+    await waitFor(() => expect(audios.length).toBeGreaterThan(2));
+    audios[2].onended();
+    await waitFor(() => expect(screen.getByRole("button", { name: "播放原始录音" })).toBeInTheDocument());
+    const emptyReportButton = screen.getAllByRole("button", { name: /Part 3 · Discussion Topic/ }).at(-1);
+    fireEvent.click(emptyReportButton);
+    expect(screen.getByText("本次训练暂未生成文字总结。")).toBeInTheDocument();
+    expect(screen.getByText("暂无录音")).toBeInTheDocument();
+  });
+});

--- a/frontend/web/src/component/interview/__tests__/InterviewModule.test.jsx
+++ b/frontend/web/src/component/interview/__tests__/InterviewModule.test.jsx
@@ -1,0 +1,355 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../infrastructure/http/apiClient.js", () => ({
+  generateInterviewScene: vi.fn(),
+  getInterviewAssets: vi.fn(),
+  getInterviewOcrAvailability: vi.fn(),
+  getInterviewReport: vi.fn(),
+  prepareInterviewMaterials: vi.fn(),
+  retryInterviewReport: vi.fn(),
+}));
+vi.mock("../../../websocket/realtimeClient.js", () => ({ createRealtimeClient: vi.fn() }));
+vi.mock("../../../analytics/analyticsClient.js", () => ({
+  analytics: { training: vi.fn(() => ({ attempt: vi.fn(), started: vi.fn(), complete: vi.fn(), abandon: vi.fn(), fail: vi.fn(), setVisible: vi.fn(), pause: vi.fn(), resume: vi.fn() })) },
+}));
+
+import {
+  generateInterviewScene,
+  getInterviewAssets,
+  getInterviewOcrAvailability,
+  getInterviewReport,
+  prepareInterviewMaterials,
+  retryInterviewReport,
+} from "../../../infrastructure/http/apiClient.js";
+import { createRealtimeClient } from "../../../websocket/realtimeClient.js";
+import { InterviewAssets, InterviewModule } from "../InterviewModule.jsx";
+
+afterEach(() => cleanup());
+beforeEach(() => {
+  vi.clearAllMocks();
+  createRealtimeClient.mockReset();
+  getInterviewOcrAvailability.mockResolvedValue({ available: false });
+  getInterviewAssets.mockResolvedValue([]);
+  getInterviewReport.mockResolvedValue({ status: "PROCESSING", report: null });
+  prepareInterviewMaterials.mockResolvedValue({ material: { jobTitle: "工程师", responsibilities: ["开发"], qualificationRequirements: ["沟通"], finalText: "工程师 · 开发 · 沟通" } });
+  generateInterviewScene.mockResolvedValue({ sceneId: "scene-1" });
+  retryInterviewReport.mockResolvedValue({ status: "PROCESSING", report: null });
+});
+
+function mockInterviewRealtimeClient(overrides = {}) {
+  const client = {
+    start: vi.fn().mockResolvedValue({}),
+    stop: vi.fn().mockResolvedValue({ reportStatus: "PROCESSING" }),
+    pause: vi.fn().mockResolvedValue(),
+    resume: vi.fn().mockResolvedValue(),
+    ...overrides,
+  };
+  createRealtimeClient.mockImplementation((options) => {
+    client.options = options;
+    return client;
+  });
+  return client;
+}
+
+function mockCanvas() {
+  const context = {
+    scale: vi.fn(), clearRect: vi.fn(), beginPath: vi.fn(), moveTo: vi.fn(), lineTo: vi.fn(),
+    stroke: vi.fn(), fill: vi.fn(), closePath: vi.fn(), arc: vi.fn(), fillText: vi.fn(),
+    createLinearGradient: vi.fn(() => ({ addColorStop: vi.fn() })),
+  };
+  vi.spyOn(HTMLCanvasElement.prototype, "getBoundingClientRect").mockReturnValue({ width: 320, height: 160 });
+  vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue(context);
+}
+
+const completedReport = {
+  overallScore: 78,
+  summary: "回答结构清晰",
+  dimensions: [
+    { dimension: "STRUCTURE", score: 82, evaluation: "结构完整", advice: "补充结果" },
+    { dimension: "RELEVANCE", score: 55, evaluation: "相关性一般" },
+    { dimension: "COMMUNICATION", score: 78, evaluation: "表达自然" },
+    { dimension: "DEPTH", score: 70, evaluation: "可以深入" },
+    { dimension: "VOCABULARY_EXPRESSION", score: 80, evaluation: "词汇丰富" },
+  ],
+};
+
+const assetItems = [
+  { sceneId: "scene-complete", jobTitle: "前端工程师", difficulty: "STANDARD", practiceCount: 3, latestSessionId: "session-1", latestReportStatus: "COMPLETED", latestOverallScore: 78, latestPracticedAt: "2026-08-25T10:00:00Z" },
+  { sceneId: "scene-processing", jobTitle: "产品经理", difficulty: "HARD", practiceCount: 1, latestSessionId: "session-2", latestReportStatus: "PROCESSING", latestPracticedAt: "2026-08-24T10:00:00Z" },
+  { sceneId: "scene-new", jobTitle: "设计师", difficulty: "EASY", practiceCount: 0, latestReportStatus: "", latestPracticedAt: null },
+];
+
+describe("InterviewModule home and reports", () => {
+  it("renders the home, validates JD, prepares materials and generates a session", async () => {
+    const onNavigate = vi.fn();
+    render(<InterviewModule route={{ screen: "home" }} onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "模拟面试" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "整理材料" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("请输入 JD 文本");
+    fireEvent.change(screen.getByPlaceholderText(/招聘 JD/), { target: { value: "负责前端开发" } });
+    fireEvent.click(screen.getByRole("button", { name: /困难 每主题/ }));
+    fireEvent.click(screen.getByRole("button", { name: "整理材料" }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    expect(prepareInterviewMaterials).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "确认并生成面试" }));
+    await waitFor(() => expect(generateInterviewScene).toHaveBeenCalledWith(expect.objectContaining({ difficulty: "HARD" })));
+    expect(onNavigate).toHaveBeenCalledWith("/interview/scenes/scene-1/session");
+  });
+
+  it("covers OCR unavailable and material preparation errors", async () => {
+    getInterviewOcrAvailability.mockRejectedValue(new Error("ocr unavailable"));
+    prepareInterviewMaterials.mockRejectedValue(new Error("prepare failed"));
+    render(<InterviewModule route={{ screen: "home" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "上传图片" })).toBeDisabled());
+    fireEvent.change(screen.getByPlaceholderText(/招聘 JD/), { target: { value: "岗位职责" } });
+    fireEvent.click(screen.getByRole("button", { name: "整理材料" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("prepare failed"));
+  });
+
+  it("covers file validation, OCR image input, draft editing, and generation errors", async () => {
+    getInterviewOcrAvailability.mockResolvedValue({ available: true });
+    prepareInterviewMaterials.mockResolvedValue({
+      material: {
+        jobTitle: "工程师", responsibilities: "开发；测试", qualificationRequirements: "沟通;协作",
+        requiredSkills: ["React"], otherJobInformation: "上海", education: ["本科"],
+        finalText: "工程师 · 开发 · 沟通",
+      },
+    });
+    const onNavigate = vi.fn();
+    render(<InterviewModule route={{ screen: "home" }} onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("button", { name: "上传图片" })).not.toBeDisabled());
+    fireEvent.click(screen.getByRole("button", { name: "上传文件" }));
+    const resumeInput = document.querySelector('input[type="file"]');
+    fireEvent.change(resumeInput, { target: { files: [new File(["legacy"], "resume.doc", { type: "application/msword" })] } });
+    expect(screen.getByText(/\.doc 简历暂不支持/)).toBeInTheDocument();
+    fireEvent.change(resumeInput, { target: { files: [new File(["pdf"], "resume.pdf", { type: "application/pdf" })] } });
+    expect(screen.getByText("resume.pdf")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "上传图片" }));
+    const imageInput = document.querySelector('input[accept="image/*"]');
+    fireEvent.click(screen.getByRole("button", { name: "整理材料" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("请选择一张包含 JD 的图片");
+    fireEvent.change(imageInput, { target: { files: [new File(["image"], "jd.png", { type: "image/png" })] } });
+    fireEvent.click(screen.getByRole("button", { name: "整理材料" }));
+    await waitFor(() => expect(screen.getByRole("dialog")).toBeInTheDocument());
+    const responsibilities = screen.getAllByRole("textbox").find((field) => field.value === "开发\n测试");
+    fireEvent.change(responsibilities, { target: { value: "开发\n测试\n交付" } });
+    fireEvent.click(screen.getByRole("button", { name: "重新整理" }));
+    await waitFor(() => expect(prepareInterviewMaterials).toHaveBeenCalledTimes(2));
+    generateInterviewScene.mockRejectedValueOnce(new Error("generation failed"));
+    fireEvent.click(screen.getByRole("button", { name: "确认并生成面试" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("generation failed"));
+    generateInterviewScene.mockResolvedValueOnce({});
+    fireEvent.click(screen.getByRole("button", { name: "确认并生成面试" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("缺少 sceneId"));
+  });
+
+  it("renders processing, failed/retry, and completed interview reports", async () => {
+    const onNavigate = vi.fn();
+    render(<InterviewModule route={{ screen: "report", sceneId: "scene", sessionId: "session" }} onNavigate={onNavigate} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "正在生成面试报告" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "返回" }));
+    expect(onNavigate).toHaveBeenCalledWith("/interview");
+
+    cleanup();
+    getInterviewReport.mockResolvedValue({ status: "FAILED", failureReason: "服务异常", report: null });
+    retryInterviewReport.mockResolvedValue({ status: "COMPLETED", report: completedReport });
+    render(<InterviewModule route={{ screen: "report", sceneId: "scene", sessionId: "session" }} onNavigate={onNavigate} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "报告生成失败" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "重新生成" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "面试表现报告" })).toBeInTheDocument());
+    expect(screen.getAllByText("78").length).toBeGreaterThan(0);
+    fireEvent.click(screen.getByRole("button", { name: "返回训练中心" }));
+    expect(onNavigate).toHaveBeenCalledWith("/interview");
+  });
+
+  it("retries report failures and keeps polling after transient report errors", async () => {
+    getInterviewReport.mockRejectedValueOnce(new Error("report temporarily unavailable"));
+    vi.useFakeTimers();
+    render(<InterviewModule route={{ screen: "report", sceneId: "scene", sessionId: "session" }} onNavigate={vi.fn()} />);
+    await vi.waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("report temporarily unavailable"));
+    retryInterviewReport.mockRejectedValueOnce(new Error("retry failed"));
+    getInterviewReport.mockResolvedValueOnce({ status: "FAILED", report: null });
+    await vi.advanceTimersByTimeAsync(2000);
+    await vi.waitFor(() => expect(screen.getByRole("heading", { name: "报告生成失败" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "重新生成" }));
+    await vi.waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("retry failed"));
+    vi.useRealTimers();
+  });
+
+  it("covers interview realtime lifecycle, transcript, pause, finish, errors, and exit", async () => {
+    const client = mockInterviewRealtimeClient();
+    const onNavigate = vi.fn();
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-1" }} teacher={{ name: "Alex", voiceId: "Aiden", image: "/alex.png" }} speed="自然" onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(client.options).toBeDefined());
+    client.options.onEvent({ type: "local.connecting" });
+    client.options.onEvent({ type: "local.connected", sessionId: "session-1" });
+    client.options.onEvent({ type: "session.updated" });
+    client.options.onEvent({ type: "input_audio_buffer.speech_started" });
+    client.options.onEvent({ type: "response.audio.delta" });
+    client.options.onEvent({ type: "conversation.item.input_audio_transcription.delta", item_id: "u1", delta: "hello" });
+    client.options.onEvent({ type: "conversation.item.input_audio_transcription.text", item_id: "u1", text: "hello world" });
+    client.options.onEvent({ type: "response.audio_transcript.delta", item_id: "a1", delta: "Tell me more" });
+    client.options.onEvent({ type: "local.transcript.final", owner: 0, itemId: "a1", text: "Tell me more" });
+    await waitFor(() => expect(screen.getByText("Tell me more")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "暂停会话" }));
+    await waitFor(() => expect(client.pause).toHaveBeenCalled());
+    fireEvent.click(screen.getByRole("button", { name: "恢复会话" }));
+    await waitFor(() => expect(client.resume).toHaveBeenCalled());
+    client.options.onEvent({ type: "local.interview_state", state: { currentTopic: "行为问题" } });
+    client.options.onEvent({ type: "local.interview_closing" });
+    client.options.onEvent({ type: "local.interview_state", state: { currentTopic: "ignored" } });
+    client.options.onEvent({ type: "local.interview_end_error", message: "end warning" });
+    client.options.onEvent({ type: "local.backend_warning", message: "backend warning" });
+    client.options.onEvent({ type: "local.mic_error", message: "mic failed" });
+    client.options.onEvent({ type: "error", error: { message: "socket failed" } });
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("socket failed"));
+
+    cleanup();
+    const exitClient = mockInterviewRealtimeClient({ stop: vi.fn().mockResolvedValue({}) });
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-2" }} teacher={{ name: "Alex" }} speed="慢一些" onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(exitClient.options).toBeDefined());
+    fireEvent.click(screen.getByRole("button", { name: "退出面试" }));
+    fireEvent.click(screen.getByRole("button", { name: "确认退出" }));
+    await waitFor(() => expect(onNavigate).toHaveBeenCalledWith("/interview"));
+
+    cleanup();
+    const stopClient = mockInterviewRealtimeClient({ stop: vi.fn().mockResolvedValue({ reportStatus: "COMPLETED" }) });
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-3" }} teacher={{ name: "Alex" }} speed="快一些" onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(stopClient.options).toBeDefined());
+    stopClient.options.onEvent({ type: "local.connected", sessionId: "session-3" });
+    fireEvent.click(screen.getByRole("button", { name: "结束面试" }));
+    await waitFor(() => expect(onNavigate).toHaveBeenLastCalledWith("/interview/scenes/scene-3/session/session-3/report"));
+  });
+});
+
+describe("InterviewAssets", () => {
+  it("covers loading, overview, history, trends and asset navigation", async () => {
+    let resolveAssets;
+    getInterviewAssets.mockReturnValueOnce(new Promise((resolve) => { resolveAssets = resolve; }));
+    render(<InterviewAssets route={{ tab: "overview" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    expect(screen.getByRole("status", { name: /正在读取面试学习资产/ })).toBeInTheDocument();
+    resolveAssets([]);
+    cleanup();
+
+    getInterviewAssets.mockResolvedValue(assetItems);
+    getInterviewReport.mockImplementation((sceneId, sessionId) => sceneId === "scene-complete" && sessionId === "session-1"
+      ? Promise.resolve({ status: "COMPLETED", report: completedReport })
+      : Promise.resolve({ status: "PROCESSING", report: null }));
+    const onNavigate = vi.fn();
+    const callbacks = { onBack: vi.fn(), onBackToAssets: vi.fn(), onBackToIelts: vi.fn(), onTraining: vi.fn(), onPractice: vi.fn() };
+    render(<InterviewAssets route={{ tab: "overview" }} onNavigate={onNavigate} {...callbacks} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "面试学习资产" })).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText("前端工程师")).toBeInTheDocument());
+    expect(screen.getByText("优先提升")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /查看能力趋势/ }));
+    expect(onNavigate).toHaveBeenCalledWith("/interview/assets/trends");
+
+    cleanup();
+    render(<InterviewAssets route={{ tab: "history" }} onNavigate={onNavigate} {...callbacks} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "面试记录" })).toBeInTheDocument());
+    expect(screen.getAllByText(/累计练习 3 次/).length).toBeGreaterThan(0);
+    await waitFor(() => expect(screen.getByText("结构完整")).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: /复练本岗位/ }));
+    expect(callbacks.onPractice).toHaveBeenCalledWith("scene-complete");
+    fireEvent.click(screen.getByRole("button", { name: /产品经理/ }));
+    expect(screen.getByText("报告生成中")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /能力趋势/ }));
+    expect(onNavigate).toHaveBeenCalledWith("/interview/assets/trends");
+
+    cleanup();
+    mockCanvas();
+    render(<InterviewAssets route={{ tab: "trends" }} onNavigate={onNavigate} {...callbacks} />);
+    await waitFor(() => expect(screen.getByText("最近五次评分")).toBeInTheDocument());
+    expect(screen.getByText("78")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "切换学习资产模块" }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /IELTS 学习资产/ }));
+    expect(callbacks.onBackToIelts).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /返回训练中心/ }));
+    expect(callbacks.onTraining).toHaveBeenCalled();
+  });
+
+  it("shows API errors and empty history state", async () => {
+    getInterviewAssets.mockRejectedValue(new Error("interview assets down"));
+    render(<InterviewAssets route={{ tab: "overview" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "学习资产加载失败" })).toBeInTheDocument());
+    expect(screen.getByText("interview assets down")).toBeInTheDocument();
+    cleanup();
+    getInterviewAssets.mockResolvedValue([]);
+    render(<InterviewAssets route={{ tab: "history" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("暂无面试学习资产")).toBeInTheDocument());
+  });
+
+  it("covers report fallbacks, unknown dimensions, and retrying processing reports", async () => {
+    getInterviewReport.mockResolvedValue({ status: "COMPLETED", report: { overallScore: "not-a-score", summary: "", dimensions: [] } });
+    render(<InterviewModule route={{ screen: "report", sceneId: "scene-fallback", sessionId: "session-fallback" }} onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "面试表现报告" })).toBeInTheDocument());
+    expect(screen.getByText("本次面试已结束，暂无文字总结。")).toBeInTheDocument();
+    expect(screen.getByText("报告暂未包含分维度评分。")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: "返回训练中心" })[0]);
+
+    cleanup();
+    getInterviewReport.mockResolvedValue({ status: "FAILED", failureReason: "首次失败", report: null });
+    retryInterviewReport.mockResolvedValue({ status: "PROCESSING", report: null });
+    render(<InterviewModule route={{ screen: "report", sceneId: "scene-retry", sessionId: "session-retry" }} onNavigate={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "报告生成失败" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "重新生成" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "正在生成面试报告" })).toBeInTheDocument());
+    expect(retryInterviewReport).toHaveBeenCalledWith("scene-retry", "session-retry");
+  });
+
+  it("handles report polling errors, report retrieval errors in assets, and empty trends", async () => {
+    getInterviewReport.mockRejectedValue(new Error("asset report unavailable"));
+    getInterviewAssets.mockResolvedValue([
+      { sceneId: "scene-failed", jobTitle: "数据工程师", difficulty: "UNKNOWN", practiceCount: 2, latestSessionId: "session-failed", latestReportStatus: "FAILED", latestPracticedAt: null },
+      { sceneId: "scene-new", jobTitle: "未命名岗位", difficulty: "", practiceCount: 0, latestSessionId: null, latestReportStatus: "" },
+    ]);
+    const onPractice = vi.fn();
+    render(<InterviewAssets route={{ tab: "history" }} onNavigate={vi.fn()} onBack={vi.fn()} onPractice={onPractice} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "报告暂不可用" })).toBeInTheDocument());
+    fireEvent.click(screen.getByRole("button", { name: "复练本岗位" }));
+    expect(onPractice).toHaveBeenCalledWith("scene-failed");
+    fireEvent.click(screen.getByRole("button", { name: /未命名岗位/ }));
+    expect(screen.getByRole("heading", { name: "尚未开始面试" })).toBeInTheDocument();
+
+    cleanup();
+    getInterviewAssets.mockResolvedValue([]);
+    render(<InterviewAssets route={{ tab: "trends" }} onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("暂无评分趋势")).toBeInTheDocument());
+    expect(screen.getByText("暂无能力评分")).toBeInTheDocument();
+    expect(screen.getByText("等待报告")).toBeInTheDocument();
+  });
+
+  it("covers interview session start/stop failures, quota completion, and the remote audio fallback", async () => {
+    const startClient = mockInterviewRealtimeClient({ start: vi.fn().mockRejectedValue(new Error("interview start failed")) });
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-start-fail" }} teacher={{ name: "Alex" }} speed="未知" onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("interview start failed"));
+    expect(startClient.options).toBeDefined();
+
+    cleanup();
+    const stopClient = mockInterviewRealtimeClient({ stop: vi.fn().mockRejectedValue(new Error("interview stop failed")) });
+    const onNavigate = vi.fn();
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-stop-fail" }} teacher={{ name: "Alex" }} speed="自然" onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(stopClient.options).toBeDefined());
+    stopClient.options.onEvent({ type: "local.connected", sessionId: "session-stop" });
+    fireEvent.click(screen.getByRole("button", { name: "结束面试" }));
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("interview stop failed"));
+    expect(onNavigate).not.toHaveBeenCalled();
+
+    cleanup();
+    const quotaClient = mockInterviewRealtimeClient({ stop: vi.fn().mockResolvedValue({ reportStatus: null }) });
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-quota" }} teacher={{ name: "Alex" }} speed="适中" onNavigate={onNavigate} onBack={vi.fn()} />);
+    await waitFor(() => expect(quotaClient.options).toBeDefined());
+    quotaClient.options.onEvent({ type: "local.connected", sessionId: "session-quota" });
+    quotaClient.options.onEvent({ type: "local.quota_exhausted", message: "quota exhausted" });
+    await waitFor(() => expect(quotaClient.stop).toHaveBeenCalledWith({ reason: "quota_exhausted" }));
+    await waitFor(() => expect(onNavigate).toHaveBeenLastCalledWith("/interview/scenes/scene-quota/session/session-quota/report"));
+
+    cleanup();
+    const audioClient = mockInterviewRealtimeClient();
+    render(<InterviewModule route={{ screen: "session", sceneId: "scene-audio" }} teacher={{ name: "Alex" }} speed="慢一些" onNavigate={vi.fn()} onBack={vi.fn()} />);
+    await waitFor(() => expect(audioClient.options).toBeDefined());
+    await audioClient.options.onRemoteAudioDrain({ fallbackMs: 1 });
+    expect(audioClient.options.onRemoteAudioDrain).toBeTypeOf("function");
+  });
+});

--- a/frontend/web/src/component/landing/__tests__/LandingPage.test.jsx
+++ b/frontend/web/src/component/landing/__tests__/LandingPage.test.jsx
@@ -1,0 +1,57 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { LandingPage } from "../LandingPage.jsx";
+
+afterEach(() => {
+  cleanup();
+  document.body.className = "";
+});
+
+describe("LandingPage", () => {
+  it("renders the landing content and wires primary actions", () => {
+    const onStart = vi.fn();
+    const onLogin = vi.fn();
+    const onWeb = vi.fn();
+    const onSpecialty = vi.fn();
+    render(<LandingPage onStart={onStart} onLogin={onLogin} onWeb={onWeb} onSpecialty={onSpecialty} />);
+    expect(screen.getByRole("heading", { name: /越说/ })).toBeInTheDocument();
+    expect(screen.getByText("实时语音对话")).toBeInTheDocument();
+    fireEvent.click(screen.getAllByRole("button", { name: /开始练习/ })[0]);
+    fireEvent.click(screen.getByRole("button", { name: "登录" }));
+    fireEvent.click(screen.getByRole("button", { name: "进入 Web" }));
+    fireEvent.click(screen.getByRole("button", { name: "开始体验 IELTS 口语" }));
+    fireEvent.click(screen.getByRole("button", { name: "开始体验英文面试" }));
+    expect(onStart).toHaveBeenCalled();
+    expect(onLogin).toHaveBeenCalledTimes(1);
+    expect(onWeb).toHaveBeenCalledTimes(1);
+    expect(onSpecialty).toHaveBeenNthCalledWith(1, "ielts");
+    expect(onSpecialty).toHaveBeenNthCalledWith(2, "interview");
+  });
+
+  it("opens mobile menu, selects teacher, toggles FAQ, and supports all cta paths", () => {
+    const onStart = vi.fn();
+    const onLogin = vi.fn();
+    render(<LandingPage onStart={onStart} onLogin={onLogin} onWeb={vi.fn()} onSpecialty={vi.fn()} />);
+    const menu = screen.getByRole("button", { name: "打开菜单" });
+    fireEvent.click(menu);
+    expect(screen.getByRole("button", { name: "关闭菜单" })).toBeInTheDocument();
+    expect(document.body).toHaveClass("landing-menu-open");
+    fireEvent.click(screen.getByRole("navigation", { name: "移动端主导航" }).querySelector("a"));
+    expect(screen.getByRole("button", { name: "打开菜单" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "打开菜单" }));
+    fireEvent.click(screen.getByRole("navigation", { name: "移动端主导航" }).parentElement.querySelector("button"));
+    expect(onLogin).toHaveBeenCalled();
+
+    const teachers = screen.getByLabelText("AI 老师列表").querySelectorAll("button");
+    fireEvent.click(teachers[1]);
+    expect(screen.getByRole("heading", { level: 3, name: /James|Clara|David|Emily|Leo|Arthur/ })).toBeInTheDocument();
+    const faqButtons = screen.getAllByRole("button", { name: /吗？|什么？/ });
+    expect(faqButtons[0]).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(faqButtons[0]);
+    expect(faqButtons[0]).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(faqButtons[1]);
+    expect(faqButtons[1]).toHaveAttribute("aria-expanded", "true");
+    fireEvent.click(screen.getAllByRole("button", { name: /免费开始/ })[0]);
+    expect(onStart).toHaveBeenCalled();
+  });
+});

--- a/frontend/web/src/component/profile/__tests__/profile-components.test.jsx
+++ b/frontend/web/src/component/profile/__tests__/profile-components.test.jsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { AboutProduct } from "../AboutProduct.jsx";
+import { AbilityTrendChart } from "../AbilityTrendChart.jsx";
+import { AccountSecurity } from "../AccountSecurity.jsx";
+import { LearningInsights } from "../LearningInsights.jsx";
+import { ProductLegalDocument } from "../ProductLegalDocument.jsx";
+import { WeaknessRecommendations } from "../WeaknessRecommendations.jsx";
+
+vi.mock("../../../infrastructure/http/apiClient.js", () => ({
+  getProfileInsights: vi.fn(),
+  updateWeeklyLearningGoals: vi.fn(),
+}));
+
+import { getProfileInsights, updateWeeklyLearningGoals } from "../../../infrastructure/http/apiClient.js";
+
+afterEach(() => cleanup());
+beforeEach(() => vi.clearAllMocks());
+
+const insightPayload = {
+  weeklyGoals: {
+    weekStartsAt: "2026-08-24T00:00:00+08:00",
+    weekEndsAt: "2026-08-31T00:00:00+08:00",
+    completedDurationSeconds: 90,
+    remainingDurationSeconds: 120,
+    durationTargetMinutes: 10,
+    durationProgress: 12.5,
+    durationAchieved: false,
+    completedTrainingCount: 2,
+    trainingCountTarget: 3,
+    countProgress: 66.6,
+    remainingTrainingCount: 1,
+    countAchieved: false,
+  },
+  trainingTypeDistribution: [
+    { type: "FREE_CHAT", durationSeconds: 60, percentage: 50 },
+    { type: "UNKNOWN", durationSeconds: 60, percentage: 50 },
+    { type: "CUSTOM_SCENE", durationSeconds: 0, percentage: 0 },
+  ],
+  abilityTrends: [
+    { sessionId: "one", completedAt: "2026-08-24T12:00:00+08:00", trainingType: "FREE_CHAT", scores: { accuracy: 90, fluency: 30 } },
+    { sessionId: "two", completedAt: "2026-08-25T12:00:00+08:00", trainingType: "CUSTOM_SCENE", scores: { accuracy: 120, fluency: -1, grammar: 50 } },
+  ],
+  weaknessAnalysis: { sampleCount: 3, minimumSampleCount: 3, reliable: true },
+  weaknesses: [
+    { dimension: "accuracy", rank: 1, averageScore: 78.5, basis: "最近准确度需要加强", recentChange: 2.5 },
+    { dimension: "fluency", rank: 2, averageScore: 60, basis: "表达容易停顿", recentChange: -3 },
+    { dimension: "unknown", rank: 3, averageScore: 0, basis: "综合", recentChange: 0 },
+  ],
+  recommendations: [
+    { dimension: "accuracy", trainingType: "FREE_CHAT", reason: "通过自由对话保持准确表达" },
+    { dimension: "fluency", trainingType: "IELTS_SCENE", reason: "专项入口建设中" },
+  ],
+};
+
+describe("profile presentation components", () => {
+  it("covers empty and interactive ability trend chart states", () => {
+    const { rerender } = render(<AbilityTrendChart items={[]} />);
+    expect(screen.getByText("暂无可用的五维评分报告")).toBeInTheDocument();
+    rerender(<AbilityTrendChart items={insightPayload.abilityTrends} />);
+    expect(screen.getByRole("img", { name: /准确度最近 2 次评分趋势/ })).toBeInTheDocument();
+    expect(screen.getByText("最近 2 次有效评分")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "流利度" }));
+    expect(screen.getByRole("img", { name: /流利度最近 2 次评分趋势/ })).toBeInTheDocument();
+    fireEvent.focus(screen.getAllByRole("img", { name: /流利度/ })[0]);
+  });
+
+  it("renders weak sample state and supported/unsupported recommendations", () => {
+    const onStart = vi.fn();
+    const { rerender } = render(<WeaknessRecommendations analysis={{ sampleCount: 1, minimumSampleCount: 3, reliable: false }} />);
+    expect(screen.getByText("还需 2 次有效评分")).toBeInTheDocument();
+    rerender(<WeaknessRecommendations analysis={insightPayload.weaknessAnalysis} weaknesses={insightPayload.weaknesses} recommendations={insightPayload.recommendations} onStartTraining={onStart} />);
+    expect(screen.getByText("准确度")).toBeInTheDocument();
+    expect(screen.getAllByRole("button", { name: "建设中" })[0]).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "开始训练" }));
+    expect(onStart).toHaveBeenCalledWith("FREE_CHAT");
+    expect(screen.getAllByRole("button", { name: "建设中" })).toHaveLength(2);
+  });
+
+  it("loads learning insights, edits goals, validates and saves", async () => {
+    getProfileInsights.mockResolvedValue(insightPayload);
+    updateWeeklyLearningGoals.mockResolvedValue({ ...insightPayload, weeklyGoals: { ...insightPayload.weeklyGoals, durationAchieved: true, countAchieved: true } });
+    render(<LearningInsights onStartTraining={vi.fn()} />);
+    await waitFor(() => expect(screen.getByRole("heading", { name: "学习目标与洞察" })).toBeInTheDocument());
+    expect(screen.getByText(/还差 2 分钟/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /调整目标/ }));
+    expect(screen.getByRole("dialog", { name: "调整每周目标" })).toBeInTheDocument();
+    const inputs = screen.getByRole("dialog").querySelectorAll("input");
+    fireEvent.change(inputs[0], { target: { value: "0" } });
+    fireEvent.submit(screen.getByRole("dialog").querySelector("form"));
+    expect(screen.getByRole("alert")).toHaveTextContent("时长目标需在");
+    fireEvent.change(inputs[0], { target: { value: "20" } });
+    fireEvent.change(inputs[1], { target: { value: "4" } });
+    fireEvent.click(screen.getByRole("button", { name: "保存目标" }));
+    await waitFor(() => expect(updateWeeklyLearningGoals).toHaveBeenCalledWith({ durationTargetMinutes: 20, trainingCountTarget: 4 }));
+  });
+
+  it("shows insight load errors and retry", async () => {
+    getProfileInsights.mockRejectedValueOnce(new Error("网络不可用")).mockResolvedValueOnce(insightPayload);
+    render(<LearningInsights />);
+    await waitFor(() => expect(screen.getByRole("alert")).toHaveTextContent("网络不可用"));
+    fireEvent.click(screen.getByRole("button", { name: /重新加载/ }));
+    await waitFor(() => expect(getProfileInsights).toHaveBeenCalledTimes(2));
+  });
+
+  it("renders account, about, and legal pages with navigation callbacks", () => {
+    const onNavigate = vi.fn();
+    const onHelpNavigate = vi.fn();
+    const onOpenPassword = vi.fn();
+    const onLogout = vi.fn();
+    render(<AccountSecurity email="person@example.com" onOpenPassword={onOpenPassword} onLogout={onLogout} />);
+    expect(screen.getByText("person@example.com")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: /修改密码/ }));
+    fireEvent.click(screen.getByRole("button", { name: /退出登录/ }));
+    expect(onOpenPassword).toHaveBeenCalled();
+    expect(onLogout).toHaveBeenCalled();
+    cleanup();
+
+    render(<AboutProduct onNavigate={onNavigate} onHelpNavigate={onHelpNavigate} />);
+    expect(screen.getByRole("heading", { name: "关于 UniSpeaking" })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: /用户协议/ }));
+    fireEvent.click(screen.getByRole("link", { name: /帮助中心/ }));
+    expect(onNavigate).toHaveBeenCalled();
+    expect(onHelpNavigate).toHaveBeenCalledWith("/help");
+    cleanup();
+
+    render(<ProductLegalDocument documentId="privacy-policy" onNavigate={onNavigate} />);
+    expect(screen.getByRole("heading", { name: /隐私政策/ })).toBeInTheDocument();
+    expect(screen.getByText("开发草案")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("link", { name: /返回关于产品/ }));
+    expect(onNavigate).toHaveBeenCalledWith("/about");
+    cleanup();
+    render(<ProductLegalDocument documentId="unknown" />);
+    expect(screen.getByRole("heading", { name: /用户协议/ })).toBeInTheDocument();
+  });
+});

--- a/frontend/web/src/controller/__tests__/App.test.jsx
+++ b/frontend/web/src/controller/__tests__/App.test.jsx
@@ -1,0 +1,1474 @@
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockApi = vi.hoisted(() => ({
+  changePassword: vi.fn(),
+  clearAuthSession: vi.fn(),
+  advanceCustomSceneFlow: vi.fn(),
+  createCustomSceneFlow: vi.fn(),
+  deleteLearningAsset: vi.fn(),
+  evaluateSentenceReading: vi.fn(),
+  generateCustomScene: vi.fn(),
+  getDailyPicks: vi.fn(),
+  getAchievementOverview: vi.fn(),
+  getAccessToken: vi.fn(),
+  getCurrentUser: vi.fn(),
+  getLearningAsset: vi.fn(),
+  getLearningAssets: vi.fn(),
+  getProfileOverview: vi.fn(),
+  getUserPreference: vi.fn(),
+  synthesizeSpeech: vi.fn(),
+  translateSceneText: vi.fn(),
+  translateSessionText: vi.fn(),
+  updateProfile: vi.fn(),
+  updateUserPreference: vi.fn(),
+  uploadProfileAvatar: vi.fn(),
+  revokeWebSession: vi.fn(),
+}));
+
+const mockAuthApi = vi.hoisted(() => ({
+  issueEmailChallenge: vi.fn(),
+  issuePasswordResetChallenge: vi.fn(),
+  loginWithPassword: vi.fn(),
+  logoutUser: vi.fn(),
+  registerWithEmail: vi.fn(),
+  resetPasswordWithEmail: vi.fn(),
+  validateRegistrationCredentials: vi.fn(),
+}));
+
+const mockAnalytics = vi.hoisted(() => ({
+  setDistinctId: vi.fn(),
+  trackPageView: vi.fn(),
+  trackModeSelection: vi.fn(),
+  trackLearningAsset: vi.fn(),
+  training: vi.fn(() => ({
+    attempt: vi.fn(),
+    started: vi.fn(),
+    fail: vi.fn(),
+    complete: vi.fn(),
+    abandon: vi.fn(),
+    pause: vi.fn(),
+    resume: vi.fn(),
+    setVisible: vi.fn(),
+  })),
+}));
+
+const mockRealtime = vi.hoisted(() => ({
+  clients: [],
+  createRealtimeClient: vi.fn((options = {}) => {
+    const client = {
+      options,
+      start: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      stop: vi.fn(),
+    };
+    mockRealtime.clients.push(client);
+    return client;
+  }),
+  realtimeFailureMessage: vi.fn((error) => error?.message || "实时连接失败"),
+}));
+
+const mockRecorder = vi.hoisted(() => ({
+  create: vi.fn(),
+}));
+
+const mockAchievements = vi.hoisted(() => ({
+  synchronizeAchievements: vi.fn().mockResolvedValue(undefined),
+  clearAchievementNotifications: vi.fn(),
+}));
+
+vi.mock("@phosphor-icons/react", () => {
+  const Icon = () => null;
+  return {
+    ArrowLeft: Icon,
+    ArrowClockwise: Icon,
+    ArrowRight: Icon,
+    ArrowsClockwise: Icon,
+    BookOpenText: Icon,
+    Briefcase: Icon,
+    CalendarBlank: Icon,
+    CaretDown: Icon,
+    CaretRight: Icon,
+    Subtitles: Icon,
+    Check: Icon,
+    CheckCircle: Icon,
+    Clock: Icon,
+    Crown: Icon,
+    EnvelopeSimple: Icon,
+    Eye: Icon,
+    EyeSlash: Icon,
+    Fire: Icon,
+    GearSix: Icon,
+    Headphones: Icon,
+    Lifebuoy: Icon,
+    LockKey: Icon,
+    Medal: Icon,
+    Microphone: Icon,
+    MicrophoneSlash: Icon,
+    PaperPlaneTilt: Icon,
+    Pause: Icon,
+    PencilSimple: Icon,
+    PhoneDisconnect: Icon,
+    Play: Icon,
+    Plus: Icon,
+    ShieldCheck: Icon,
+    SignOut: Icon,
+    SlidersHorizontal: Icon,
+    SpeakerHigh: Icon,
+    SpeakerSlash: Icon,
+    SquaresFour: Icon,
+    Trash: Icon,
+    Translate: Icon,
+    UploadSimple: Icon,
+    User: Icon,
+    Waveform: Icon,
+    X: Icon,
+  };
+});
+
+vi.mock("lucide-react", () => {
+  const Icon = () => null;
+  return {
+    AudioLines: Icon,
+    CalendarCheck2: Icon,
+    ChevronLeft: Icon,
+    ChevronRight: Icon,
+    Compass: Icon,
+    Footprints: Icon,
+    Info: Icon,
+    MessagesSquare: Icon,
+    PackageCheck: Icon,
+    Sparkles: Icon,
+    Target: Icon,
+    ChartLine: Icon,
+  };
+});
+
+vi.mock("../../infrastructure/http/apiClient.js", () => ({
+  AUTH_SESSION_EXPIRED_EVENT: "unispeaking:auth-session-expired",
+  ...mockApi,
+}));
+
+vi.mock("../../userAuthApi.js", () => ({
+  ...mockAuthApi,
+  UserAuthApiError: class UserAuthApiError extends Error {
+    constructor(code, message) {
+      super(message);
+      this.name = "UserAuthApiError";
+      this.code = code;
+    }
+  },
+}));
+
+vi.mock("../../analytics/analyticsClient.js", () => ({ analytics: mockAnalytics }));
+vi.mock("../../websocket/realtimeClient.js", () => mockRealtime);
+vi.mock("../../infrastructure/audio/audioRecorder.js", () => ({
+  createPcmWavRecorder: mockRecorder.create,
+}));
+vi.mock("../../component/achievement/AchievementNotifications.jsx", () => ({
+  useAchievementNotifications: () => mockAchievements,
+}));
+
+function Stub({ name, children, ...props }) {
+  return <section data-testid={`stub-${name}`} {...props}>{children || name}</section>;
+}
+
+vi.mock("../../component/ielts/IeltsModule.jsx", () => ({
+  IeltsAssets: (props) => <Stub name="ielts-assets">
+    <button onClick={props.onBack}>返回场景广场</button>
+    <button onClick={() => props.onNavigate("/ielts/assets/history")}>打开雅思历史</button>
+    <button onClick={props.onBackToAssets}>返回普通资产</button>
+    <button onClick={props.onBackToInterview}>打开面试资产</button>
+    <button onClick={props.onTraining}>开始雅思训练</button>
+  </Stub>,
+  IeltsTrainingCenter: (props) => <Stub name="ielts-training">
+    <button onClick={() => props.onNavigate("/ielts/assets")}>打开雅思资产</button>
+    <button onClick={props.onExit}>返回场景广场</button>
+    <button onClick={props.onAssets}>打开雅思资产入口</button>
+  </Stub>,
+}));
+vi.mock("../../component/interview/InterviewModule.jsx", () => ({
+  InterviewAssets: (props) => <Stub name="interview-assets">
+    <button onClick={() => props.onNavigate("/interview/assets/history")}>打开面试历史</button>
+    <button onClick={props.onBack}>返回场景广场</button>
+    <button onClick={props.onBackToAssets}>返回普通资产</button>
+    <button onClick={props.onBackToIelts}>打开雅思资产</button>
+    <button onClick={props.onTraining}>开始面试训练</button>
+    <button onClick={() => props.onPractice("practice-scene")}>复练面试场景</button>
+  </Stub>,
+  InterviewModule: (props) => <Stub name="interview-training">
+    <button onClick={() => props.onNavigate("/interview/assets")}>打开面试资产</button>
+    <button onClick={props.onBack}>返回场景广场</button>
+  </Stub>,
+}));
+vi.mock("../../component/help/HelpCenter.jsx", () => ({
+  HelpCenter: ({ route, onNavigate }) => (
+    <Stub name="help-center">
+      <output data-testid="help-route">{JSON.stringify(route || null)}</output>
+      <button onClick={() => onNavigate?.("/help")}>帮助首页</button>
+      <button onClick={() => onNavigate?.("/help/category/account")}>账户分类</button>
+      <button onClick={() => onNavigate?.("/help/article/session-expired")}>会话文章</button>
+    </Stub>
+  ),
+}));
+vi.mock("../../component/help/HelpLayout.jsx", () => ({ HelpLayout: ({ children }) => <Stub name="help-layout">{children}</Stub> }));
+vi.mock("../../component/help/ExternalFeedbackLink.jsx", () => ({ feedbackUrl: "https://feedback.example.com" }));
+vi.mock("../../component/landing/LandingPage.jsx", () => ({
+  LandingPage: ({ onLogin, onStart, onWeb, onSpecialty }) => (
+    <main data-testid="landing-page">
+      <button onClick={() => onStart("Tina")}>开始体验</button>
+      <button onClick={onLogin}>登录</button>
+      <button onClick={onWeb}>打开应用</button>
+      <button onClick={() => onSpecialty("ielts")}>雅思专项</button>
+      <button onClick={() => onSpecialty("interview")}>英文面试</button>
+      <button onClick={() => onSpecialty("unknown")}>未知专项</button>
+    </main>
+  ),
+}));
+vi.mock("../../component/common/NewtonsCradle.jsx", () => ({ NewtonsCradle: () => null }));
+vi.mock("../../component/common/Modal.jsx", () => ({ Modal: ({ children }) => <div role="dialog">{children}</div> }));
+vi.mock("../../component/profile/LearningInsights.jsx", () => ({
+  LearningInsights: ({ onStartTraining }) => (
+    <Stub name="learning-insights">
+      <button onClick={() => onStartTraining("FREE_CHAT")}>开始自由对话</button>
+      <button onClick={() => onStartTraining("CUSTOM_SCENE")}>开始场景训练</button>
+    </Stub>
+  ),
+}));
+vi.mock("../../component/profile/AccountSecurity.jsx", () => ({
+  AccountSecurity: ({ onOpenPassword, onLogout }) => (
+    <Stub name="account-security">
+      <button onClick={onOpenPassword}>修改密码</button>
+      <button onClick={onLogout}>安全页退出登录</button>
+    </Stub>
+  ),
+}));
+vi.mock("../../component/profile/AboutProduct.jsx", () => ({
+  AboutProduct: ({ onNavigate, onHelpNavigate }) => (
+    <Stub name="about-product">
+      <button onClick={() => onNavigate("/about/user-agreement")}>用户协议</button>
+      <button onClick={() => onHelpNavigate("/help")}>帮助中心</button>
+    </Stub>
+  ),
+}));
+vi.mock("../../component/profile/ProductLegalDocument.jsx", () => ({
+  ProductLegalDocument: ({ onNavigate }) => (
+    <Stub name="legal-document">
+      <button onClick={() => onNavigate("/about")}>返回关于产品</button>
+    </Stub>
+  ),
+}));
+vi.mock("../../HumanVerification.jsx", () => ({
+  HumanVerification: ({ onVerify }) => <button type="button" onClick={() => onVerify("human-token")}>人机验证</button>,
+}));
+
+const { App } = await import("../App.jsx");
+
+function resetLocation(path = "/") {
+  window.history.replaceState({}, "", path);
+}
+
+function configureAuthenticatedDefaults() {
+  window.sessionStorage.setItem("unispeaking.accessToken", "session-token");
+  mockApi.getAccessToken.mockImplementation(() => window.sessionStorage.getItem("unispeaking.accessToken"));
+  mockApi.getCurrentUser.mockResolvedValue({ id: "user-1", nickname: "测试用户" });
+  mockApi.getUserPreference.mockResolvedValue({ cefrLevel: "B1", preferredVoice: "Tina", preferredAiSpeechSpeed: "NATURAL" });
+  mockApi.getProfileOverview.mockResolvedValue({
+    account: {
+      userId: "user-1",
+      nickname: "测试用户",
+      displayName: "测试用户",
+      email: "user@example.com",
+    },
+    calendar: {
+      month: "2026-08",
+      checkedDates: ["2026-08-01"],
+      checkedInToday: false,
+    },
+    statistics: {
+      weeklyPracticeSeconds: 125,
+      trainingRecordCount: 1,
+      consecutiveLearningDays: 2,
+      lastSevenDays: [],
+    },
+  });
+  mockApi.getDailyPicks.mockResolvedValue({ picks: [] });
+}
+
+describe("App", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  beforeEach(() => {
+    resetLocation("/");
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+    vi.clearAllMocks();
+    mockRealtime.clients.length = 0;
+    mockApi.getAccessToken.mockReturnValue(null);
+    mockApi.getDailyPicks.mockResolvedValue({ picks: [] });
+    mockApi.getAchievementOverview.mockResolvedValue({ achievements: [] });
+    mockApi.getLearningAssets.mockResolvedValue([]);
+    mockApi.getLearningAsset.mockResolvedValue(null);
+    mockApi.getProfileOverview.mockResolvedValue({ account: { userId: "user-1" } });
+    mockApi.getUserPreference.mockResolvedValue({ cefrLevel: "B1", preferredVoice: "Tina" });
+    mockApi.updateUserPreference.mockResolvedValue({ cefrLevel: "B1", preferredVoice: "Tina" });
+    mockApi.translateSessionText.mockResolvedValue({ translatedText: "你好" });
+    mockApi.translateSceneText.mockResolvedValue({ translatedText: "中文摘要" });
+    mockApi.synthesizeSpeech.mockResolvedValue(new Blob(["audio"], { type: "audio/wav" }));
+    mockApi.generateCustomScene.mockResolvedValue(null);
+    mockApi.createCustomSceneFlow.mockResolvedValue(undefined);
+    mockApi.advanceCustomSceneFlow.mockResolvedValue(undefined);
+    mockApi.evaluateSentenceReading.mockResolvedValue({ overallScore: 88, passed: true, words: [] });
+    mockRecorder.create.mockResolvedValue({
+      stop: vi.fn().mockResolvedValue(new Blob(["wav"], { type: "audio/wav" })),
+      cancel: vi.fn(),
+    });
+    mockRealtime.createRealtimeClient.mockImplementation((options = {}) => {
+      const client = {
+        options,
+        start: vi.fn().mockResolvedValue({ sessionId: "default-session" }),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockRealtime.clients.push(client);
+      return client;
+    });
+    HTMLCanvasElement.prototype.getContext = vi.fn(() => ({
+      scale: vi.fn(),
+      clearRect: vi.fn(),
+      beginPath: vi.fn(),
+      moveTo: vi.fn(),
+      lineTo: vi.fn(),
+      closePath: vi.fn(),
+      stroke: vi.fn(),
+      fill: vi.fn(),
+      arc: vi.fn(),
+      fillText: vi.fn(),
+    }));
+    mockAuthApi.validateRegistrationCredentials.mockReturnValue(null);
+    if (!URL.createObjectURL) URL.createObjectURL = vi.fn();
+    if (!URL.revokeObjectURL) URL.revokeObjectURL = vi.fn();
+    URL.createObjectURL = vi.fn(() => "blob:avatar-preview");
+    URL.revokeObjectURL = vi.fn();
+    window.alert = vi.fn();
+  });
+
+  it("renders the splash route, removes a legacy local token, and enters auth", async () => {
+    window.localStorage.setItem("unispeaking.accessToken", "legacy-token");
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByTestId("landing-page")).toBeInTheDocument());
+    expect(window.localStorage.getItem("unispeaking.accessToken")).toBeNull();
+    expect(mockApi.getAccessToken).toHaveBeenCalled();
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "登录" }));
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/login");
+  });
+
+  it("logs in through the auth screen and navigates the authenticated shell", async () => {
+    resetLocation("/login");
+    mockApi.getAccessToken.mockReturnValue(null);
+    mockAuthApi.loginWithPassword.mockResolvedValue({ accessToken: "session-token", user: { id: "user-1" } });
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "欢迎回来" });
+    await user.type(screen.getByLabelText("邮箱"), "user@example.com");
+    await user.type(screen.getByLabelText("密码"), "a-valid-password");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+
+    await waitFor(() => expect(mockAuthApi.loginWithPassword).toHaveBeenCalledWith(
+      "user@example.com",
+      "a-valid-password",
+      "human-token",
+    ));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "想聊什么都可以" })).toBeInTheDocument());
+    expect(mockApi.getUserPreference).toHaveBeenCalled();
+    expect(mockAnalytics.setDistinctId).toHaveBeenCalledWith("user-1");
+  });
+
+  it("navigates from conversation to scenes and the mocked IELTS page", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+    await user.click(screen.getByRole("button", { name: "场景广场" }));
+    expect(await screen.findByRole("heading", { name: "场景广场" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /雅思口语/ }));
+    expect(await screen.findByTestId("stub-ielts-training")).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/ielts");
+    expect(mockAnalytics.trackModeSelection).toHaveBeenCalledWith(
+      { mode: "IELTS", pageCode: "ielts-training" },
+      "scene-plaza",
+    );
+  });
+
+  it("records the return path and shows login after session expiration", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    render(<App />);
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+
+    fireEvent(window, new Event("unispeaking:auth-session-expired"));
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/login");
+    expect(window.sessionStorage.getItem("unispeaking.authReturnPath")).toBe("/conversation");
+    expect(mockAchievements.clearAchievementNotifications).toHaveBeenCalled();
+  });
+
+  it("keeps public help accessible without an authentication token", async () => {
+    resetLocation("/help");
+    render(<App />);
+    expect(await screen.findByTestId("stub-help-center")).toBeInTheDocument();
+    expect(screen.getByTestId("stub-help-layout")).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/help");
+  });
+
+  it("renders profile navigation and stores a selected page", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+
+    const sidebar = screen.getByRole("complementary");
+    await user.click(within(sidebar).getByRole("button", { name: "个人中心" }));
+    expect(await screen.findByRole("heading", { name: "你的学习空间" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/profile");
+  });
+
+  it("registers an account through email verification and enters level setup", async () => {
+    resetLocation("/signup");
+    mockAuthApi.issueEmailChallenge.mockResolvedValue({ challengeId: "signup-challenge" });
+    mockAuthApi.registerWithEmail.mockResolvedValue({
+      accessToken: "signup-token",
+      user: { id: "user-2", nickname: "新用户" },
+    });
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+    await user.type(screen.getByLabelText("邮箱"), "new@example.com");
+    await user.type(screen.getByLabelText("昵称"), "新用户");
+    await user.type(screen.getByLabelText("密码"), "a-valid-password");
+    await user.type(screen.getByLabelText("确认密码"), "a-valid-password");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+
+    expect(await screen.findByRole("heading", { name: "验证你的邮箱" })).toBeInTheDocument();
+    expect(mockAuthApi.issueEmailChallenge).toHaveBeenCalledWith("new@example.com", "human-token");
+    await user.type(screen.getByLabelText("6 位验证码"), "12a3456");
+    expect(screen.getByLabelText("6 位验证码")).toHaveValue("123456");
+    await user.click(screen.getByRole("button", { name: "完成注册" }));
+
+    await waitFor(() => expect(mockAuthApi.registerWithEmail).toHaveBeenCalledWith({
+      email: "new@example.com",
+      password: "a-valid-password",
+      nickname: "新用户",
+      challengeId: "signup-challenge",
+      code: "123456",
+    }));
+    expect(await screen.findByRole("heading", { name: /你现在说英语时/ })).toBeInTheDocument();
+  });
+
+  it("resets a password after switching from login to reset verification", async () => {
+    resetLocation("/login");
+    mockAuthApi.issuePasswordResetChallenge.mockResolvedValue({ challengeId: "reset-challenge" });
+    mockAuthApi.resetPasswordWithEmail.mockResolvedValue({ success: true });
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "欢迎回来" });
+    await user.click(screen.getByRole("button", { name: "忘记密码？" }));
+    expect(screen.getByRole("heading", { name: "重置密码" })).toBeInTheDocument();
+    await user.type(screen.getByLabelText("邮箱"), "reset@example.com");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+
+    expect(await screen.findByLabelText("6 位验证码")).toBeInTheDocument();
+    expect(mockAuthApi.issuePasswordResetChallenge).toHaveBeenCalledWith("reset@example.com", "human-token");
+    await user.type(screen.getByLabelText("6 位验证码"), "654321");
+    await user.type(screen.getByPlaceholderText("至少 12 位字符"), "new-valid-password");
+    await user.type(screen.getByPlaceholderText("再次输入新密码"), "new-valid-password");
+    await user.click(screen.getByRole("button", { name: "重置密码" }));
+
+    await waitFor(() => expect(mockAuthApi.resetPasswordWithEmail).toHaveBeenCalledWith({
+      email: "reset@example.com",
+      password: "new-valid-password",
+      challengeId: "reset-challenge",
+      code: "654321",
+    }));
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(screen.getByRole("status")).toHaveTextContent("密码已重置");
+  });
+
+  it("covers profile help, about, legal document, and recommended training navigation", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile");
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "你的学习空间" });
+
+    const profileNav = screen.getByRole("navigation", { name: "个人中心导航" });
+    await user.click(within(profileNav).getByRole("button", { name: "学习目标与洞察" }));
+    expect(await screen.findByTestId("stub-learning-insights")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "开始自由对话" }));
+    expect(await screen.findByRole("heading", { name: "想聊什么都可以" })).toBeInTheDocument();
+
+    await user.click(within(screen.getByRole("complementary")).getByRole("button", { name: "个人中心" }));
+    await user.click(within(screen.getByRole("navigation", { name: "个人中心导航" })).getByRole("button", { name: "帮助中心" }));
+    expect(await screen.findByTestId("stub-help-center")).toBeInTheDocument();
+
+    await user.click(within(screen.getByRole("navigation", { name: "个人中心导航" })).getByRole("button", { name: "关于产品" }));
+    expect(await screen.findByTestId("stub-about-product")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "用户协议" }));
+    expect(await screen.findByTestId("stub-legal-document")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回关于产品" }));
+    expect(await screen.findByTestId("stub-about-product")).toBeInTheDocument();
+    await user.click(within(screen.getByTestId("stub-about-product")).getByRole("button", { name: "帮助中心" }));
+    expect(await screen.findByTestId("stub-help-center")).toBeInTheDocument();
+  });
+
+  it("updates assistant settings and shows the synchronized state", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/settings");
+    mockApi.updateUserPreference.mockResolvedValue({
+      cefrLevel: "A",
+      preferredVoice: "Katerina",
+      preferredAiSpeechSpeed: "SLOWER",
+    });
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "AI 助手设置" });
+
+    await user.click(screen.getByRole("button", { name: "慢一些" }));
+    await waitFor(() => expect(mockApi.updateUserPreference).toHaveBeenCalledWith({ preferredAiSpeechSpeed: "SLOWER" }));
+    expect(screen.getByText("设置已同步")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /刚开始学/ }));
+    await user.click(screen.getByRole("option", { name: /可以简单交流/ }));
+    await waitFor(() => expect(mockApi.updateUserPreference).toHaveBeenCalledWith({ cefrLevel: "B" }));
+
+    await user.click(screen.getByRole("button", { name: /Clara/ }));
+    await waitFor(() => expect(mockApi.updateUserPreference).toHaveBeenCalledWith({ preferredVoice: "Katerina" }));
+  });
+
+  it("confirms logout and returns to the splash page", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile");
+    mockAuthApi.logoutUser.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "你的学习空间" });
+
+    await user.click(screen.getByRole("button", { name: "退出登录" }));
+    expect(screen.getByRole("heading", { name: "确定要退出登录吗？" })).toBeInTheDocument();
+    await user.click(within(screen.getByRole("dialog")).getByRole("button", { name: "退出登录" }));
+    await waitFor(() => expect(mockAuthApi.logoutUser).toHaveBeenCalledTimes(1));
+    expect(await screen.findByTestId("landing-page")).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/");
+    expect(mockAchievements.clearAchievementNotifications).toHaveBeenCalled();
+  });
+
+  it("loads, filters, opens, and deletes a scene learning asset", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/assets");
+    const record = {
+      sceneId: "scene-1",
+      title: "咖啡店点单",
+      label: "餐饮",
+      latestPracticedAt: "2026-08-01T10:00:00Z",
+      latestSessionId: "session-1",
+      latestScore: 84,
+    };
+    mockApi.getLearningAssets.mockResolvedValue([record]);
+    mockApi.getLearningAsset.mockResolvedValue({
+      ...record,
+      aiRole: "咖啡师",
+      dialogueEvaluation: { dialogue: [], turnEvaluation: [] },
+      wordList: [{ contentId: "word-1", englishText: "latte", chineseText: "拿铁" }],
+      phraseList: [],
+      sentenceList: [],
+    });
+    mockApi.deleteLearningAsset.mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "学习资产" });
+    expect(await screen.findByRole("button", { name: /咖啡店点单/ })).toBeInTheDocument();
+    expect(await screen.findByText("latte")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "餐饮" }));
+    expect(screen.getByRole("button", { name: /咖啡店点单/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "删除当前学习资产" }));
+    expect(screen.getByRole("heading", { name: "删除当前学习资产？" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "确认删除" }));
+    await waitFor(() => expect(mockApi.deleteLearningAsset).toHaveBeenCalledWith("scene-1"));
+  });
+
+  it("covers authentication validation, mode switching, and the onboarding steps", async () => {
+    resetLocation("/signup");
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "创建账号" });
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("请输入有效邮箱地址");
+
+    await user.type(screen.getByLabelText("邮箱"), "onboard@example.com");
+    await user.type(screen.getByLabelText("昵称"), "测试昵称");
+    await user.type(screen.getByLabelText("密码"), "short");
+    await user.type(screen.getByLabelText("确认密码"), "different-password");
+    mockAuthApi.validateRegistrationCredentials.mockReturnValue("WEAK_PASSWORD");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("密码至少需要 12 位字符");
+
+    mockAuthApi.validateRegistrationCredentials.mockReturnValue(null);
+    await user.clear(screen.getByLabelText("密码"));
+    await user.type(screen.getByLabelText("密码"), "a-valid-password");
+    await user.clear(screen.getByLabelText("确认密码"));
+    await user.type(screen.getByLabelText("确认密码"), "a-valid-password");
+    mockAuthApi.issueEmailChallenge.mockResolvedValue({ challengeId: "onboard-challenge" });
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+    expect(await screen.findByRole("heading", { name: "验证你的邮箱" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回修改邮箱" }));
+    expect(screen.getByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+    expect(screen.getByLabelText("密码")).toHaveValue("a-valid-password");
+
+    await user.click(screen.getByRole("button", { name: "直接登录" }));
+    expect(screen.getByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "创建账号" }));
+    expect(screen.getByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+
+    resetLocation("/login");
+    cleanup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "欢迎回来" });
+    await user.click(screen.getByRole("button", { name: "忘记密码？" }));
+    await user.click(screen.getByRole("button", { name: "返回登录" }));
+    expect(screen.getByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+
+    resetLocation("/login");
+    cleanup();
+    mockAuthApi.loginWithPassword.mockResolvedValue({ accessToken: "onboard-token", user: { id: "user-3" } });
+    mockApi.getUserPreference.mockResolvedValue({ cefrLevel: null, preferredVoice: null });
+    render(<App />);
+    await screen.findByRole("heading", { name: "欢迎回来" });
+    await user.type(screen.getByLabelText("邮箱"), "onboard@example.com");
+    await user.type(screen.getByLabelText("密码"), "a-valid-password");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+    expect(await screen.findByRole("heading", { name: /你现在说英语时/ })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /可以简单交流/ }));
+    mockApi.updateUserPreference.mockResolvedValue({ cefrLevel: "B", preferredVoice: null });
+    await user.click(screen.getByRole("button", { name: "下一步" }));
+    expect(await screen.findByRole("heading", { name: "选择一位 AI 老师" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "选择 James" }));
+    mockApi.updateUserPreference.mockResolvedValue({ cefrLevel: "B", preferredVoice: "Harvey" });
+    await user.click(screen.getByRole("button", { name: "选择这位老师" }));
+    expect(await screen.findByRole("heading", { name: "想聊什么都可以" })).toBeInTheDocument();
+  });
+
+  it("covers the free conversation lifecycle, realtime events, translation, and cleanup", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+
+    await user.click(screen.getByRole("button", { name: "对话设置" }));
+    const settings = screen.getByRole("dialog", { name: "对话设置" });
+    expect(settings).toBeInTheDocument();
+    await user.click(within(settings).getByRole("button", { name: "自然" }));
+    await user.click(within(settings).getByRole("button", { name: "英语水平" }));
+    await user.click(within(settings).getByRole("option", { name: /可以简单交流/ }));
+    await user.click(within(settings).getByRole("button", { name: /James 英式口音/ }));
+    mockApi.updateUserPreference.mockResolvedValue({ cefrLevel: "B", preferredVoice: "Harvey", preferredAiSpeechSpeed: "NATURAL" });
+    await user.click(within(settings).getByRole("button", { name: "保存设置" }));
+    await waitFor(() => expect(mockApi.updateUserPreference).toHaveBeenCalled());
+
+    const startPromise = Promise.resolve({ sessionId: "free-session-1" });
+    mockRealtime.createRealtimeClient.mockImplementationOnce((options = {}) => {
+      const client = {
+        options,
+        start: vi.fn().mockReturnValue(startPromise),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockRealtime.clients.push(client);
+      return client;
+    });
+    await user.click(screen.getByRole("button", { name: "开始对话" }));
+    await waitFor(() => expect(mockRealtime.clients.length).toBeGreaterThan(0));
+    const client = mockRealtime.clients.at(-1);
+    await waitFor(() => expect(client.start).toHaveBeenCalledWith({ voice: "Harvey", speechSpeed: "NATURAL" }));
+    await screen.findByRole("button", { name: "结束当前会话" });
+
+    await act(async () => {
+      client.options.onEvent({ type: "local.connecting" });
+      client.options.onEvent({ type: "local.connected" });
+      client.options.onEvent({ type: "session.created" });
+      client.options.onEvent({ type: "session.updated" });
+      client.options.onEvent({ type: "local.transcript.final", itemId: "assistant-1", owner: 2, text: "Hey there" });
+      client.options.onEvent({ type: "conversation.item.input_audio_transcription.delta", item_id: "user-1", delta: "Hello" });
+      client.options.onEvent({ type: "response.text.delta", response_id: "assistant-live", delta: " How are you?" });
+      client.options.onEvent({ type: "input_audio_buffer.speech_started" });
+      client.options.onEvent({ type: "response.audio.delta" });
+      client.options.onEvent({ type: "local.interrupted" });
+    });
+    expect(screen.getByText("Hey there")).toBeInTheDocument();
+    expect(screen.getByText("Hello")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "查看James这句字幕的翻译" }));
+    await waitFor(() => expect(mockApi.translateSessionText).toHaveBeenCalledWith("free-session-1", "Hey there"));
+    await user.click(screen.getByRole("button", { name: "收起James这句字幕的翻译" }));
+
+    await user.click(screen.getByRole("button", { name: "暂停会话" }));
+    await waitFor(() => expect(client.pause).toHaveBeenCalled());
+    await user.click(screen.getByRole("button", { name: "恢复会话" }));
+    await waitFor(() => expect(client.resume).toHaveBeenCalled());
+    await user.click(screen.getByRole("button", { name: "关闭字幕" }));
+    await user.click(screen.getByRole("button", { name: "打开字幕" }));
+
+    await user.click(screen.getByRole("button", { name: "结束当前会话" }));
+    await waitFor(() => expect(client.stop).toHaveBeenCalledWith({ reason: "user_stop" }));
+    await waitFor(() => expect(screen.getByRole("heading", { name: "想聊什么都可以" })).toBeInTheDocument());
+  });
+
+  it("covers generated scene creation, staged learning, pronunciation scoring, result, and cleanup", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/scenes");
+    const scene = {
+      sceneId: "generated-scene-1",
+      title: "在咖啡店点单",
+      label: "餐饮",
+      background: "Practice ordering a drink at a cafe.",
+      aiRole: "a barista",
+      userRole: "a customer",
+      learningGoal: "Order clearly and politely.",
+      estimatedMinutes: 8,
+      wordList: [{ contentId: "word-1", englishText: "latte", chineseText: "拿铁", phonetic: "/ˈlɑːteɪ/" }],
+      phraseList: [{ contentId: "phrase-1", englishText: "less sweet", chineseText: "不太甜", phonetic: "/les swiːt/" }],
+      sentenceList: [
+        { contentId: "sentence-1", englishText: "Could I have a latte?", chineseText: "我可以要一杯拿铁吗？" },
+        { contentId: "sentence-2", englishText: "Could you make it less sweet?", chineseText: "可以少放一点糖吗？" },
+      ],
+    };
+    mockApi.generateCustomScene.mockResolvedValue(scene);
+    mockApi.translateSceneText.mockResolvedValue({ translatedText: "咖啡店练习摘要" });
+    mockApi.evaluateSentenceReading
+      .mockRejectedValueOnce(new Error("朗读评分服务暂时不可用"))
+      .mockResolvedValue({
+        overallScore: 91,
+        passed: true,
+        words: [{ word: "Could", wordScore: 95 }, { word: "I", wordScore: 80 }],
+      });
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "场景广场" });
+    await user.type(screen.getByPlaceholderText(/你今天想练习什么/), "在咖啡店练习点单");
+    await user.click(screen.getByRole("button", { name: /生成练习场景/ }));
+    expect(await screen.findByText("场景已准备好")).toBeInTheDocument();
+    await waitFor(() => expect(mockApi.translateSceneText).toHaveBeenCalled());
+    expect(await screen.findAllByText("咖啡店练习摘要")).not.toHaveLength(0);
+
+    await user.click(screen.getByRole("button", { name: "确认进入" }));
+    await waitFor(() => expect(mockApi.createCustomSceneFlow).toHaveBeenCalledWith("generated-scene-1"));
+    expect(await screen.findByRole("heading", { name: "latte" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "进入词组" }));
+    await waitFor(() => expect(mockApi.advanceCustomSceneFlow).toHaveBeenCalledWith("generated-scene-1", "WORD_LEARNING"));
+    expect(await screen.findByRole("heading", { name: "less sweet" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "进入朗读" }));
+    await waitFor(() => expect(mockApi.advanceCustomSceneFlow).toHaveBeenCalledWith("generated-scene-1", "PHRASE_LEARNING"));
+    expect(await screen.findByRole("heading", { name: "Could I have a latte?" })).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "开始朗读录音" }));
+    await user.click(screen.getByRole("button", { name: "结束朗读并评分" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("朗读评分服务暂时不可用");
+    mockApi.evaluateSentenceReading.mockResolvedValueOnce({
+      overallScore: 91,
+      passed: true,
+      words: [{ word: "Could", wordScore: 95 }, { word: "I", wordScore: 80 }],
+    });
+    await user.click(screen.getByRole("button", { name: "开始朗读录音" }));
+    await user.click(screen.getByRole("button", { name: "结束朗读并评分" }));
+    expect(await screen.findAllByText("91")).not.toHaveLength(0);
+    await user.click(screen.getByRole("button", { name: "知道了" }));
+    await user.click(screen.getByRole("button", { name: "下一句" }));
+
+    await user.click(screen.getByRole("button", { name: "开始朗读录音" }));
+    await user.click(screen.getByRole("button", { name: "结束朗读并评分" }));
+    await waitFor(() => expect(mockApi.evaluateSentenceReading).toHaveBeenCalledWith(
+      "generated-scene-1",
+      "sentence-2",
+      expect.any(Blob),
+    ));
+    await user.click(screen.getByRole("button", { name: "进入模拟" }));
+    await waitFor(() => expect(mockApi.advanceCustomSceneFlow).toHaveBeenCalledWith("generated-scene-1", "SENTENCE_LEARNING"));
+    expect(await screen.findByRole("button", { name: "结束当前会话" })).toBeInTheDocument();
+
+    const client = mockRealtime.clients.at(-1);
+    await act(async () => {
+      client.options.onEvent({ type: "local.connecting" });
+      client.options.onEvent({ type: "local.connected", sessionId: "scene-session-1" });
+      client.options.onEvent({ type: "session.updated" });
+      client.options.onEvent({ type: "input_audio_buffer.speech_started" });
+      client.options.onEvent({ type: "response.audio.delta" });
+      client.options.onEvent({ type: "local.transcript.final", itemId: "scene-ai-1", owner: 2, text: "Welcome to the cafe." });
+      client.options.onEvent({ type: "conversation.item.input_audio_transcription.delta", item_id: "scene-user-1", delta: "I would like" });
+      client.options.onEvent({ type: "response.text.delta", response_id: "scene-ai-live", delta: " a latte." });
+      client.options.onEvent({
+        type: "local.turn_evaluation",
+        evaluation: { turnNo: 1, overallScore: 84 },
+        scenarioState: { outcomes: [{ satisfied: true }], effectiveUserTurns: 1, maximumUserTurns: 10 },
+      });
+      client.options.onEvent({ type: "local.scenario_state", state: { stage: "CONFIRMATION", completed: false } });
+      client.options.onEvent({ type: "local.scenario_completed" });
+      client.options.onEvent({
+        type: "local.ended",
+        reason: "state_machine",
+        completion: {
+          evaluation: {
+            finalScore: 88,
+            accuracyScore: 90,
+            fluencyScore: 86,
+            grammarScore: 87,
+            vocabularyScore: 89,
+            naturalnessScore: 88,
+            summary: "表达清晰，继续保持。",
+          },
+        },
+      });
+    });
+    expect(await screen.findByRole("heading", { name: "模拟完成" })).toBeInTheDocument();
+    expect(screen.getByText("表达清晰，继续保持。")).toBeInTheDocument();
+    expect(screen.getAllByText("88").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("button", { name: "返回场景广场" }));
+    expect(await screen.findByRole("heading", { name: "场景广场" })).toBeInTheDocument();
+  });
+
+  it("covers scene generation, flow advancement, translation, reconnect, and stop errors", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/scenes");
+    const user = userEvent.setup();
+    mockApi.getDailyPicks.mockRejectedValueOnce(new Error("推荐暂时不可用"));
+    mockApi.generateCustomScene.mockRejectedValueOnce(new Error("场景生成失败"));
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "场景广场" });
+    await user.type(screen.getByPlaceholderText(/你今天想练习什么/), "练习问路");
+    await user.click(screen.getByRole("button", { name: /生成练习场景/ }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("场景生成失败");
+
+    const scene = {
+      sceneId: "error-scene",
+      title: "问路",
+      label: "出行",
+      background: "Ask for directions.",
+      aiRole: "a local",
+      userRole: "a traveler",
+      learningGoal: "Confirm the route.",
+      estimatedMinutes: 5,
+      wordList: [{ contentId: "word", englishText: "station", chineseText: "车站" }],
+      phraseList: [],
+      sentenceList: [],
+    };
+    mockApi.generateCustomScene.mockResolvedValueOnce(scene);
+    mockApi.createCustomSceneFlow.mockRejectedValueOnce(new Error("流程创建失败"));
+    await user.click(screen.getByRole("button", { name: /生成练习场景/ }));
+    await user.click(await screen.findByRole("button", { name: "确认进入" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("流程创建失败");
+    expect(screen.queryByRole("heading", { name: "station" })).not.toBeInTheDocument();
+
+    mockApi.createCustomSceneFlow.mockResolvedValueOnce(undefined);
+    await user.clear(screen.getByPlaceholderText(/你今天想练习什么/));
+    await user.type(screen.getByPlaceholderText(/你今天想练习什么/), "再次生成问路场景");
+    mockApi.generateCustomScene.mockResolvedValueOnce({ ...scene, sceneId: "error-scene-2", wordList: [] });
+    await user.click(screen.getByRole("button", { name: /生成练习场景/ }));
+    await user.click(await screen.findByRole("button", { name: "确认进入" }));
+    expect(await screen.findByText("场景内容加载失败")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "关闭训练" }));
+    await user.click(screen.getByRole("button", { name: "继续训练" }));
+    await user.click(screen.getByRole("button", { name: "关闭训练" }));
+    await user.click(screen.getByRole("button", { name: "确认退出" }));
+    expect(await screen.findByRole("heading", { name: "场景广场" })).toBeInTheDocument();
+  });
+
+  it("covers free-call microphone, provider, quota, start, and unmount errors", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    const user = userEvent.setup();
+    let client;
+    mockRealtime.createRealtimeClient.mockImplementationOnce((options = {}) => {
+      client = {
+        options,
+        start: vi.fn().mockRejectedValue(new Error("启动失败")),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockRealtime.clients.push(client);
+      return client;
+    });
+    render(<App />);
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+    await user.click(screen.getByRole("button", { name: "开始对话" }));
+    expect(await screen.findByText("启动失败")).toBeInTheDocument();
+
+    await act(async () => {
+      client.options.onEvent({ type: "local.mic_error", message: "麦克风被拒绝" });
+      client.options.onEvent({ type: "error", error: { message: "提供方异常" } });
+      client.options.onEvent({ type: "local.provider_warning" });
+      client.options.onEvent({ type: "local.greeting_timeout" });
+    });
+    expect(screen.getByText("提供方异常")).toBeInTheDocument();
+    cleanup();
+    expect(client.stop).toHaveBeenCalledWith({ notifyBackend: false, reason: "component_unmount" });
+  });
+
+  it("covers scene translation failures, completion errors, and user stop errors", async () => {
+    configureAuthenticatedDefaults();
+    const user = userEvent.setup();
+    const scene = {
+      sceneId: "scene-error-events",
+      title: "问路",
+      label: "出行",
+      background: "问路练习",
+      aiRole: "路人",
+      userRole: "旅行者",
+      learningGoal: "确认路线",
+      estimatedMinutes: 5,
+      wordList: [],
+      phraseList: [],
+      sentenceList: [],
+    };
+    window.sessionStorage.setItem("unispeaking.scene.scene-error-events", JSON.stringify(scene));
+    resetLocation("/scenes/scene-error-events/session/session-error");
+    mockRealtime.createRealtimeClient.mockImplementation((options = {}) => {
+      const client = {
+        options,
+        start: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockRejectedValue(new Error("结束失败")),
+      };
+      mockRealtime.clients.push(client);
+      return client;
+    });
+    mockApi.translateSceneText.mockRejectedValue(new Error("翻译失败"));
+    render(<App />);
+    expect(await screen.findByRole("button", { name: "结束当前会话" })).toBeInTheDocument();
+    await waitFor(() => expect(mockRealtime.clients.length).toBeGreaterThan(0));
+    const client = mockRealtime.clients.at(-1);
+    await act(async () => {
+      client.options.onEvent({ type: "local.connected", sessionId: "session-error" });
+      client.options.onEvent({ type: "local.transcript.final", itemId: "line-1", owner: 2, text: "Where is the station?" });
+      client.options.onEvent({ type: "local.scenario_state_error" });
+      client.options.onEvent({ type: "local.turn_evaluation_error", message: "评分失败" });
+      client.options.onEvent({ type: "local.mic_error", message: "无麦克风" });
+    });
+    await user.click(screen.getByRole("button", { name: /查看Emily这句字幕的翻译/ }));
+    expect(await screen.findByText("翻译失败")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "结束当前会话" }));
+    expect(await screen.findByRole("heading", { name: "本次模拟已结束" })).toBeInTheDocument();
+
+    resetLocation("/scenes/scene-error-events/session/session-error");
+    cleanup();
+    mockRealtime.createRealtimeClient.mockImplementationOnce((options = {}) => {
+      const nextClient = {
+        options,
+        start: vi.fn().mockResolvedValue(undefined),
+        pause: vi.fn().mockResolvedValue(undefined),
+        resume: vi.fn().mockResolvedValue(undefined),
+        stop: vi.fn().mockResolvedValue(undefined),
+      };
+      mockRealtime.clients.push(nextClient);
+      return nextClient;
+    });
+    render(<App />);
+    await screen.findByRole("button", { name: "结束当前会话" });
+    const completionClient = mockRealtime.clients.at(-1);
+    await act(async () => {
+      completionClient.options.onEvent({ type: "local.scenario_completion_error", message: "自动结束失败" });
+    });
+    expect(await screen.findByRole("heading", { name: "模拟完成" })).toBeInTheDocument();
+  });
+
+  it("covers public landing entry points and authentication return paths", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByTestId("landing-page");
+
+    await user.click(screen.getByRole("button", { name: "打开应用" }));
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回" }));
+    await screen.findByTestId("landing-page");
+
+    await user.click(screen.getByRole("button", { name: "英文面试" }));
+    expect(await screen.findByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+    expect(window.sessionStorage.getItem("unispeaking.authReturnPath")).toBe("/interview");
+    await user.click(screen.getByRole("button", { name: "返回" }));
+    await screen.findByTestId("landing-page");
+
+    await user.click(screen.getByRole("button", { name: "未知专项" }));
+    expect(screen.getByTestId("landing-page")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "开始体验" }));
+    expect(await screen.findByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+    expect(window.location.search).toBe("?voice=Tina");
+  });
+
+  it("applies a requested landing teacher and routes login to the stored destination", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/login?voice=Harvey");
+    mockApi.getUserPreference.mockResolvedValue({ cefrLevel: "B1", preferredVoice: "Tina" });
+    mockApi.updateUserPreference.mockResolvedValue({ cefrLevel: "B1", preferredVoice: "Harvey" });
+    mockAuthApi.loginWithPassword.mockResolvedValue({ accessToken: "session-token", user: { id: "user-landing" } });
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "欢迎回来" });
+    await user.type(screen.getByLabelText("邮箱"), "landing@example.com");
+    await user.type(screen.getByLabelText("密码"), "a-valid-password");
+    await user.click(screen.getByRole("button", { name: "人机验证" }));
+
+    await waitFor(() => expect(mockApi.updateUserPreference).toHaveBeenCalledWith({ preferredVoice: "Harvey" }));
+    expect(await screen.findByRole("heading", { name: "想聊什么都可以" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/conversation");
+    expect(window.sessionStorage.getItem("unispeaking.authReturnPath")).toBeNull();
+  });
+
+  it("covers assets module routing, detail replay, and delete failure recovery", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/assets");
+    mockApi.getLearningAssets.mockResolvedValue([
+      { sceneId: "asset-a", title: "咖啡店点单", label: "餐饮", latestPracticedAt: "not-a-date", latestSessionId: null },
+      { sceneId: "asset-b", title: "问路", label: "出行", createdAt: "2026-08-02T00:00:00Z", latestSessionId: "session-b", latestScore: 72 },
+    ]);
+    mockApi.getLearningAsset.mockResolvedValue({
+      sceneId: "asset-a",
+      title: "咖啡店点单",
+      aiRole: "咖啡师",
+      wordList: [{ contentId: "word-a", englishText: "latte", chineseText: "拿铁" }],
+      phraseList: [],
+      sentenceList: [],
+      dialogueEvaluation: {
+        dialogue: [{ owner: 1, content: "I want a latte." }, { owner: 2, content: "Sure." }],
+        turnEvaluation: [{ turnNo: 1, feedbackSummary: "表达清楚", suggestedExpression: "Could I have a latte?" }],
+      },
+      latestSessionId: "asset-session",
+    });
+    mockApi.deleteLearningAsset.mockRejectedValueOnce(new Error("删除失败"));
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "学习资产" });
+    await screen.findByText("latte");
+    await user.click(screen.getByRole("button", { name: "出行" }));
+    expect(screen.getAllByText("问路").length).toBeGreaterThan(0);
+    await user.click(screen.getByRole("button", { name: "全部" }));
+    await user.click(screen.getByRole("button", { name: "删除当前学习资产" }));
+    await user.click(screen.getByRole("button", { name: "确认删除" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("删除失败");
+    await user.click(screen.getByRole("button", { name: "取消" }));
+
+    await user.click(screen.getByRole("button", { name: "打开当前学习资产" }));
+    expect(await screen.findByRole("heading", { name: "咖啡店点单 · 语境复现" })).toBeInTheDocument();
+    expect(screen.getByText("I want a latte.")).toBeInTheDocument();
+    expect(screen.getByText("Could I have a latte?")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "复练场景" }));
+    expect(await screen.findByRole("button", { name: "结束当前会话" })).toBeInTheDocument();
+    cleanup();
+    resetLocation("/assets");
+    render(<App />);
+    await screen.findByRole("heading", { name: "学习资产" });
+
+    await user.click(screen.getByRole("button", { name: "切换学习资产模块" }));
+    await user.click(screen.getByRole("menuitem", { name: /IELTS 学习资产/ }));
+    expect(await screen.findByTestId("stub-ielts-assets")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回普通资产" }));
+    expect(await screen.findByRole("heading", { name: "学习资产" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "切换学习资产模块" }));
+    await user.click(screen.getByRole("menuitem", { name: /面试学习资产/ }));
+    expect(await screen.findByTestId("stub-interview-assets")).toBeInTheDocument();
+  });
+
+  it("covers profile editing, calendar, membership, and security error paths", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile");
+    mockApi.getProfileOverview.mockResolvedValue({
+      account: { userId: "user-1", nickname: "旧昵称", displayName: "旧昵称", email: "old@example.com", avatarUrl: "avatar.png" },
+      calendar: { month: "2026-07", checkedDates: ["2026-07-02"], checkedInToday: true },
+      statistics: { weeklyPracticeSeconds: 0, trainingRecordCount: 0, consecutiveLearningDays: 0, lastSevenDays: [] },
+    });
+    mockApi.updateProfile.mockResolvedValue({ nickname: "新昵称", displayName: "新昵称" });
+    mockApi.uploadProfileAvatar.mockResolvedValue({ avatarUrl: "new-avatar.png", avatarUrlExpiresAt: "2026-09-01" });
+    mockApi.changePassword.mockRejectedValueOnce(new Error("当前密码错误"));
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByRole("heading", { name: "你的学习空间" });
+    await user.click(screen.getByRole("button", { name: "查看上一个月" }));
+    await waitFor(() => expect(mockApi.getProfileOverview).toHaveBeenCalledWith("2026-06"));
+    await user.click(screen.getByRole("gridcell", { name: /2026 年 7 月2日/ }));
+    expect(screen.getByText("已打卡")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "编辑用户名和头像" }));
+    const avatarInput = screen.getByLabelText("选择新头像");
+    fireEvent.change(avatarInput, { target: { files: [new File(["bad"], "avatar.gif", { type: "image/gif" })] } });
+    expect(screen.getByRole("alert")).toHaveTextContent("JPEG 或 PNG");
+    fireEvent.change(avatarInput, { target: { files: [new File(["image"], "avatar.png", { type: "image/png" })] } });
+    await user.clear(screen.getByLabelText("用户名"));
+    await user.type(screen.getByLabelText("用户名"), "新昵称");
+    await user.click(screen.getByRole("button", { name: "保存修改" }));
+    await waitFor(() => expect(mockApi.updateProfile).toHaveBeenCalledWith({ nickname: "新昵称" }));
+    expect(mockApi.uploadProfileAvatar).toHaveBeenCalled();
+
+    await user.click(screen.getByRole("button", { name: "会员权益" }));
+    expect(await screen.findByRole("heading", { name: "会员与订阅中心" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "升级专业版" }));
+    await user.click(screen.getByRole("button", { name: "模拟支付并完成" }));
+    await user.click(screen.getByRole("button", { name: "账号与安全" }));
+    await user.click(screen.getByRole("button", { name: "修改密码" }));
+    await user.type(screen.getByLabelText("当前密码"), "current");
+    await user.type(screen.getByLabelText("新密码"), "new-password");
+    await user.type(screen.getByLabelText("确认新密码"), "different");
+    await user.click(screen.getByRole("button", { name: "确认修改" }));
+    expect(screen.getByRole("alert")).toHaveTextContent("两次输入的新密码不一致");
+    await user.clear(screen.getByLabelText("确认新密码"));
+    await user.type(screen.getByLabelText("确认新密码"), "new-password");
+    await user.click(screen.getByRole("button", { name: "确认修改" }));
+    expect(await screen.findByRole("alert")).toHaveTextContent("当前密码错误");
+  });
+
+  it("covers specialty assets navigation and guarded conversation navigation", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/ielts");
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(await screen.findByTestId("stub-ielts-training")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "打开雅思资产入口" }));
+    expect(await screen.findByTestId("stub-ielts-assets")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "打开面试资产" }));
+    expect(await screen.findByTestId("stub-interview-assets")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "打开雅思资产" }));
+    expect(await screen.findByTestId("stub-ielts-assets")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回场景广场" }));
+    expect(await screen.findByRole("heading", { name: "场景广场" })).toBeInTheDocument();
+
+    resetLocation("/conversation");
+    cleanup();
+    configureAuthenticatedDefaults();
+    render(<App />);
+    await screen.findByRole("heading", { name: "想聊什么都可以" });
+    await user.click(screen.getByRole("button", { name: "开始对话" }));
+    const client = mockRealtime.clients.at(-1);
+    await waitFor(() => expect(client.start).toHaveBeenCalled());
+    await user.click(within(screen.getByRole("complementary")).getByRole("button", { name: "场景广场" }));
+    expect(screen.getByRole("heading", { name: "确定要退出当前训练吗？" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "继续训练" }));
+    expect(screen.queryByRole("heading", { name: "确定要退出当前训练吗？" })).not.toBeInTheDocument();
+    await user.click(within(screen.getByRole("complementary")).getByRole("button", { name: "场景广场" }));
+    await user.click(screen.getByRole("button", { name: "确认退出" }));
+    expect(await screen.findByRole("heading", { name: "场景广场" })).toBeInTheDocument();
+  });
+
+  it("covers daily recommendation refresh and recommendation-generated preview", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/scenes");
+    mockApi.getDailyPicks.mockResolvedValueOnce({ picks: [] }).mockResolvedValueOnce({
+      picks: [
+        { id: "pick-a", position: 4, title: "预约理发", category: "services", duration: "6 分钟", goal: "说明需求", sceneInput: "预约理发并说明需求" },
+        { id: "pick-b", position: 5, title: "医院挂号", category: "health", duration: "8 分钟", goal: "描述症状", sceneInput: "去医院挂号" },
+        { id: "pick-c", position: 6, title: "课堂讨论", category: "education", duration: "8 分钟", goal: "表达观点", sceneInput: "参加英语课堂讨论" },
+      ],
+    });
+    mockApi.generateCustomScene.mockResolvedValue({
+      sceneId: "recommendation-scene",
+      title: "预约理发",
+      label: "服务",
+      background: "Book a haircut.",
+      aiRole: "a stylist",
+      userRole: "a customer",
+      learningGoal: "Explain your needs.",
+      estimatedMinutes: 6,
+      wordList: [],
+      phraseList: [],
+      sentenceList: [],
+    });
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "场景广场" });
+    await user.click(screen.getByRole("button", { name: "换一批" }));
+    expect(await screen.findByText("预约理发")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "开始练习 预约理发 场景" }));
+    await waitFor(() => expect(mockApi.generateCustomScene).toHaveBeenCalledWith("预约理发并说明需求"));
+    expect(await screen.findByText("场景已准备好")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "返回修改" }));
+    expect(screen.queryByRole("heading", { name: "场景已准备好" })).not.toBeInTheDocument();
+  });
+
+  it("covers achievement rendering, filtering, expansion, and empty/error recovery", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile");
+    mockApi.getAchievementOverview
+      .mockResolvedValueOnce({
+        series: [
+          {
+            seriesId: "conversation",
+            category: "练习",
+            title: "开口练习",
+            currentLevel: 1,
+            currentValue: 3,
+            nextLevel: 2,
+            nextThreshold: 5,
+            nextTitle: "持续表达",
+            unit: "次",
+            completed: false,
+            milestones: [
+              { achievementId: "m1", level: 1, title: "第一次开口", description: "完成第一次练习", threshold: 1, unlocked: true },
+              { achievementId: "m2", level: 2, title: "持续表达", description: "完成五次练习", threshold: 5, unlocked: false },
+              { achievementId: "m3", level: 3, title: "表达习惯", description: "完成十次练习", threshold: 10, unlocked: false },
+            ],
+          },
+          {
+            seriesId: "unknown-series",
+            category: "其他",
+            title: "隐藏成就",
+            currentLevel: 0,
+            currentValue: "bad-number",
+            unit: "分",
+            completed: true,
+            milestones: [],
+          },
+        ],
+      })
+      .mockRejectedValueOnce(new Error("成就服务不可用"))
+      .mockResolvedValueOnce({ series: [] });
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "你的学习空间" });
+    expect(await screen.findByText("开口练习")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "查看开口练习全部等级" }));
+    expect(screen.getByRole("region", { name: "开口练习全部等级" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "收起开口练习等级" }));
+    await user.click(screen.getByRole("button", { name: /其他/ }));
+    expect(screen.getByText("隐藏成就")).toBeInTheDocument();
+
+    await user.click(screen.getAllByRole("button", { name: "个人中心" })[0]);
+    await user.click(within(screen.getByRole("navigation", { name: "个人中心导航" })).getByRole("button", { name: "会员权益" }));
+    await user.click(within(screen.getByRole("navigation", { name: "个人中心导航" })).getByRole("button", { name: "个人概览" }));
+    await waitFor(() => expect(mockApi.getAchievementOverview).toHaveBeenCalledTimes(2));
+    expect(await screen.findByRole("alert")).toHaveTextContent("成就服务不可用");
+    await user.click(screen.getByRole("button", { name: "重新加载" }));
+    expect(await screen.findByText("成就目录暂时为空")).toBeInTheDocument();
+  });
+
+  it("covers bootstrap failure, preference failures, and safe public about routes", async () => {
+    resetLocation("/about/privacy-policy");
+    render(<App />);
+    expect(await screen.findByTestId("stub-legal-document")).toBeInTheDocument();
+    cleanup();
+
+    configureAuthenticatedDefaults();
+    resetLocation("/conversation");
+    mockApi.getCurrentUser.mockRejectedValueOnce(new Error("session invalid"));
+    mockApi.clearAuthSession.mockImplementationOnce(() => undefined);
+    render(<App />);
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(mockApi.clearAuthSession).toHaveBeenCalledWith("session-token");
+
+    cleanup();
+    configureAuthenticatedDefaults();
+    resetLocation("/level");
+    mockApi.updateUserPreference.mockRejectedValueOnce(new Error("水平保存失败"));
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: /你现在说英语时/ });
+    await user.click(screen.getByRole("button", { name: /可以简单交流/ }));
+    await user.click(screen.getByRole("button", { name: "下一步" }));
+    expect(window.alert).toHaveBeenCalledWith("水平保存失败");
+  });
+
+  it("renders the public about home and keeps its home link available", async () => {
+    resetLocation("/about");
+    render(<App />);
+
+    expect(await screen.findByTestId("stub-about-product")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /返回首页/ })).toHaveAttribute("href", "/");
+    expect(window.location.pathname).toBe("/about");
+  });
+
+  it("falls back to an inline error when learning assets cannot be listed or opened", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/assets");
+    mockApi.getLearningAssets.mockRejectedValueOnce(new Error("资产列表暂时不可用"));
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "学习资产" })).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("资产列表暂时不可用");
+    expect(screen.getByText("暂无场景学习资产")).toBeInTheDocument();
+
+    cleanup();
+    resetLocation("/scenes/asset-fallback/assets");
+    mockApi.getLearningAssets.mockResolvedValueOnce([
+      { sceneId: "asset-fallback", title: "资产详情回退", label: "其他", latestSessionId: "session-1" },
+    ]);
+    mockApi.getLearningAsset.mockRejectedValue(new Error("资产详情暂时不可用"));
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "学习资产" })).toBeInTheDocument();
+    expect(await screen.findByRole("alert")).toHaveTextContent("资产详情暂时不可用");
+    expect(screen.getByText("正在读取最近一次对话与评分。")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "打开当前学习资产" })).not.toBeInTheDocument();
+  });
+
+  it("redirects an unauthenticated protected route and preserves its return path", async () => {
+    resetLocation("/profile/security");
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/login");
+    expect(window.sessionStorage.getItem("unispeaking.authReturnPath")).toBe("/profile/security");
+    expect(mockApi.getCurrentUser).not.toHaveBeenCalled();
+  });
+
+  it("cleans the auth session when logout fails and still returns to the splash page", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile/security");
+    mockAuthApi.logoutUser.mockRejectedValueOnce(new Error("logout endpoint unavailable"));
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findByTestId("stub-account-security");
+    await user.click(screen.getByRole("button", { name: "安全页退出登录" }));
+    const logoutDialog = screen.getByRole("dialog");
+    await user.click(within(logoutDialog).getByRole("button", { name: "退出登录" }));
+
+    await waitFor(() => expect(mockApi.clearAuthSession).toHaveBeenCalledWith());
+    expect(await screen.findByTestId("landing-page")).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/");
+  });
+
+  it("completes the membership checkout and clears the session after a successful password change", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/membership");
+    mockApi.changePassword.mockResolvedValueOnce(undefined);
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(await screen.findByRole("heading", { name: "会员与订阅中心" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "升级专业版" }));
+    expect(screen.getByRole("heading", { name: "确认升级至专业版" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "模拟支付并完成" }));
+    expect(screen.queryByRole("heading", { name: "确认升级至专业版" })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "账号与安全" }));
+    await user.click(screen.getByRole("button", { name: "修改密码" }));
+    await user.type(screen.getByLabelText("当前密码"), "current-password");
+    await user.type(screen.getByLabelText("新密码"), "new-password");
+    await user.type(screen.getByLabelText("确认新密码"), "new-password");
+    await user.click(screen.getByRole("button", { name: "确认修改" }));
+
+    await waitFor(() => expect(mockApi.changePassword).toHaveBeenCalledWith({
+      currentPassword: "current-password",
+      newPassword: "new-password",
+    }));
+    expect(mockApi.clearAuthSession).toHaveBeenCalledWith();
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/login");
+  });
+
+  it("guards navigation away from IELTS session and releases the guard after confirmation", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/ielts/part1/travel/session");
+    const user = userEvent.setup();
+    render(<App />);
+
+    expect(await screen.findByTestId("stub-ielts-training")).toBeInTheDocument();
+    await user.click(within(screen.getByRole("complementary")).getByRole("button", { name: "学习资产" }));
+    expect(screen.getByRole("heading", { name: "确定要退出当前训练吗？" })).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "确认退出" }));
+
+    expect(await screen.findByTestId("stub-ielts-assets")).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { name: "确定要退出当前训练吗？" })).not.toBeInTheDocument();
+  });
+
+  it("covers landing entry choices and preserves a specialty return path", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByTestId("landing-page");
+
+    await user.click(screen.getByRole("button", { name: "未知专项" }));
+    expect(window.location.pathname).toBe("/");
+    await user.click(screen.getByRole("button", { name: "打开应用" }));
+    expect(await screen.findByRole("heading", { name: "欢迎回来" })).toBeInTheDocument();
+    expect(window.location.pathname).toBe("/login");
+
+    cleanup();
+    resetLocation("/");
+    render(<App />);
+    await screen.findByTestId("landing-page");
+    await user.click(screen.getByRole("button", { name: "雅思专项" }));
+    expect(await screen.findByRole("heading", { name: "创建账号" })).toBeInTheDocument();
+    expect(window.sessionStorage.getItem("unispeaking.authReturnPath")).toBe("/ielts");
+  });
+
+  it("handles profile editing validation, avatar upload, and calendar navigation", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/profile");
+    mockApi.getProfileOverview.mockResolvedValue({
+      account: { userId: "user-1", nickname: "测试用户", displayName: "测试用户", email: "user@example.com" },
+      calendar: { month: "2026-08", checkedDates: ["2026-08-01"], checkedInToday: false },
+      statistics: {
+        weeklyPracticeSeconds: 125,
+        trainingRecordCount: 2,
+        consecutiveLearningDays: 2,
+        lastSevenDays: [{ date: "2026-08-01", practiceSeconds: 0 }, { date: "2026-08-02", practiceSeconds: 30 }],
+      },
+    });
+    mockApi.updateProfile.mockResolvedValue({ nickname: "新昵称", displayName: "新昵称" });
+    mockApi.uploadProfileAvatar.mockResolvedValue({ avatarUrl: "https://cdn.example/avatar.png", avatarUrlExpiresAt: "2026-09-01" });
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "你的学习空间" });
+    await user.click(screen.getByRole("button", { name: "编辑用户名和头像" }));
+    const dialog = screen.getByRole("dialog");
+    const nickname = within(dialog).getByRole("textbox");
+    await user.clear(nickname);
+    fireEvent.submit(dialog.querySelector("form"));
+    expect(within(dialog).getByRole("alert")).toHaveTextContent("用户名不能为空");
+
+    await user.type(nickname, "新昵称");
+    const invalidFile = new File(["not-image"], "avatar.gif", { type: "image/gif" });
+    fireEvent.change(within(dialog).getByLabelText("选择新头像"), { target: { files: [invalidFile] } });
+    expect(within(dialog).getByRole("alert")).toHaveTextContent("JPEG 或 PNG");
+    const validFile = new File(["image"], "avatar.png", { type: "image/png" });
+    fireEvent.change(within(dialog).getByLabelText("选择新头像"), { target: { files: [validFile] } });
+    await user.click(within(dialog).getByRole("button", { name: "保存修改" }));
+    await waitFor(() => expect(mockApi.updateProfile).toHaveBeenCalledWith({ nickname: "新昵称" }));
+    await waitFor(() => expect(mockApi.uploadProfileAvatar).toHaveBeenCalledWith(validFile));
+    expect(await screen.findByText("新昵称")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "查看上一个月" }));
+    await waitFor(() => expect(mockApi.getProfileOverview).toHaveBeenCalledWith("2026-07"));
+  });
+
+  it("routes specialty training from the scene plaza", async () => {
+    configureAuthenticatedDefaults();
+    resetLocation("/scenes");
+    const user = userEvent.setup();
+    render(<App />);
+    await screen.findByRole("heading", { name: "场景广场" });
+    await user.click(screen.getByRole("button", { name: "场景广场" }));
+    await screen.findByRole("heading", { name: "场景广场" });
+    await user.click(screen.getByRole("button", { name: /雅思口语/ }));
+    expect(await screen.findByTestId("stub-ielts-training")).toBeInTheDocument();
+  });
+});

--- a/frontend/web/src/controller/__tests__/main.test.jsx
+++ b/frontend/web/src/controller/__tests__/main.test.jsx
@@ -1,0 +1,42 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const telemetry = vi.hoisted(() => ({
+  captureException: vi.fn(),
+  initializeBrowserTelemetry: vi.fn(),
+}));
+const root = vi.hoisted(() => ({
+  createRoot: vi.fn(() => ({ render: vi.fn() })),
+}));
+
+vi.mock("react-dom/client", () => root);
+vi.mock("../../telemetry/clientTelemetry.js", () => telemetry);
+vi.mock("../../component/achievement/AchievementNotifications.jsx", () => ({
+  AchievementNotificationProvider: ({ children }) => <div data-testid="provider">{children}</div>,
+}));
+vi.mock("../App.jsx", () => ({ App: () => <div data-testid="app">应用内容</div> }));
+
+describe("controller entrypoint", () => {
+  it("initializes telemetry and mounts the application tree", async () => {
+    document.body.innerHTML = '<div id="root"></div>';
+    await import("../main.jsx");
+    expect(telemetry.initializeBrowserTelemetry).toHaveBeenCalledTimes(1);
+    expect(root.createRoot).toHaveBeenCalledWith(document.getElementById("root"));
+    expect(root.createRoot.mock.results[0].value.render).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the entrypoint's provider tree when the root render callback is used", async () => {
+    const rendered = root.createRoot.mock.results[0]?.value.render.mock.calls[0]?.[0];
+    expect(rendered).toBeTruthy();
+    render(rendered);
+    expect(screen.getByTestId("provider")).toBeInTheDocument();
+    expect(screen.getByTestId("app")).toHaveTextContent("应用内容");
+  });
+
+  it("keeps the entrypoint testable with a browser root", () => {
+    const rootElement = document.getElementById("root");
+    expect(rootElement).not.toBeNull();
+    fireEvent(window, new Event("load"));
+    expect(telemetry.captureException).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/web/src/controller/__tests__/router.test.js
+++ b/frontend/web/src/controller/__tests__/router.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  hrefForPage,
+  normalizePath,
+  parseAboutRoute,
+  parseHelpRoute,
+  parseIeltsRoute,
+  parseInterviewRoute,
+  parseSceneRoute,
+  paths,
+  resolveRoute,
+  sidebarPageTarget,
+} from "../router.js";
+
+describe("router", () => {
+  it("normalizes missing and repeated slashes", () => {
+    expect(normalizePath()).toBe("/");
+    expect(normalizePath("ielts///part1/")).toBe("/ielts/part1");
+    expect(normalizePath("///")).toBe("/");
+  });
+
+  it("resolves auth, splash, preview, and unknown routes", () => {
+    expect(resolveRoute({ pathname: "/", search: "" })).toMatchObject({ flow: "splash", page: "conversation" });
+    expect(resolveRoute({ pathname: "/login", search: "?voice=Tina" })).toMatchObject({ flow: "auth", authMode: "login", selectedVoice: "Tina" });
+    expect(resolveRoute({ pathname: "/signup", search: "?voice=Harvey" })).toMatchObject({ flow: "auth", authMode: "signup", selectedVoice: "Harvey" });
+    expect(resolveRoute({ pathname: "/", search: "?preview=training" })).toMatchObject({ flow: "app", page: "scenes", training: { initialStep: "learn" } });
+    expect(resolveRoute({ pathname: "/unknown", search: "" })).toMatchObject({ flow: "splash", canonicalPath: "/" });
+  });
+
+  it("parses encoded scene, help, and about routes", () => {
+    expect(parseSceneRoute(paths.scenes.session("scene one", "session/1"))).toMatchObject({
+      page: "scenes",
+      sceneId: "scene one",
+      sessionId: "session/1",
+      result: null,
+    });
+    expect(parseHelpRoute(paths.help.article("change password"))).toMatchObject({
+      page: "help",
+      publicAccess: true,
+      helpRoute: { screen: "article", articleId: "change password" },
+    });
+    expect(parseHelpRoute("/help/unknown/path")).toMatchObject({ canonicalPath: "/help" });
+    expect(parseAboutRoute(paths.about.privacyPolicy)).toMatchObject({
+      page: "about",
+      publicAccess: true,
+      aboutRoute: { screen: "document", documentId: "privacy-policy" },
+    });
+  });
+
+  it("handles IELTS and interview fallback routes", () => {
+    expect(parseIeltsRoute(paths.ielts.step("part1", "daily topic", "report"))).toMatchObject({
+      page: "ielts",
+      ieltsRoute: { part: "p1", selection: "daily topic", screen: "report" },
+    });
+    expect(parseIeltsRoute("/ielts/mock/not-a-screen")).toMatchObject({
+      ieltsRoute: { part: "mock", selection: "random", screen: "setup" },
+    });
+    expect(parseIeltsRoute("/ielts/assets/review")).toMatchObject({ ieltsRoute: { tab: "history" } });
+    expect(parseInterviewRoute(paths.interview.report("interview one", "session one"))).toMatchObject({
+      page: "interview",
+      interviewRoute: { screen: "report", sceneId: "interview one", sessionId: "session one" },
+    });
+    expect(parseInterviewRoute("/interview/invalid")).toMatchObject({ canonicalPath: "/interview" });
+  });
+
+  it("maps pages and preserves specialty asset navigation", () => {
+    expect(hrefForPage("profile")).toBe("/profile");
+    expect(hrefForPage("not-a-page")).toBe("/conversation");
+    expect(sidebarPageTarget("ielts", "assets")).toBe("ielts-assets");
+    expect(sidebarPageTarget("interview-assets", "scenes")).toBe("interview");
+    expect(sidebarPageTarget("scenes", "assets")).toBe("assets");
+  });
+
+  it("covers every public route parser branch and canonical fallback", () => {
+    expect(parseIeltsRoute("/conversation")).toBeNull();
+    expect(parseIeltsRoute("/ielts")).toMatchObject({ ieltsRoute: { screen: "home" } });
+    expect(parseIeltsRoute("/ielts/assets/trends")).toMatchObject({
+      ieltsRoute: { tab: "trends" },
+      canonicalPath: paths.ielts.assets.trends,
+    });
+    expect(parseIeltsRoute("/ielts/assets/unknown")).toMatchObject({
+      ieltsRoute: { tab: "overview" },
+      canonicalPath: paths.ielts.assets.root,
+    });
+    expect(parseIeltsRoute("/ielts/not-a-part")).toMatchObject({ canonicalPath: paths.ielts.root });
+    expect(parseIeltsRoute("/ielts/part1")).toMatchObject({ ieltsRoute: { part: "p1", screen: "topics" } });
+    expect(parseIeltsRoute("/ielts/part2/%E0%A4%A/setup")).toMatchObject({
+      ieltsRoute: { part: "p2", selection: "%E0%A4%A", screen: "setup" },
+    });
+    expect(parseIeltsRoute("/ielts/part3/topic/not-a-screen")).toMatchObject({
+      ieltsRoute: { part: "p3", screen: "setup" },
+    });
+    expect(parseIeltsRoute("/ielts/mock/report")).toMatchObject({ ieltsRoute: { screen: "report" } });
+
+    expect(parseSceneRoute("/conversation")).toBeNull();
+    expect(parseSceneRoute("/scenes/training")).toBeNull();
+    expect(parseSceneRoute("/scenes/scene/word")).toMatchObject({ training: { initialStep: "learn" } });
+    expect(parseSceneRoute("/scenes/scene/phrase")).toMatchObject({ training: { initialStep: "learn" } });
+    expect(parseSceneRoute("/scenes/scene/sentence")).toMatchObject({ training: { initialStep: "read" } });
+    expect(parseSceneRoute("/scenes/scene/session/session-1")).toMatchObject({ result: null });
+    expect(parseSceneRoute("/scenes/scene/session/session-1/result")).toMatchObject({ result: { completed: true } });
+    expect(parseSceneRoute("/scenes/scene/assets")).toMatchObject({ page: "assets", assetView: "detail" });
+    expect(parseSceneRoute("/scenes/scene/other")).toMatchObject({ canonicalPath: paths.app.scenes });
+
+    expect(parseHelpRoute("/about")).toBeNull();
+    expect(parseHelpRoute("/help")).toMatchObject({ helpRoute: { screen: "home" } });
+    expect(parseHelpRoute(paths.help.category("billing question"))).toMatchObject({ helpRoute: { screen: "category" } });
+    expect(parseHelpRoute("/help/invalid")).toMatchObject({ canonicalPath: paths.help.root });
+    expect(parseAboutRoute("/help")).toBeNull();
+    expect(parseAboutRoute(paths.about.root)).toMatchObject({ aboutRoute: { screen: "home" } });
+    expect(parseAboutRoute(paths.about.userAgreement)).toMatchObject({ aboutRoute: { documentId: "user-agreement" } });
+    expect(parseAboutRoute(paths.about.aiService)).toMatchObject({ aboutRoute: { documentId: "ai-service" } });
+    expect(parseAboutRoute("/about/unknown")).toMatchObject({ canonicalPath: paths.about.root });
+  });
+
+  it("covers interview, preview, legacy, and shared page resolution", () => {
+    expect(parseInterviewRoute("/about")).toBeNull();
+    expect(parseInterviewRoute(paths.interview.root)).toMatchObject({ interviewRoute: { screen: "home" } });
+    expect(parseInterviewRoute(paths.interview.assets.history)).toMatchObject({ interviewRoute: { tab: "history" } });
+    expect(parseInterviewRoute(paths.interview.assets.trends)).toMatchObject({ interviewRoute: { tab: "trends" } });
+    expect(parseInterviewRoute("/interview/assets/review")).toMatchObject({ interviewRoute: { tab: "overview" } });
+    expect(parseInterviewRoute(paths.interview.session("scene one"))).toMatchObject({ interviewRoute: { screen: "session" } });
+    expect(parseInterviewRoute("/interview/scenes/scene/other")).toMatchObject({ canonicalPath: paths.interview.root });
+
+    expect(resolveRoute({ pathname: "/", search: "?preview=teacher" })).toMatchObject({ flow: "teacher" });
+    expect(resolveRoute({ pathname: "/", search: "?preview=result" })).toMatchObject({ result: { completed: true } });
+    expect(resolveRoute({ pathname: "/", search: "?preview=profile" })).toMatchObject({ page: "profile" });
+    expect(resolveRoute({ pathname: "/", search: "?preview=not-real" })).toMatchObject({ flow: "splash" });
+    expect(resolveRoute({ pathname: "/level", search: "" })).toMatchObject({ flow: "level" });
+    expect(resolveRoute({ pathname: "/teacher", search: "" })).toMatchObject({ flow: "teacher" });
+    expect(resolveRoute({ pathname: paths.conversation.session("session one"), search: "" })).toMatchObject({ conversationSessionId: "session one" });
+    expect(resolveRoute({ pathname: "/conversation/too/many", search: "" })).toMatchObject({ flow: "splash" });
+    expect(resolveRoute({ pathname: "/training", search: "" })).toMatchObject({ canonicalPath: paths.scenes.training });
+    expect(resolveRoute({ pathname: "/result", search: "" })).toMatchObject({ canonicalPath: paths.scenes.result });
+    expect(resolveRoute({ pathname: paths.assets.latest, search: "" })).toMatchObject({ assetView: "detail" });
+    expect(resolveRoute({ pathname: "/ielts-assets", search: "" })).toMatchObject({ canonicalPath: paths.ielts.assets.root });
+    expect(resolveRoute({ pathname: "/assets", search: "?view=detail" })).toMatchObject({ page: "assets", assetView: "detail" });
+    expect(resolveRoute({ pathname: "/assets", search: "?view=list" })).toMatchObject({ page: "assets" });
+    expect(resolveRoute({ pathname: "/settings", search: "" })).toMatchObject({ page: "settings" });
+  });
+
+  it("exposes all path builders and sidebar mappings", () => {
+    expect(paths.conversation.session("a b")).toBe("/conversation/a%20b");
+    expect(paths.scenes.word("a b")).toBe("/scenes/a%20b/word");
+    expect(paths.scenes.phrase("a b")).toBe("/scenes/a%20b/phrase");
+    expect(paths.scenes.sentence("a b")).toBe("/scenes/a%20b/sentence");
+    expect(paths.scenes.session("a b", "s/1")).toBe("/scenes/a%20b/session/s%2F1");
+    expect(paths.scenes.sessionResult("a b", "s/1")).toContain("/result");
+    expect(paths.scenes.assets("a b")).toBe("/scenes/a%20b/assets");
+    expect(paths.ielts.part("part1")).toBe("/ielts/part1");
+    expect(paths.ielts.topic("part1", "daily topic")).toBe("/ielts/part1/daily%20topic");
+    expect(paths.ielts.step("mock", "ignored", "session")).toBe("/ielts/mock/session");
+    expect(paths.interview.session("a b")).toBe("/interview/scenes/a%20b/session");
+    expect(paths.help.category("a b")).toBe("/help/category/a%20b");
+    expect(paths.help.article("a b")).toBe("/help/article/a%20b");
+    expect(sidebarPageTarget("ielts-assets", "scenes")).toBe("ielts");
+    expect(sidebarPageTarget("interview", "assets")).toBe("interview-assets");
+    expect(sidebarPageTarget("scenes", "profile")).toBe("profile");
+  });
+});

--- a/frontend/web/src/infrastructure/audio/__tests__/audioRecorder.test.js
+++ b/frontend/web/src/infrastructure/audio/__tests__/audioRecorder.test.js
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPcmWavRecorder, createPcmWavSegmentRecorder } from "../audioRecorder.js";
+
+const originalAudioContext = window.AudioContext;
+
+function makeAudioContext(sampleRate = 16_000) {
+  const source = { connect: vi.fn(), disconnect: vi.fn() };
+  const processor = { connect: vi.fn(), disconnect: vi.fn(), onaudioprocess: null };
+  const gain = { connect: vi.fn(), disconnect: vi.fn(), gain: { value: 1 } };
+  const context = {
+    sampleRate,
+    destination: {},
+    resume: vi.fn(async () => undefined),
+    close: vi.fn(async () => undefined),
+    createMediaStreamSource: vi.fn(() => source),
+    createScriptProcessor: vi.fn(() => processor),
+    createGain: vi.fn(() => gain),
+  };
+  return { context, source, processor, gain };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.AudioContext = originalAudioContext;
+  delete window.webkitAudioContext;
+  delete navigator.mediaDevices;
+});
+
+describe("browser PCM WAV recorder", () => {
+  it("reports unsupported microphone and audio APIs", async () => {
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: undefined });
+    await expect(createPcmWavRecorder()).rejects.toThrow("不支持麦克风录音");
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: {} });
+    await expect(createPcmWavRecorder()).rejects.toThrow("不支持麦克风录音");
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: { getUserMedia: vi.fn() } });
+    await expect(createPcmWavRecorder()).rejects.toThrow("不支持音频采集");
+    await expect(createPcmWavSegmentRecorder({ getAudioTracks: () => [] })).rejects.toThrow("没有可用的麦克风音轨");
+  });
+
+  it("records, resamples, encodes a WAV, and closes the microphone exactly once", async () => {
+    const track = { stop: vi.fn() };
+    const stream = { getTracks: () => [track] };
+    const getUserMedia = vi.fn(async () => stream);
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: { getUserMedia } });
+    const fake = makeAudioContext(8_000);
+    window.AudioContext = vi.fn(() => fake.context);
+
+    const recorder = await createPcmWavRecorder();
+    expect(getUserMedia).toHaveBeenCalledWith({ audio: {
+      channelCount: 1,
+      echoCancellation: false,
+      noiseSuppression: false,
+      autoGainControl: false,
+    } });
+    fake.processor.onaudioprocess({ inputBuffer: { getChannelData: () => new Float32Array([0, 0.5, -0.5, 1]) } });
+    const wav = await recorder.stop();
+    expect(wav).toBeInstanceOf(Blob);
+    expect(wav.type).toBe("audio/wav");
+    expect(wav.size).toBeGreaterThan(44);
+    expect(wav.size).toBeGreaterThan(44);
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(fake.context.close).toHaveBeenCalledTimes(1);
+    await recorder.stop();
+    expect(track.stop).toHaveBeenCalledTimes(1);
+
+    const second = await createPcmWavRecorder();
+    second.cancel();
+    await Promise.resolve();
+    expect(track.stop).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects empty recordings", async () => {
+    const track = { stop: vi.fn() };
+    const stream = { getTracks: () => [track] };
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: { getUserMedia: vi.fn(async () => stream) } });
+    const fake = makeAudioContext();
+    window.AudioContext = vi.fn(() => fake.context);
+    const recorder = await createPcmWavRecorder();
+    await expect(recorder.stop()).rejects.toThrow("没有采集到声音");
+  });
+
+  it("captures segments only while active and trims surrounding silence", async () => {
+    const track = { stop: vi.fn() };
+    const stream = { getAudioTracks: () => [track] };
+    const fake = makeAudioContext();
+    window.AudioContext = vi.fn(() => fake.context);
+    const recorder = await createPcmWavSegmentRecorder(stream);
+
+    fake.processor.onaudioprocess({ inputBuffer: { getChannelData: () => new Float32Array([1, 1]) } });
+    expect(await recorder.stopSegment()).toBeNull();
+    expect(() => recorder.startSegment()).not.toThrow();
+    fake.processor.onaudioprocess({ inputBuffer: { getChannelData: () => new Float32Array(16_000).fill(0.2) } });
+    const wav = await recorder.stopSegment();
+    expect(wav).toBeInstanceOf(Blob);
+    expect(wav.size).toBeGreaterThan(44);
+    await recorder.close();
+    await recorder.close();
+    expect(fake.context.close).toHaveBeenCalledTimes(1);
+    expect(() => recorder.startSegment()).toThrow("已关闭");
+    expect(track.stop).not.toHaveBeenCalled();
+  });
+
+  it("validates segment streams and audio context availability", async () => {
+    await expect(createPcmWavSegmentRecorder(null)).rejects.toThrow("没有可用的麦克风音轨");
+    const stream = { getAudioTracks: () => [{}] };
+    await expect(createPcmWavSegmentRecorder(stream)).rejects.toThrow("不支持音频采集");
+  });
+});

--- a/frontend/web/src/infrastructure/auth/__tests__/authTokenCoordinator.test.js
+++ b/frontend/web/src/infrastructure/auth/__tests__/authTokenCoordinator.test.js
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  clearAccessToken,
+  getAccessToken,
+  refreshAccessToken,
+  revokeWebSession,
+  saveAccessToken,
+} from "../authTokenCoordinator.js";
+
+function createStorage() {
+  const values = new Map();
+  return {
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+    has: (key) => values.has(key),
+  };
+}
+
+describe("auth token coordinator", () => {
+  beforeEach(() => {
+    window.sessionStorage.clear();
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it("prefers session storage and falls back to local storage", () => {
+    window.localStorage.setItem("unispeaking.accessToken", "local-token");
+    expect(getAccessToken()).toBe("local-token");
+    window.sessionStorage.setItem("unispeaking.accessToken", "session-token");
+    expect(getAccessToken()).toBe("session-token");
+  });
+
+  it("saves, clears, and conditionally preserves tokens", () => {
+    saveAccessToken({ accessToken: "token-1", user: { id: "user-1" } });
+    expect(getAccessToken()).toBe("token-1");
+    clearAccessToken("stale-token");
+    expect(getAccessToken()).toBe("token-1");
+    clearAccessToken("token-1");
+    expect(getAccessToken()).toBeNull();
+    expect(() => saveAccessToken({})).toThrow("登录响应缺少 access token");
+  });
+
+  it("refreshes once for concurrent callers and handles expected expiry", async () => {
+    window.sessionStorage.setItem("unispeaking.accessToken", "old-token");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response(
+      JSON.stringify({ success: true, data: { accessToken: "new-token" } }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    ));
+    const [first, second] = await Promise.all([refreshAccessToken(), refreshAccessToken()]);
+    expect(first).toBe("new-token");
+    expect(second).toBe("new-token");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/web/token/refresh", expect.objectContaining({ method: "POST", credentials: "include" }));
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ success: false }), { status: 401 }));
+    expect(await refreshAccessToken()).toBeNull();
+  });
+
+  it("falls back to local storage when session storage is unavailable", () => {
+    const original = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    Object.defineProperty(window, "sessionStorage", {
+      configurable: true,
+      value: { getItem: undefined, setItem: undefined, removeItem: undefined },
+    });
+
+    try {
+      saveAccessToken({ accessToken: "local-only", user: { id: "local-user" } });
+      expect(getAccessToken()).toBe("local-only");
+      clearAccessToken();
+      expect(window.localStorage.getItem("unispeaking.accessToken")).toBeNull();
+    } finally {
+      Object.defineProperty(window, "sessionStorage", original);
+    }
+  });
+
+  it("returns early without a token and propagates refresh network failures", async () => {
+    expect(await refreshAccessToken()).toBeNull();
+
+    window.sessionStorage.setItem("unispeaking.accessToken", "old-token");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("refresh offline"));
+    await expect(refreshAccessToken()).rejects.toThrow("refresh offline");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles refresh server errors and direct auth response shapes", async () => {
+    window.sessionStorage.setItem("unispeaking.accessToken", "old-token");
+    const fetchMock = vi.spyOn(globalThis, "fetch");
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ success: false }), { status: 400 }));
+    expect(await refreshAccessToken()).toBeNull();
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ error: { message: "refresh failed" } }), {
+      status: 503,
+      headers: { "Content-Type": "application/json" },
+    }));
+    await expect(refreshAccessToken()).rejects.toThrow("refresh failed");
+
+    fetchMock.mockResolvedValueOnce(new Response("not json", { status: 502 }));
+    await expect(refreshAccessToken()).rejects.toThrow("刷新登录态失败（502）");
+
+    fetchMock.mockResolvedValueOnce(new Response(JSON.stringify({ accessToken: "direct-token" }), { status: 200 }));
+    await expect(refreshAccessToken()).resolves.toBe("direct-token");
+  });
+
+  it("always clears the token after revoking, including a failed request", async () => {
+    window.sessionStorage.setItem("unispeaking.accessToken", "token-to-revoke");
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockRejectedValue(new Error("revoke offline"));
+
+    await expect(revokeWebSession()).rejects.toThrow("revoke offline");
+    expect(fetchMock).toHaveBeenCalledWith("/api/auth/web/token/revoke", expect.objectContaining({
+      method: "POST",
+      credentials: "include",
+      keepalive: true,
+    }));
+    expect(getAccessToken()).toBeNull();
+  });
+});

--- a/frontend/web/src/infrastructure/http/__tests__/apiClient.test.js
+++ b/frontend/web/src/infrastructure/http/__tests__/apiClient.test.js
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const auth = {
+  token: "access-token",
+  get: vi.fn(),
+  refresh: vi.fn(),
+  save: vi.fn(),
+  clear: vi.fn(),
+  revoke: vi.fn(),
+};
+const telemetry = { record: vi.fn(), user: vi.fn() };
+
+vi.mock("../../auth/authTokenCoordinator.js", () => ({
+  getAccessToken: auth.get,
+  refreshAccessToken: auth.refresh,
+  saveAccessToken: auth.save,
+  clearAccessToken: auth.clear,
+  revokeWebSession: auth.revoke,
+}));
+vi.mock("../../../telemetry/clientTelemetry.js", () => ({
+  recordTelemetry: telemetry.record,
+  setTelemetryUser: telemetry.user,
+}));
+
+const api = await import("../apiClient.js");
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  auth.get.mockReturnValue(auth.token);
+  auth.refresh.mockResolvedValue("refreshed-token");
+  vi.stubGlobal("fetch", vi.fn(async () => jsonResponse({ success: true, data: { ok: true } })));
+});
+afterEach(() => vi.unstubAllGlobals());
+
+describe("web API client request behavior", () => {
+  it("sends JSON with auth, unwraps data, and delegates session helpers", async () => {
+    await expect(api.requestAuthenticated("/api/test", { method: "POST", body: JSON.stringify({ hello: "world" }) })).resolves.toEqual({ ok: true });
+    expect(fetch).toHaveBeenCalledWith("/api/test", expect.objectContaining({ credentials: "include", headers: expect.objectContaining({ "Content-Type": "application/json", Authorization: "Bearer access-token" }) }));
+    expect(api.getAccessToken()).toBe("access-token");
+    expect(api.hasAuthSession()).toBe(true);
+    api.saveAuthSession({ accessToken: "new" });
+    api.clearAuthSession("old");
+    expect(auth.save).toHaveBeenCalledWith({ accessToken: "new" });
+    expect(auth.clear).toHaveBeenCalledWith("old");
+  });
+
+  it("refreshes once on protected 401 and emits expiry when refresh is unavailable", async () => {
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "expired" }, 401)).mockResolvedValueOnce(jsonResponse({ success: true, data: "fresh" }));
+    await expect(api.getProfileInsights()).resolves.toBe("fresh");
+    expect(auth.refresh).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenLastCalledWith("/api/profile/insights", expect.objectContaining({ headers: expect.objectContaining({ Authorization: "Bearer refreshed-token" }) }));
+
+    auth.refresh.mockResolvedValue(null);
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "expired" }, 401));
+    const expired = vi.fn();
+    window.addEventListener(api.AUTH_SESSION_EXPIRED_EVENT, expired, { once: true });
+    await expect(api.getProfileInsights()).rejects.toThrow("expired");
+    expect(auth.clear).toHaveBeenCalledWith("access-token");
+    expect(expired).toHaveBeenCalled();
+    expect(telemetry.user).not.toHaveBeenCalled();
+  });
+
+  it("handles network and expected-status failures", async () => {
+    fetch.mockRejectedValueOnce(new Error("network down"));
+    await expect(api.getProfileInsights()).rejects.toThrow("network down");
+    expect(telemetry.record).toHaveBeenCalledWith("api.request", expect.objectContaining({ severity: "ERROR" }));
+    fetch.mockResolvedValueOnce(new Response("accepted", { status: 202 }));
+    await expect(api.requestAuthenticated("/api/async", { expectedStatuses: [202] })).resolves.toBe("accepted");
+    fetch.mockResolvedValueOnce(jsonResponse({ success: false, error: { message: "bad request" } }, 422));
+    await expect(api.requestAuthenticated("/api/bad")).rejects.toThrow("bad request");
+    expect(telemetry.record).toHaveBeenCalledWith("api.request", expect.objectContaining({ severity: "ERROR" }));
+  });
+
+  it("does not refresh auth endpoints or skipped-token requests", async () => {
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "bad credentials" }, 401));
+    await expect(api.requestAuthenticated("/api/auth/login", { method: "POST", body: "{}" })).rejects.toThrow("bad credentials");
+    expect(auth.refresh).not.toHaveBeenCalled();
+
+    auth.get.mockClear();
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: { ok: true } }));
+    await expect(api.requestAuthenticated("/api/public", {
+      skipAccessToken: true,
+      headers: { "X-Test": "yes" },
+    })).resolves.toEqual({ ok: true });
+    expect(auth.get).not.toHaveBeenCalled();
+    expect(fetch).toHaveBeenLastCalledWith("/api/public", expect.objectContaining({
+      headers: { "X-Test": "yes" },
+    }));
+  });
+
+  it("propagates refresh failures and protects a newer session from stale cleanup", async () => {
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "expired" }, 401));
+    auth.refresh.mockRejectedValueOnce(new Error("refresh failed"));
+    await expect(api.getProfileInsights()).rejects.toThrow("refresh failed");
+    expect(auth.clear).not.toHaveBeenCalled();
+
+    auth.refresh.mockResolvedValueOnce(null);
+    auth.clear.mockClear();
+    auth.get.mockReturnValueOnce("access-token").mockReturnValue("newer-token");
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "expired" }, 401));
+    await expect(api.getProfileInsights()).rejects.toThrow("expired");
+    expect(auth.clear).not.toHaveBeenCalled();
+  });
+
+  it("covers async task failure, malformed results, and evaluation completion", async () => {
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "task-1", status: "FAILED", failureReason: "generation rejected" }));
+    await expect(api.generateCustomScene("input")).rejects.toThrow("generation rejected");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "task-2", status: "FAILED" }));
+    await expect(api.generateCustomScene("input")).rejects.toThrow("场景生成失败，请稍后重试");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "task-3", status: "PROCESSING" }));
+    await expect(api.generateCustomScene("input")).rejects.toThrow("任务状态异常");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "task-4", status: "COMPLETED", result: {
+      sceneId: "scene",
+      wordList: [],
+      phraseList: ["phrase"],
+      sentenceList: ["sentence"],
+    } }));
+    await expect(api.generateCustomScene("input")).rejects.toThrow("场景生成内容不完整");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ status: "COMPLETED", result: { score: 7 } }));
+    await expect(api.generateIeltsEvaluation("ielts", "session")).resolves.toEqual({ score: 7 });
+  });
+
+  it("handles auth helpers, multipart requests, completion cleanup, and speech success", async () => {
+    const authResponse = { accessToken: "new-token", user: { id: "u1" } };
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: authResponse }));
+    await expect(api.register({ username: "a", password: "b" })).resolves.toEqual(authResponse);
+    expect(auth.save).toHaveBeenCalledWith(authResponse);
+
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: authResponse }));
+    await expect(api.login({ username: "a", password: "b" })).resolves.toEqual(authResponse);
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: { id: "current" } }));
+    await expect(api.getCurrentUser()).resolves.toEqual({ id: "current" });
+    expect(telemetry.user).toHaveBeenCalledWith("current");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: { uploaded: true } }));
+    await expect(api.uploadProfileAvatar(new Blob(["avatar"]))).resolves.toEqual({ uploaded: true });
+    expect(fetch.mock.calls.at(-1)[1].headers).not.toHaveProperty("Content-Type");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ success: true, data: { completed: true } }));
+    await expect(api.completeCustomDialogue("scene", "session", "now")).resolves.toEqual({ completed: true });
+    expect(fetch.mock.calls.at(-1)[1].signal).toBeInstanceOf(AbortSignal);
+
+    const audio = new Blob(["audio"]);
+    fetch.mockResolvedValueOnce(new Response(audio, { status: 200 }));
+    await expect(api.synthesizeSpeech("scene/a", "hello", "voice")).resolves.toBeInstanceOf(Blob);
+  });
+
+  it("handles media auth expiry and speech error fallbacks", async () => {
+    fetch.mockResolvedValueOnce(new Response("expired", { status: 401 }));
+    auth.refresh.mockResolvedValueOnce(null);
+    await expect(api.fetchAuthenticatedMedia("/recording.wav")).rejects.toThrow("录音加载失败（401）");
+    expect(auth.clear).toHaveBeenCalledWith("access-token");
+
+    fetch.mockResolvedValueOnce(new Response("expired", { status: 401 }));
+    await expect(api.fetchAuthenticatedMedia("https://cdn.example/recording.wav")).rejects.toThrow("录音加载失败（401）");
+    expect(auth.refresh).toHaveBeenCalledTimes(1);
+
+    fetch.mockResolvedValueOnce(jsonResponse({ code: "SPEECH_LIMIT" }, 429));
+    await expect(api.synthesizeSpeech("scene", "hello")).rejects.toThrow("SPEECH_LIMIT");
+    fetch.mockResolvedValueOnce(new Response("bad", { status: 500 }));
+    await expect(api.synthesizeSpeech("scene", "hello")).rejects.toThrow("语音生成失败（500）");
+  });
+
+  it("constructs the profile, achievement, user, IELTS, interview and asset URLs", async () => {
+    const calls = [
+      () => api.getRealtimeIceConfiguration(true), () => api.getProfileOverview("2026-08"), () => api.getProfileInsights(),
+      () => api.updateWeeklyLearningGoals({ count: 3 }), () => api.getAchievementOverview(), () => api.syncAchievementUnlocks(),
+      () => api.acknowledgeAchievementUnlock("a/b"), () => api.updateProfile({ nickname: "N" }),
+      () => api.changePassword({ currentPassword: "a", newPassword: "b" }), () => api.getIeltsTopics({ part: "PART_1", category: "CAT", keyword: " hi ", page: 2, pageSize: 5 }),
+      () => api.getIeltsTraining("PART_2", "topic/1"), () => api.getIeltsSettings(), () => api.updateIeltsSettings({ targetScore: 7, examinerId: "daniel" }),
+      () => api.generateIeltsScene({ mode: "RANDOM", part: "PART_1", topicId: "t" }), () => api.createIeltsSceneFlow("scene"), () => api.getUserPreference(),
+      () => api.getDailyPicks(["a", "b"]), () => api.getDailyPicks(), () => api.updateUserPreference({ voice: "Tina" }),
+      () => api.createCustomSceneFlow("scene"), () => api.advanceCustomSceneFlow("scene", "learn"),
+      () => api.evaluateCustomDialogueTurn("scene/a", "session", 1, "hello"), () => api.evaluateIeltsDialogueTurn("i", "s", 2, "hi"),
+      () => api.advanceIeltsDialogueState("i", "s", 2, true), () => api.advanceIeltsPart2State("i", "s", "START"), () => api.getIeltsEvaluationHistory(),
+      () => api.advanceCustomDialogueState("scene", "session", 1, "hi"), () => api.getCustomDialogueEvaluation("scene", "session"), () => api.getCustomDialogueState("scene", "session"),
+      () => api.prepareInterviewMaterials(new FormData()), () => api.getInterviewOcrAvailability(), () => api.generateInterviewScene({ material: {}, difficulty: "EASY" }),
+      () => api.startInterviewSession("scene", { x: 1 }), () => api.submitInterviewTurn("scene", "session", 1, new FormData()), () => api.endInterview("scene", "session"),
+      () => api.getInterviewReport("scene", "session"), () => api.retryInterviewReport("scene", "session"), () => api.getInterviewAssets(),
+      () => api.getLearningAssets(), () => api.getLearningAsset("scene/a"), () => api.deleteLearningAsset("scene/a"),
+      () => api.evaluateSentenceReading("scene", "sentence", new Blob(["a"])), () => api.translateSceneText("scene", "hello"), () => api.translateSessionText("session", "hello"),
+    ];
+    await Promise.all(calls.map((call) => call()));
+    const urls = fetch.mock.calls.map(([url]) => url);
+    expect(urls).toContain("/api/realtime/ice-configuration?forceRelay=true");
+    expect(urls).toContain("/api/profile/overview?month=2026-08");
+    expect(urls).toContain("/api/ielts/topics?part=PART_1&page=2&pageSize=5&category=CAT&keyword=hi");
+    expect(urls).toContain("/api/daily-picks?exclude=a&exclude=b");
+    expect(urls).toContain("/api/custom-scenes/scene%2Fa/sessions/session/turns/1/evaluation");
+    expect(urls).toContain("/api/interview-scenes/scene/sessions/session/report/retry");
+  });
+
+  it("supports media requests, auth, multipart, speech errors, and async scene generation", async () => {
+    const blob = new Blob(["audio"]);
+    fetch.mockResolvedValueOnce(new Response(blob, { status: 200 }));
+    await expect(api.fetchAuthenticatedMedia("/media.wav")).resolves.toBeInstanceOf(Blob);
+    expect(fetch).toHaveBeenCalledWith("/media.wav", { headers: { Authorization: "Bearer access-token" } });
+    fetch.mockResolvedValueOnce(new Response(blob, { status: 401 })).mockResolvedValueOnce(new Response(blob, { status: 200 }));
+    await expect(api.fetchAuthenticatedMedia("/media.wav")).resolves.toBeInstanceOf(Blob);
+    fetch.mockResolvedValueOnce(new Response("no", { status: 404 }));
+    await expect(api.fetchAuthenticatedMedia("https://cdn.example/media.wav")).rejects.toThrow("录音加载失败（404）");
+    fetch.mockResolvedValueOnce(new Response("bad", { status: 500 }));
+    await expect(api.synthesizeSpeech("scene", "hi")).rejects.toThrow("语音生成失败（500）");
+    fetch.mockResolvedValueOnce(jsonResponse({ message: "speech bad" }, 422));
+    await expect(api.synthesizeSpeech("scene", "hi")).rejects.toThrow("speech bad");
+
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "task/1", status: "PROCESSING" })).mockResolvedValueOnce(jsonResponse({ taskId: "task/1", status: "COMPLETED", result: { sceneId: "scene", wordList: [1], phraseList: [2], sentenceList: [3] } }));
+    await expect(api.generateCustomScene("input", { level: "B1" })).resolves.toMatchObject({ sceneId: "scene", wordList: [1] });
+    fetch.mockResolvedValueOnce(jsonResponse({ taskId: "bad", status: "PROCESSING" })).mockResolvedValueOnce(jsonResponse({ status: "COMPLETED", result: {} }));
+    await expect(api.generateCustomScene("input")).rejects.toThrow("缺少 sceneId");
+  });
+});

--- a/frontend/web/src/infrastructure/http/__tests__/apiClient.test.js
+++ b/frontend/web/src/infrastructure/http/__tests__/apiClient.test.js
@@ -28,6 +28,13 @@ function jsonResponse(body, status = 200) {
   return new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 }
 
+async function expectAudioBlob(request) {
+  const result = await request;
+  expect(result.size).toBe(5);
+  expect(Object.prototype.toString.call(result)).toBe("[object Blob]");
+  await expect(new Response(result).text()).resolves.toBe("audio");
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
   auth.get.mockReturnValue(auth.token);
@@ -148,9 +155,8 @@ describe("web API client request behavior", () => {
     await expect(api.completeCustomDialogue("scene", "session", "now")).resolves.toEqual({ completed: true });
     expect(fetch.mock.calls.at(-1)[1].signal).toBeInstanceOf(AbortSignal);
 
-    const audio = new Blob(["audio"]);
-    fetch.mockResolvedValueOnce(new Response(audio, { status: 200 }));
-    await expect(api.synthesizeSpeech("scene/a", "hello", "voice")).resolves.toBeInstanceOf(Blob);
+    fetch.mockResolvedValueOnce(new Response("audio", { status: 200 }));
+    await expectAudioBlob(api.synthesizeSpeech("scene/a", "hello", "voice"));
   });
 
   it("handles media auth expiry and speech error fallbacks", async () => {
@@ -199,12 +205,11 @@ describe("web API client request behavior", () => {
   });
 
   it("supports media requests, auth, multipart, speech errors, and async scene generation", async () => {
-    const blob = new Blob(["audio"]);
-    fetch.mockResolvedValueOnce(new Response(blob, { status: 200 }));
-    await expect(api.fetchAuthenticatedMedia("/media.wav")).resolves.toBeInstanceOf(Blob);
+    fetch.mockResolvedValueOnce(new Response("audio", { status: 200 }));
+    await expectAudioBlob(api.fetchAuthenticatedMedia("/media.wav"));
     expect(fetch).toHaveBeenCalledWith("/media.wav", { headers: { Authorization: "Bearer access-token" } });
-    fetch.mockResolvedValueOnce(new Response(blob, { status: 401 })).mockResolvedValueOnce(new Response(blob, { status: 200 }));
-    await expect(api.fetchAuthenticatedMedia("/media.wav")).resolves.toBeInstanceOf(Blob);
+    fetch.mockResolvedValueOnce(new Response("expired", { status: 401 })).mockResolvedValueOnce(new Response("audio", { status: 200 }));
+    await expectAudioBlob(api.fetchAuthenticatedMedia("/media.wav"));
     fetch.mockResolvedValueOnce(new Response("no", { status: 404 }));
     await expect(api.fetchAuthenticatedMedia("https://cdn.example/media.wav")).rejects.toThrow("录音加载失败（404）");
     fetch.mockResolvedValueOnce(new Response("bad", { status: 500 }));

--- a/frontend/web/src/telemetry/__tests__/clientTelemetry.test.js
+++ b/frontend/web/src/telemetry/__tests__/clientTelemetry.test.js
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { captureException, flushTelemetry, initializeBrowserTelemetry, recordTelemetry, setTelemetryUser } from "../clientTelemetry.js";
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+  sessionStorage.clear();
+  vi.stubGlobal("fetch", vi.fn(async () => new Response(null, { status: 204 })));
+  document.body.innerHTML = '<div id="root">Visible app</div>';
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("browser telemetry queue", () => {
+  it("filters invalid events, sanitizes payloads, batches, and sends auth", async () => {
+    localStorage.setItem("unispeaking.accessToken", "secret");
+    recordTelemetry("BAD", { attributes: { Good_key: "ok", bad: "x", count: 2, nan: Number.NaN, tooLong: "x".repeat(600) } });
+    recordTelemetry("web.test", { route: "/safe?token=secret", message: "hello", stack: "at x?token=secret", sessionId: "session" });
+    vi.advanceTimersByTime(5_000);
+    await vi.runOnlyPendingTimersAsync();
+    await flushTelemetry();
+    expect(fetch).toHaveBeenCalledWith(expect.stringContaining("/api/telemetry/events"), expect.objectContaining({ method: "POST", headers: expect.objectContaining({ Authorization: "Bearer secret" }) }));
+    const request = fetch.mock.calls[0][1];
+    const body = JSON.parse(request.body);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0]).toMatchObject({ eventType: "web.test", route: "/safe", sessionId: "session", message: "hello" });
+    expect(body.events[0].stack).toContain("[redacted]");
+  });
+
+  it("requeues failed non-keepalive events and accepts 429/keepalive semantics", async () => {
+    fetch.mockRejectedValueOnce(new Error("offline"));
+    recordTelemetry("web.retry");
+    await flushTelemetry();
+    fetch.mockResolvedValueOnce(new Response(null, { status: 429 }));
+    await flushTelemetry({ keepalive: true });
+    expect(fetch).toHaveBeenCalledTimes(2);
+    recordTelemetry("web.retry-again");
+    await flushTelemetry({ keepalive: true });
+    expect(fetch).toHaveBeenCalledTimes(3);
+  });
+
+  it("captures exceptions and installs browser error/rejection/page lifecycle listeners", async () => {
+    captureException("plain failure", { eventType: "custom.error", attributes: { good: true, BAD: "drop" } });
+    initializeBrowserTelemetry();
+    initializeBrowserTelemetry();
+    const resource = document.createElement("img");
+    resource.src = "https://example.com/image.png?token=secret";
+    window.dispatchEvent(new Event("error"));
+    resource.dispatchEvent(new Event("error"));
+    window.dispatchEvent(new ErrorEvent("error", { error: new Error("boom"), message: "boom" }));
+    const rejection = new Event("unhandledrejection");
+    Object.defineProperty(rejection, "reason", { value: "rejected" });
+    window.dispatchEvent(rejection);
+    document.dispatchEvent(new Event("visibilitychange"));
+    window.dispatchEvent(new Event("pagehide"));
+    setTelemetryUser("user-1");
+    setTelemetryUser(null);
+    expect(fetch).toHaveBeenCalled();
+    await flushTelemetry({ keepalive: true });
+  });
+
+  it("reports supported performance entries and white-screen checks", async () => {
+    vi.resetModules();
+    const telemetryModule = await import("../clientTelemetry.js");
+    const observers = [];
+    class TestPerformanceObserver {
+      constructor(callback) {
+        this.callback = callback;
+        observers.push(this);
+      }
+
+      observe(options) {
+        this.type = options.type;
+      }
+    }
+    vi.stubGlobal("PerformanceObserver", TestPerformanceObserver);
+    window.PerformanceObserver = TestPerformanceObserver;
+    vi.spyOn(performance, "getEntriesByType").mockReturnValue([{
+      responseStart: 12.345,
+      domContentLoadedEventEnd: 34.567,
+      loadEventEnd: 56.789,
+    }]);
+    telemetryModule.initializeBrowserTelemetry();
+
+    const observerByType = Object.fromEntries(observers.map((observer) => [observer.type, observer]));
+    observerByType.paint.callback({ getEntries: () => [{ name: "first-contentful-paint", startTime: 10.126 }] });
+    observerByType["largest-contentful-paint"].callback({ getEntries: () => [{ startTime: 22.229 }] });
+    observerByType["layout-shift"].callback({ getEntries: () => [
+      { hadRecentInput: false, value: 0.1 },
+      { hadRecentInput: true, value: 0.9 },
+    ] });
+    observerByType.event.callback({ getEntries: () => [{ duration: 41 }, { duration: 30 }] });
+
+    document.body.innerHTML = '<div id="root"></div>';
+    window.dispatchEvent(new Event("load"));
+    vi.advanceTimersByTime(5_000);
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "hidden" });
+    document.dispatchEvent(new Event("visibilitychange"));
+    await telemetryModule.flushTelemetry();
+    await telemetryModule.flushTelemetry();
+    await telemetryModule.flushTelemetry();
+
+    const sentEvents = fetch.mock.calls.flatMap(([, options]) => {
+      if (!options?.body) return [];
+      return JSON.parse(options.body).events || [];
+    });
+    expect(sentEvents.map((event) => event.eventType)).toEqual(expect.arrayContaining([
+      "web.performance",
+      "web.white_screen",
+    ]));
+    expect(sentEvents.some((event) => event.attributes.metric_name === "cls" && event.attributes.unit === "score")).toBe(true);
+    expect(sentEvents.some((event) => event.attributes.metric_name === "inp")).toBe(true);
+  });
+
+  it("handles storage failures and trims the queue to its maximum size", async () => {
+    const originalLocalStorage = Object.getOwnPropertyDescriptor(window, "localStorage");
+    const originalSessionStorage = Object.getOwnPropertyDescriptor(window, "sessionStorage");
+    const brokenStorage = {
+      getItem: () => { throw new Error("storage blocked"); },
+      setItem: () => { throw new Error("storage blocked"); },
+      removeItem: () => { throw new Error("storage blocked"); },
+    };
+    Object.defineProperty(window, "localStorage", { configurable: true, value: brokenStorage });
+    Object.defineProperty(window, "sessionStorage", { configurable: true, value: brokenStorage });
+    try {
+      recordTelemetry("web.storage-fallback", { route: "not a valid URL" });
+    } finally {
+      Object.defineProperty(window, "localStorage", originalLocalStorage);
+      Object.defineProperty(window, "sessionStorage", originalSessionStorage);
+    }
+
+    await flushTelemetry();
+    expect(fetch).toHaveBeenCalled();
+
+    fetch.mockClear();
+    for (let index = 0; index < 101; index += 1) recordTelemetry(`web.queue-${index}`);
+    await flushTelemetry();
+    expect(fetch.mock.calls[0]).toBeDefined();
+    expect(JSON.parse(fetch.mock.calls[0][1].body).events).toHaveLength(20);
+  });
+
+  it("covers telemetry defaults, empty branches, and Sentry integration", async () => {
+    vi.resetModules();
+    const telemetryModule = await import("../clientTelemetry.js");
+    await telemetryModule.flushTelemetry();
+    telemetryModule.recordTelemetry("web.defaults", {
+      severity: "",
+      message: "",
+      stack: "",
+      attributes: undefined,
+    });
+    await telemetryModule.flushTelemetry();
+    const defaultBody = JSON.parse(fetch.mock.calls.at(-1)[1].body);
+    expect(defaultBody.events[0]).toMatchObject({ severity: "INFO", message: null, stack: null, attributes: {} });
+
+    vi.stubGlobal("crypto", { randomUUID: undefined });
+    telemetryModule.recordTelemetry("web.fallback-id", {
+      route: "https://example.test/path?token=secret",
+      sessionId: "",
+      attributes: { enabled: false, count: Infinity, "bad-key": true },
+    });
+    await telemetryModule.flushTelemetry();
+    const fallbackBody = JSON.parse(fetch.mock.calls.at(-1)[1].body);
+    expect(fallbackBody.events[0].route).toBe("/path");
+    expect(fallbackBody.events[0].sessionId).toMatch(/^page-/);
+    expect(fallbackBody.events[0].attributes).toEqual({ enabled: false });
+
+    vi.resetModules();
+    vi.stubEnv("VITE_SENTRY_DSN", " https://sentry.example/123 ");
+    const sentry = {
+      init: vi.fn(),
+      browserTracingIntegration: vi.fn(() => ({ name: "tracing" })),
+      setUser: vi.fn(),
+      withScope: vi.fn((callback) => callback({ setExtra: vi.fn() })),
+      captureException: vi.fn(),
+    };
+    vi.doMock("@sentry/react", () => sentry);
+    const sentryTelemetry = await import("../clientTelemetry.js");
+    sentryTelemetry.setTelemetryUser(42);
+    sentryTelemetry.initializeBrowserTelemetry();
+    await vi.waitFor(() => expect(sentry.init).toHaveBeenCalled());
+    expect(sentry.init).toHaveBeenCalledWith(expect.objectContaining({
+      dsn: "https://sentry.example/123",
+      sendDefaultPii: false,
+      tracesSampleRate: 0.1,
+    }));
+    expect(sentry.setUser).toHaveBeenCalledWith({ id: "42" });
+    sentryTelemetry.captureException(new Error("sentry failure"), { attributes: { feature: "test" } });
+    expect(sentry.withScope).toHaveBeenCalled();
+    expect(sentry.captureException).toHaveBeenCalledWith(expect.any(Error));
+  });
+
+  it("handles unsupported performance observers and all listener fallbacks", async () => {
+    vi.resetModules();
+    vi.stubGlobal("PerformanceObserver", class UnsupportedObserver {
+      constructor() { throw new Error("unsupported"); }
+    });
+    window.PerformanceObserver = globalThis.PerformanceObserver;
+    const telemetryModule = await import("../clientTelemetry.js");
+    telemetryModule.initializeBrowserTelemetry();
+
+    const resource = document.createElement("script");
+    resource.src = "not a valid url?access_token=secret";
+    const resourceError = new Event("error");
+    Object.defineProperty(resourceError, "target", { value: resource });
+    window.dispatchEvent(resourceError);
+    const jsError = new Event("error");
+    Object.defineProperties(jsError, {
+      target: { value: window },
+      error: { value: null },
+      message: { value: "window boom" },
+    });
+    window.dispatchEvent(jsError);
+    const rejection = new Event("unhandledrejection");
+    Object.defineProperty(rejection, "reason", { value: new Error("promise boom") });
+    window.dispatchEvent(rejection);
+    document.body.innerHTML = '<div id="root"><button>click</button></div>';
+    window.dispatchEvent(new Event("load"));
+    vi.advanceTimersByTime(5_000);
+    await telemetryModule.flushTelemetry({ keepalive: true });
+    const events = fetch.mock.calls.flatMap(([, options]) => options?.body ? JSON.parse(options.body).events : []);
+    expect(events.map((event) => event.eventType)).toEqual(expect.arrayContaining([
+      "web.app_started",
+      "web.resource_error",
+      "js.exception",
+      "js.unhandled_rejection",
+    ]));
+  });
+});

--- a/frontend/web/src/telemetry/__tests__/rtcTelemetry.test.js
+++ b/frontend/web/src/telemetry/__tests__/rtcTelemetry.test.js
@@ -1,0 +1,123 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const recordTelemetry = vi.fn();
+vi.mock("../clientTelemetry.js", () => ({ recordTelemetry }));
+
+const { createRtcTelemetryMonitor, summarizeRtcStats } = await import("../rtcTelemetry.js");
+
+function reportWithPair(overrides = {}) {
+  return new Map([
+    ["transport", { id: "transport", type: "transport", selectedCandidatePairId: "pair" }],
+    ["pair", { id: "pair", type: "candidate-pair", currentRoundTripTime: 0.04, localCandidateId: "local", remoteCandidateId: "remote", ...overrides }],
+    ["local", { id: "local", type: "local-candidate", candidateType: "host", networkType: "wifi" }],
+    ["remote", { id: "remote", type: "remote-candidate", candidateType: "srflx" }],
+    ["audio", { id: "audio", type: "inbound-rtp", kind: "audio", jitter: 0.002, packetsReceived: 100, packetsLost: 2 }],
+  ]);
+}
+
+describe("rtcTelemetry", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(0);
+    recordTelemetry.mockReset();
+    vi.spyOn(performance, "now").mockReturnValue(0);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it("summarizes selected transport stats and handles fallback candidate pairs", () => {
+    const selected = summarizeRtcStats(reportWithPair({ availableOutgoingBitrate: 8000 }), { packetsReceived: 50, packetsLost: 1 });
+    expect(selected.attributes).toMatchObject({
+      rtt_ms: 40,
+      jitter_ms: 2,
+      packets_received: 100,
+      packets_lost: 2,
+      packet_loss_pct: 1.9607843137254901,
+      available_outgoing_bitrate: 8000,
+      local_candidate_type: "host",
+      remote_candidate_type: "srflx",
+      network_type: "wifi",
+      turn_used: false,
+    });
+
+    const fallback = summarizeRtcStats(new Map([
+      ["pair", { id: "pair", type: "candidate-pair", selected: true, state: "succeeded", nominated: true }],
+      ["audio", { id: "audio", type: "inbound-rtp", mediaType: "audio", packetsReceived: 3, packetsLost: 0 }],
+    ]));
+    expect(fallback.attributes.local_candidate_type).toBe("unknown");
+    expect(fallback.attributes.packet_loss_pct).toBe(0);
+  });
+
+  it("reports lifecycle events, quality collection, and ICE connection duration", async () => {
+    let clock = 0;
+    vi.spyOn(performance, "now").mockImplementation(() => clock);
+    const sessionId = vi.fn(() => "session-1");
+    const peer = {
+      iceConnectionState: "connected",
+      connectionState: "connected",
+      getStats: vi.fn().mockResolvedValue(reportWithPair()),
+    };
+    const monitor = createRtcTelemetryMonitor(peer, { sessionId, model: "test-model" });
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.started", { attributes: { model: "test-model" } });
+
+    clock = 250;
+    monitor.stateChanged("ice", "connected");
+    monitor.stateChanged("ice", "completed");
+    monitor.stateChanged("connection", "disconnected");
+    monitor.connected();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.ice_connected", expect.objectContaining({
+      sessionId: "session-1",
+      attributes: expect.objectContaining({ connect_duration_ms: 250, model: "test-model" }),
+    }));
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.connection_state", expect.objectContaining({ severity: "WARN" }));
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.quality", expect.objectContaining({
+      sessionId: "session-1",
+      attributes: expect.objectContaining({ model: "test-model", ice_state: "connected" }),
+    }));
+
+    clock = 1_250;
+    monitor.stop("user_stop");
+    monitor.stop("second_stop");
+    await Promise.resolve();
+    vi.clearAllTimers();
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.final_quality", expect.anything());
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.ended", expect.objectContaining({
+      sessionId: "session-1",
+      attributes: expect.objectContaining({ duration_ms: 1250, reason: "user_stop", model: "test-model" }),
+    }));
+    expect(peer.getStats).toHaveBeenCalled();
+  });
+
+  it("records failures and stats errors without throwing", async () => {
+    const peer = {
+      iceConnectionState: "failed",
+      connectionState: "failed",
+      getStats: vi.fn().mockRejectedValue(new Error("stats unavailable")),
+    };
+    const monitor = createRtcTelemetryMonitor(peer, { sessionId: () => "", model: "model" });
+    expect(() => monitor.stateChanged("ice", "failed")).not.toThrow();
+    await Promise.resolve();
+    monitor.stop();
+    await Promise.resolve();
+    vi.clearAllTimers();
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.ice_state", expect.objectContaining({ severity: "ERROR", message: "ice failed" }));
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.stats_failed", expect.objectContaining({
+      severity: "WARN",
+      message: "stats unavailable",
+    }));
+  });
+
+  it("stops sampling when the peer has no stats method", async () => {
+    const monitor = createRtcTelemetryMonitor({}, { sessionId: () => "session", model: "model" });
+    monitor.connected();
+    monitor.stop();
+    await Promise.resolve();
+    vi.clearAllTimers();
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.connected", expect.anything());
+    expect(recordTelemetry).toHaveBeenCalledWith("rtc.ended", expect.anything());
+  });
+});

--- a/frontend/web/src/test/setup.js
+++ b/frontend/web/src/test/setup.js
@@ -1,0 +1,27 @@
+import "@testing-library/jest-dom/vitest";
+
+if (typeof HTMLMediaElement !== "undefined") {
+  HTMLMediaElement.prototype.play = async () => undefined;
+  HTMLMediaElement.prototype.pause = () => undefined;
+}
+
+if (!window.matchMedia) {
+  window.matchMedia = () => ({
+    matches: false,
+    media: "",
+    onchange: null,
+    addListener() {},
+    removeListener() {},
+    addEventListener() {},
+    removeEventListener() {},
+    dispatchEvent() { return false; },
+  });
+}
+
+if (!window.ResizeObserver) {
+  window.ResizeObserver = class ResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+}

--- a/frontend/web/src/websocket/__tests__/realtimeClient.edge-cases.test.js
+++ b/frontend/web/src/websocket/__tests__/realtimeClient.edge-cases.test.js
@@ -1,0 +1,948 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(() => "access-token"),
+  requestAuthenticated: vi.fn(),
+  advanceCustomDialogueState: vi.fn(),
+  advanceIeltsDialogueState: vi.fn(),
+  advanceIeltsPart2State: vi.fn(),
+  completeCustomDialogue: vi.fn(),
+  endInterview: vi.fn(),
+  evaluateCustomDialogueTurn: vi.fn(),
+  evaluateIeltsDialogueTurn: vi.fn(),
+  getCustomDialogueEvaluation: vi.fn(),
+  getInterviewReport: vi.fn(),
+  getRealtimeIceConfiguration: vi.fn(),
+  submitInterviewTurn: vi.fn(),
+  createPcmWavSegmentRecorder: vi.fn(),
+  createRtcTelemetryMonitor: vi.fn(),
+}));
+
+vi.mock("../../infrastructure/http/apiClient.js", () => mocks);
+vi.mock("../../infrastructure/audio/audioRecorder.js", () => ({
+  createPcmWavSegmentRecorder: mocks.createPcmWavSegmentRecorder,
+}));
+vi.mock("../../telemetry/rtcTelemetry.js", () => ({
+  createRtcTelemetryMonitor: mocks.createRtcTelemetryMonitor,
+}));
+
+import { createRealtimeClient } from "../realtimeClient.js";
+
+let peerMode;
+let channelMode;
+let wsMode;
+let wsAckMode;
+let createdPeers;
+let createdSockets;
+
+class EdgeChannel {
+  constructor() {
+    this.readyState = channelMode.initialState || "open";
+    this.listeners = {};
+    this.sent = [];
+    this.close = vi.fn(() => {
+      this.readyState = "closed";
+      this.onclose?.();
+      this.dispatch("close", {});
+    });
+  }
+
+  addEventListener(type, handler) {
+    (this.listeners[type] ||= []).push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners[type] = (this.listeners[type] || []).filter((item) => item !== handler);
+  }
+
+  dispatch(type, event) {
+    this.listeners[type]?.slice().forEach((handler) => handler(event));
+  }
+
+  send(payload) {
+    if (channelMode.sendError) throw new Error("data channel send failed");
+    if (channelMode.sendErrorAndClose) {
+      this.readyState = "closed";
+      throw new Error("data channel send failed after close");
+    }
+    this.sent.push(JSON.parse(payload));
+  }
+}
+
+class EdgePeer {
+  constructor(configuration) {
+    this.configuration = configuration;
+    this.iceGatheringState = "new";
+    this.iceConnectionState = "connected";
+    this.connectionState = "connected";
+    this.signalingState = "stable";
+    this.listeners = {};
+    this.localDescription = null;
+    this.remoteDescription = null;
+    this.channel = null;
+    this.close = vi.fn(() => {
+      this.signalingState = "closed";
+      this.connectionState = "closed";
+    });
+    createdPeers.push(this);
+  }
+
+  addEventListener(type, handler) {
+    (this.listeners[type] ||= []).push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners[type] = (this.listeners[type] || []).filter((item) => item !== handler);
+  }
+
+  dispatch(type, event = {}) {
+    this.listeners[type]?.slice().forEach((handler) => handler(event));
+  }
+
+  addTrack(track, stream) {
+    this.localStream = stream;
+    this.sender = {
+      track: null,
+      replaceTrack: vi.fn(async (nextTrack) => {
+        this.sender.track = nextTrack;
+      }),
+    };
+    return this.sender;
+  }
+
+  createDataChannel() {
+    this.channel = new EdgeChannel();
+    return this.channel;
+  }
+
+  async createOffer() {
+    if (peerMode.createOfferError) throw new Error("offer failed");
+    return { type: "offer", sdp: "v=0\n" };
+  }
+
+  async setLocalDescription(offer) {
+    this.localDescription = {
+      ...offer,
+      sdp: "v=0\r\na=candidate:1 1 UDP 1 127.0.0.1 9 typ host\r\n",
+    };
+    this.iceGatheringState = "complete";
+  }
+
+  async setRemoteDescription(description) {
+    if (peerMode.setRemoteDescriptionError) throw new Error("answer rejected");
+    this.remoteDescription = description;
+  }
+
+  async getStats() {
+    return peerMode.stats || [];
+  }
+}
+
+class EdgeWebSocket {
+  static OPEN = 1;
+
+  static CONNECTING = 0;
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = EdgeWebSocket.CONNECTING;
+    this.listeners = {};
+    this.sent = [];
+    createdSockets.push(this);
+    if (wsMode === "timeout") return;
+    queueMicrotask(() => {
+      if (wsMode === "error") {
+        this.onerror?.();
+        this.dispatch("error", {});
+        return;
+      }
+      this.readyState = EdgeWebSocket.OPEN;
+      this.onopen?.();
+      this.dispatch("open", {});
+    });
+  }
+
+  addEventListener(type, handler) {
+    (this.listeners[type] ||= []).push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners[type] = (this.listeners[type] || []).filter((item) => item !== handler);
+  }
+
+  dispatch(type, event) {
+    this.listeners[type]?.slice().forEach((handler) => handler(event));
+  }
+
+  send(payload) {
+    const message = JSON.parse(payload);
+    this.sent.push(message);
+    if (!["activate", "bind", "end", "message"].includes(message.type)) return;
+    queueMicrotask(() => {
+      if (wsAckMode === "reject" && message.type === "activate") {
+        this.onmessage?.({ data: JSON.stringify({
+          type: "session.activate.accepted",
+          success: false,
+          code: "ACTIVATE_FAILED",
+          message: "activation rejected",
+        }) });
+        return;
+      }
+      if (wsAckMode === "reject-end" && message.type === "end") {
+        this.onmessage?.({ data: JSON.stringify({
+          type: "session.end.accepted",
+          success: false,
+          code: "END_FAILED",
+          message: "end rejected",
+        }) });
+        return;
+      }
+      if (wsAckMode === "reject-bind" && message.type === "bind") {
+        this.onmessage?.({ data: JSON.stringify({
+          type: "session.bind.accepted",
+          success: false,
+          code: "BIND_FAILED",
+          message: "bind rejected",
+        }) });
+        return;
+      }
+      if (wsAckMode === "silent") return;
+      this.onmessage?.({ data: JSON.stringify({
+        type: `session.${message.type}.accepted`,
+        success: true,
+        data: wsAckMode === "quota" && message.type === "activate"
+          ? { quotaRemainingMillis: 0 }
+          : undefined,
+      }) });
+    });
+  }
+
+  close = vi.fn(() => {
+    this.readyState = 3;
+    this.onclose?.();
+    this.dispatch("close", {});
+  });
+}
+
+function makeStream() {
+  const track = { enabled: false, stop: vi.fn() };
+  return {
+    track,
+    getAudioTracks: () => [track],
+    getTracks: () => [track],
+  };
+}
+
+function backend(overrides = {}) {
+  return {
+    sessionId: "local-session",
+    providerSessionId: "provider-session",
+    answerSdp: "v=0\n",
+    systemPrompt: "You are a helpful speaking partner.",
+    voiceId: "Tina",
+    ...overrides,
+  };
+}
+
+function installBrowserFakes() {
+  const stream = makeStream();
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: vi.fn(async () => stream) },
+  });
+  vi.stubGlobal("RTCPeerConnection", EdgePeer);
+  vi.stubGlobal("WebSocket", EdgeWebSocket);
+  return stream;
+}
+
+async function startClient(options = {}) {
+  const client = createRealtimeClient(options);
+  const promise = client.start();
+  expect(client.start()).toBe(promise);
+  await promise;
+  return client;
+}
+
+beforeEach(() => {
+  peerMode = {};
+  channelMode = {};
+  wsMode = "open";
+  wsAckMode = "normal";
+  createdPeers = [];
+  createdSockets = [];
+  vi.clearAllMocks();
+  installBrowserFakes();
+  mocks.getAccessToken.mockReturnValue("access-token");
+  mocks.requestAuthenticated.mockResolvedValue(backend());
+  mocks.getRealtimeIceConfiguration.mockResolvedValue({ turnEnabled: false, iceServers: [] });
+  mocks.createRtcTelemetryMonitor.mockReturnValue({
+    stateChanged: vi.fn(),
+    connected: vi.fn(),
+    stop: vi.fn(),
+  });
+  mocks.advanceIeltsPart2State.mockResolvedValue({ completed: false, controlInstruction: "Continue Part 2" });
+  mocks.advanceIeltsDialogueState.mockResolvedValue({ completed: false, controlInstruction: "Next Part 3 question" });
+  mocks.evaluateIeltsDialogueTurn.mockResolvedValue({ overallScore: 84 });
+  mocks.completeCustomDialogue.mockResolvedValue({ evaluation: { finalScore: 86 } });
+  mocks.getCustomDialogueEvaluation.mockResolvedValue({ finalScore: 80 });
+  mocks.endInterview.mockResolvedValue({ status: "PROCESSING" });
+  mocks.getInterviewReport.mockResolvedValue({ status: "PROCESSING" });
+  mocks.createPcmWavSegmentRecorder.mockResolvedValue(undefined);
+  vi.stubGlobal("RTCPeerConnection", EdgePeer);
+  vi.stubGlobal("WebSocket", EdgeWebSocket);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe("realtime client transport and lifecycle edges", () => {
+  it("reports malformed provider input, forwards peer events, deduplicates messages, and cleans up", async () => {
+    const events = [];
+    const onRemoteStream = vi.fn();
+    const remoteTrack = { stop: vi.fn() };
+    const client = await startClient({ onEvent: (event) => events.push(event), onRemoteStream });
+    const peer = createdPeers[0];
+    const incoming = new EdgeChannel();
+    peer.ontrack({ streams: [{ getTracks: () => [remoteTrack] }] });
+    peer.onconnectionstatechange();
+    peer.oniceconnectionstatechange();
+    peer.ondatachannel({ channel: incoming });
+    incoming.onmessage({ data: "{" });
+    await client.handleEvent("not-json");
+    expect(events.filter((event) => event.type === "local.error")).toHaveLength(2);
+    expect(onRemoteStream).toHaveBeenCalledTimes(1);
+
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.audio_transcript.done", item_id: "assistant-1", transcript: "Welcome" });
+    await client.handleEvent({ type: "response.audio_transcript.done", item_id: "assistant-1", transcript: "Welcome again" });
+    await client.handleEvent({ type: "response.text.done", text: "   " });
+    const transcripts = events.filter((event) => event.type === "local.transcript.final");
+    expect(transcripts).toHaveLength(1);
+    expect(peer.channel.sent.map((event) => event.type)).toContain("response.create");
+
+    expect(client.setMuted(true)).toBe(true);
+    expect(client.setMuted(false)).toBe(false);
+    await client.pause();
+    await client.resume();
+    await client.handleEvent({ type: "response.done" });
+    expect(client.requestResponse()).toBe(true);
+    expect(client.requestResponse()).toBe(false);
+    await client.interrupt();
+    await client.stop({ notifyBackend: false, reason: "edge_cleanup" });
+    expect(peer.channel.close).toHaveBeenCalled();
+    expect(peer.close).toHaveBeenCalled();
+    expect(remoteTrack.stop).toHaveBeenCalled();
+    expect(client.isActive()).toBe(false);
+    expect(events.map((event) => event.type)).toEqual(expect.arrayContaining([
+      "local.connection_state",
+      "local.muted",
+      "local.paused",
+      "local.resumed",
+      "local.interrupted",
+      "local.ended",
+    ]));
+  });
+
+  it("handles missing authentication and WebSocket failures during startup", async () => {
+    mocks.getAccessToken.mockReturnValueOnce(null);
+    const missingTokenEvents = [];
+    const missingToken = createRealtimeClient({ onEvent: (event) => missingTokenEvents.push(event) });
+    await expect(missingToken.start()).rejects.toThrow("请先登录");
+    expect(missingTokenEvents.at(-1)).toMatchObject({ type: "local.error", code: "SESSION_WEBSOCKET_FAILED" });
+    expect(missingToken.isActive()).toBe(false);
+
+    wsMode = "error";
+    const socketEvents = [];
+    const socketFailure = createRealtimeClient({ onEvent: (event) => socketEvents.push(event) });
+    await expect(socketFailure.start()).rejects.toThrow("会话 WebSocket 连接失败");
+    expect(socketEvents.at(-1)).toMatchObject({ type: "local.error", code: "SESSION_WEBSOCKET_FAILED" });
+    expect(createdSockets[0].close).toHaveBeenCalled();
+  });
+
+  it("cleans up after remote-description and session-activation failures", async () => {
+    peerMode.setRemoteDescriptionError = true;
+    const remoteEvents = [];
+    const remoteFailure = createRealtimeClient({ onEvent: (event) => remoteEvents.push(event) });
+    await expect(remoteFailure.start()).rejects.toThrow("answer rejected");
+    expect(remoteEvents.at(-1)).toMatchObject({ type: "local.error", code: "WEBRTC_REMOTE_DESCRIPTION_FAILED" });
+    expect(createdPeers[0].close).toHaveBeenCalled();
+
+    peerMode = {};
+    wsAckMode = "reject";
+    const activationEvents = [];
+    const activationFailure = createRealtimeClient({ onEvent: (event) => activationEvents.push(event) });
+    await expect(activationFailure.start()).rejects.toThrow("activation rejected");
+    expect(activationEvents.at(-1)).toMatchObject({ type: "local.error", code: "ACTIVATE_FAILED" });
+    expect(createdPeers.at(-1).close).toHaveBeenCalled();
+  });
+
+  it("supports instruction acknowledgements, rejects update errors, and closes active sessions", async () => {
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    const update = client.updateInstructions("extra guidance");
+    await vi.waitFor(() => expect(
+      createdPeers[0].channel.sent.filter((event) => event.type === "session.update"),
+    ).toHaveLength(2));
+    await Promise.resolve();
+    await client.handleEvent({ type: "session.updated", session: { instructions: "extra guidance" } });
+    await expect(update).resolves.toBe(true);
+    const sentUpdates = createdPeers[0].channel.sent.filter((event) => event.type === "session.update");
+    expect(sentUpdates.at(-1).session.instructions).toContain("extra guidance");
+
+    const failedUpdate = client.updateInstructions("will fail");
+    await vi.waitFor(() => expect(
+      createdPeers[0].channel.sent.filter((event) => event.type === "session.update"),
+    ).toHaveLength(3));
+    await Promise.resolve();
+    await client.handleEvent({ type: "error", error: { message: "session.update rejected" } });
+    await expect(failedUpdate).rejects.toThrow("session.update rejected");
+    expect(events).toContainEqual(expect.objectContaining({ type: "error" }));
+    await client.stop();
+    expect(createdSockets[0].sent.map((message) => message.type)).toContain("end");
+    expect(events.at(-1)).toMatchObject({ type: "local.ended", reason: "user_stop" });
+  });
+
+  it("times out a queued instruction update and continues with the next update", async () => {
+    vi.useFakeTimers();
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+
+    const timedOut = client.updateInstructions("never acknowledged");
+    const timedOutAssertion = expect(timedOut).rejects.toThrow("等待实时会话指令更新确认超时");
+    await vi.advanceTimersByTimeAsync(5_000);
+    await timedOutAssertion;
+
+    const next = client.updateInstructions("acknowledged next");
+    await vi.waitFor(() => expect(
+      createdPeers[0].channel.sent.filter((event) => event.type === "session.update"),
+    ).toHaveLength(3));
+    await client.handleEvent({ type: "session.updated", session: { instructions: "acknowledged next" } });
+    await expect(next).resolves.toBe(true);
+    vi.useRealTimers();
+    await client.stop({ notifyBackend: false, reason: "instruction_timeout_cleanup" });
+    expect(events).not.toContainEqual(expect.objectContaining({ type: "local.provider_warning" }));
+  });
+
+  it("handles a provider close racing a response send without throwing", async () => {
+    const client = await startClient();
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.done" });
+    channelMode.sendErrorAndClose = true;
+    expect(client.requestResponse()).toBe(false);
+    await client.stop({ notifyBackend: false, reason: "response_race_cleanup" });
+  });
+
+  it("rejects IELTS controls unless the matching stage is active", async () => {
+    const client = createRealtimeClient({ sceneId: "free-client", sceneType: "free-chat" });
+    await expect(client.transitionIeltsPart2("PREPARATION_COMPLETE")).rejects.toThrow("当前会话不是 IELTS Part 2");
+    await expect(client.forceIeltsPart3TurnTimeout()).rejects.toThrow("当前会话不是 IELTS Part 3");
+
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({ currentStage: "PART_3" }));
+    const part3 = await startClient({ sceneId: "part3-controls", sceneType: "ielts" });
+    await expect(part3.transitionIeltsPart2("ANSWER_COMPLETE")).rejects.toThrow("当前会话不是 IELTS Part 2");
+    await part3.stop({ notifyBackend: false, reason: "invalid_control_cleanup" });
+  });
+
+  it("recovers an IELTS Part 1 turn with the prepared-question fallback", async () => {
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({
+      currentStage: "PART_1",
+      content: { part1: [{ question: "Only prepared question" }] },
+    }));
+    mocks.advanceIeltsDialogueState.mockRejectedValueOnce(new Error("state unavailable"));
+    const events = [];
+    const client = await startClient({
+      sceneId: "part1-fallback-complete",
+      sceneType: "ielts",
+      onEvent: (event) => events.push(event),
+    });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "part1-answer",
+      transcript: "My answer",
+    });
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ielts_state_recovered",
+      message: "state unavailable",
+    }));
+    expect(createdPeers[0].channel.sent).toContainEqual(expect.objectContaining({
+      type: "response.create",
+      response: expect.objectContaining({
+        instructions: expect.stringContaining("PREPARED_QUESTIONS"),
+      }),
+    }));
+    await client.stop({ notifyBackend: false, reason: "part1_fallback_cleanup" });
+  });
+
+  it("defers custom completion when the assistant asks a follow-up question", async () => {
+    mocks.createPcmWavSegmentRecorder.mockResolvedValue({
+      startSegment: vi.fn(),
+      stopSegment: vi.fn(async () => new Blob(["custom"])),
+      close: vi.fn(),
+    });
+    mocks.advanceCustomDialogueState.mockResolvedValueOnce({
+      completed: true,
+      controlInstruction: "Ask one final follow-up.",
+    });
+    const events = [];
+    const client = await startClient({
+      sceneId: "custom-follow-up",
+      sceneType: "custom",
+      onEvent: (event) => events.push(event),
+    });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "custom-follow-up-input" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "custom-follow-up-input",
+      transcript: "My final answer",
+    });
+    await vi.waitFor(() => expect(mocks.advanceCustomDialogueState).toHaveBeenCalled());
+    await client.handleEvent({
+      type: "response.audio_transcript.done",
+      item_id: "follow-up-question",
+      transcript: "Could you explain that further?",
+    });
+    await client.handleEvent({ type: "response.done" });
+    expect(events).not.toContainEqual(expect.objectContaining({ type: "local.scenario_completed" }));
+    expect(mocks.completeCustomDialogue).not.toHaveBeenCalled();
+    await client.stop({ notifyBackend: false, reason: "custom_follow_up_cleanup" });
+  });
+
+  it("recovers a failed custom completion request with an idempotent evaluation query", async () => {
+    mocks.completeCustomDialogue.mockRejectedValueOnce(new Error("completion interrupted"));
+    mocks.getCustomDialogueEvaluation.mockResolvedValueOnce({ finalScore: 91 });
+    const events = [];
+    const client = await startClient({
+      sceneId: "custom-1",
+      sceneType: "custom",
+      onEvent: (event) => events.push(event),
+    });
+    const completion = await client.stop({ reason: "user_stop" });
+    expect(completion.evaluation).toEqual({ finalScore: 91 });
+    expect(mocks.getCustomDialogueEvaluation).toHaveBeenCalledWith("custom-1", "local-session");
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.session_evaluation",
+      evaluation: { finalScore: 91 },
+    }));
+  });
+
+  it("exercises IELTS Part 2 transitions and Part 3 timeout state", async () => {
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({
+      currentStage: "PART_2",
+      content: { part3: [] },
+    }));
+    const part2Events = [];
+    const part2 = await startClient({
+      sceneId: "ielts-2",
+      sceneType: "ielts",
+      onEvent: (event) => part2Events.push(event),
+    });
+    await expect(part2.transitionIeltsPart2("PREPARATION_COMPLETE")).resolves.toMatchObject({ completed: false });
+    await expect(part2.transitionIeltsPart2("ANSWER_COMPLETE")).resolves.toMatchObject({ completed: false });
+    expect(mocks.advanceIeltsPart2State).toHaveBeenCalledWith("ielts-2", "local-session", "PREPARATION_COMPLETE");
+    expect(part2Events.map((event) => event.type)).toContain("local.ielts_part2_state");
+    await part2.stop({ notifyBackend: false });
+
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({ currentStage: "PART_3" }));
+    const part3 = await startClient({ sceneId: "ielts-3", sceneType: "ielts" });
+    await expect(part3.forceIeltsPart3TurnTimeout()).resolves.toMatchObject({ completed: false });
+    await expect(part3.forceIeltsPart3TurnTimeout()).resolves.toBeNull();
+    expect(mocks.advanceIeltsDialogueState).toHaveBeenCalledWith("ielts-3", "local-session", 1, true);
+    await part3.stop({ notifyBackend: false });
+  });
+
+  it("ends a quota-expired session and keeps stop idempotent", async () => {
+    wsAckMode = "quota";
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({ type: "local.quota_exhausted" })));
+    await vi.waitFor(() => expect(client.isActive()).toBe(false));
+    expect(events).toContainEqual(expect.objectContaining({ type: "local.ended", reason: "quota_exhausted" }));
+    await client.stop({ notifyBackend: false });
+  });
+
+  it("covers data-channel open, close, error, and ICE failure branches during startup", async () => {
+    channelMode.initialState = "connecting";
+    const openClient = createRealtimeClient();
+    const opening = openClient.start();
+    await vi.waitFor(() => expect(createdPeers).toHaveLength(1));
+    createdPeers[0].channel.readyState = "open";
+    createdPeers[0].channel.dispatch("open");
+    await expect(opening).resolves.toMatchObject({ sessionId: "local-session" });
+    await openClient.stop({ notifyBackend: false });
+
+    channelMode.initialState = "connecting";
+    const closeEvents = [];
+    const closeClient = createRealtimeClient({ onEvent: (event) => closeEvents.push(event) });
+    const closing = closeClient.start();
+    await vi.waitFor(() => expect(createdPeers).toHaveLength(2));
+    createdPeers[1].channel.dispatch("close");
+    await expect(closing).rejects.toThrow("实时会话启动已取消");
+    expect(closeEvents).toEqual([{ type: "local.connecting" }]);
+
+    channelMode.initialState = "connecting";
+    const errorClient = createRealtimeClient();
+    const errored = errorClient.start();
+    await vi.waitFor(() => expect(createdPeers).toHaveLength(3));
+    createdPeers[2].channel.dispatch("error");
+    await expect(errored).rejects.toThrow("实时数据通道连接失败");
+
+    channelMode.initialState = "connecting";
+    const iceClient = createRealtimeClient();
+    const iceFailure = iceClient.start();
+    await vi.waitFor(() => expect(createdPeers).toHaveLength(4));
+    createdPeers[3].iceConnectionState = "failed";
+    createdPeers[3].dispatch("iceconnectionstatechange");
+    await expect(iceFailure).rejects.toThrow("实时网络通道建立失败");
+  });
+
+  it("binds a provider session discovered after startup and handles a missing binding ack", async () => {
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({ providerSessionId: undefined }));
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+    await client.handleEvent({ type: "session.created", session: { id: "late-provider-session" } });
+    expect(createdSockets[0].sent).toContainEqual(expect.objectContaining({
+      type: "bind",
+      providerSessionId: "late-provider-session",
+    }));
+
+    await client.handleEvent({ type: "session.created" });
+    expect(events).not.toContainEqual(expect.objectContaining({
+      message: expect.stringContaining("服务商未返回 session.created"),
+    }));
+    await client.stop({ notifyBackend: false });
+  });
+
+  it("completes an interview through its closing response and end request", async () => {
+    mocks.submitInterviewTurn.mockResolvedValueOnce({
+      state: { shouldEnd: true, controlInstruction: "Thank the candidate and close." },
+      reportStatus: "PROCESSING",
+    });
+    mocks.endInterview.mockResolvedValueOnce({ status: "PROCESSING" });
+    const events = [];
+    const onRemoteAudioDrain = vi.fn(async () => undefined);
+    const client = await startClient({
+      sceneId: "interview-final",
+      sceneType: "interview",
+      onEvent: (event) => events.push(event),
+      onRemoteAudioDrain,
+    });
+
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "interview-input" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_stopped" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "interview-input",
+      transcript: "I led the project",
+    });
+    expect(mocks.submitInterviewTurn).toHaveBeenCalledWith(
+      "interview-final",
+      "local-session",
+      1,
+      expect.any(FormData),
+    );
+    expect(events).toContainEqual(expect.objectContaining({ type: "local.interview_closing" }));
+
+    await client.handleEvent({
+      type: "response.audio_transcript.done",
+      item_id: "closing-message",
+      transcript: "Thank you for your time.",
+    });
+    await client.handleEvent({ type: "response.done" });
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
+      type: "local.interview_end_requested",
+      reportStatus: "PROCESSING",
+    })));
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ended",
+      reason: "state_machine",
+    })));
+    expect(onRemoteAudioDrain).toHaveBeenCalledWith({ fallbackMs: 2_500, timeoutMs: 10_000 });
+    expect(mocks.endInterview).toHaveBeenCalledWith("interview-final", "local-session");
+  });
+
+  it("recovers an interrupted interview end request from its report", async () => {
+    mocks.endInterview.mockRejectedValueOnce(new Error("interview end interrupted"));
+    mocks.getInterviewReport.mockResolvedValueOnce({ status: "READY", report: { score: 92 } });
+    const events = [];
+    const client = await startClient({
+      sceneId: "interview-recovery",
+      sceneType: "interview",
+      onEvent: (event) => events.push(event),
+    });
+
+    const completion = await client.stop();
+    expect(completion).toMatchObject({
+      sceneId: "interview-recovery",
+      sessionId: "local-session",
+      reportStatus: "READY",
+      report: { score: 92 },
+    });
+    expect(mocks.getInterviewReport).toHaveBeenCalledWith("interview-recovery", "local-session");
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.interview_state",
+      reportStatus: "READY",
+    }));
+  });
+
+  it("reports a failed interview end when report recovery also fails", async () => {
+    mocks.endInterview.mockRejectedValueOnce(new Error("interview end failed"));
+    mocks.getInterviewReport.mockRejectedValue(new Error("report unavailable"));
+    const events = [];
+    const client = await startClient({
+      sceneId: "interview-failed",
+      sceneType: "interview",
+      onEvent: (event) => events.push(event),
+    });
+
+    await expect(client.stop({ awaitEvaluations: false })).rejects.toThrow("interview end failed");
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.backend_warning",
+      message: "interview end failed",
+    }));
+  });
+
+  it("keeps a free-chat stop resolved when the backend end ack fails", async () => {
+    wsAckMode = "reject-end";
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+
+    const completion = await client.stop();
+    expect(completion).toBeNull();
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.backend_warning",
+      message: "end rejected",
+    }));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ended",
+      reason: "user_stop",
+    }));
+  });
+
+  it("recovers IELTS state with the exact fallback instruction and restores input after assistant output", async () => {
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({
+      currentStage: "PART_1",
+      content: { part1: [{ question: 'What is your "home" like?' }] },
+    }));
+    mocks.advanceIeltsDialogueState.mockRejectedValueOnce(new Error("IELTS state unavailable"));
+    const events = [];
+    const client = await startClient({
+      sceneId: "ielts-recovery",
+      sceneType: "ielts",
+      onEvent: (event) => events.push(event),
+    });
+
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "ielts-input",
+      transcript: "I live near the city center",
+    });
+    const recovered = events.find((event) => event.type === "local.ielts_state_recovered");
+    expect(recovered).toMatchObject({ message: "IELTS state unavailable" });
+    const response = createdPeers[0].channel.sent.find(
+      (event) => event.type === "response.create" && event.response?.instructions,
+    );
+    expect(response.response.instructions).toContain('"What is your \\"home\\" like?"');
+
+    await client.handleEvent({
+      type: "response.audio_transcript.done",
+      item_id: "assistant-ielts",
+      transcript: "Please answer the question.",
+    });
+    await new Promise((resolve) => setTimeout(resolve, 2_600));
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ielts_input_ready",
+      source: "assistant_output_fallback",
+    }));
+    await client.stop({ notifyBackend: false });
+  });
+
+  it("handles IELTS Part 2 completion and ignores input after completion", async () => {
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({ currentStage: "PART_2", content: { part3: [] } }));
+    mocks.advanceIeltsPart2State.mockResolvedValueOnce({
+      completed: true,
+      controlInstruction: "Part 2 is complete.",
+    });
+    const events = [];
+    const client = await startClient({
+      sceneId: "ielts-complete",
+      sceneType: "ielts",
+      onEvent: (event) => events.push(event),
+    });
+
+    await client.transitionIeltsPart2("ANSWER_COMPLETE");
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "late-input" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "late-input",
+      transcript: "This answer arrived late",
+    });
+    expect(events).toContainEqual(expect.objectContaining({ type: "local.ielts_part2_completion_ready" }));
+    expect(mocks.advanceIeltsPart2State).toHaveBeenCalledWith("ielts-complete", "local-session", "ANSWER_COMPLETE");
+    expect(mocks.evaluateIeltsDialogueTurn).not.toHaveBeenCalled();
+    await client.stop({ notifyBackend: false });
+  });
+
+  it("completes a custom scene after its final response audio drains", async () => {
+    mocks.createPcmWavSegmentRecorder.mockResolvedValue({
+      startSegment: vi.fn(),
+      stopSegment: vi.fn(async () => new Blob(["custom"])),
+      close: vi.fn(),
+    });
+    mocks.advanceCustomDialogueState.mockResolvedValueOnce({
+      completed: true,
+      controlInstruction: "Close the custom scene.",
+    });
+    const events = [];
+    const client = await startClient({
+      sceneId: "custom-complete",
+      sceneType: "custom",
+      onEvent: (event) => events.push(event),
+      onRemoteAudioDrain: vi.fn(async () => undefined),
+    });
+
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "custom-input" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_stopped" });
+    await client.handleEvent({
+      type: "conversation.item.input_audio_transcription.completed",
+      item_id: "custom-input",
+      transcript: "My final answer",
+    });
+    await vi.waitFor(() => expect(mocks.advanceCustomDialogueState).toHaveBeenCalled());
+    expect(client.requestResponse()).toBe(true);
+    await client.handleEvent({ type: "response.done" });
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
+      type: "local.scenario_completed",
+    })));
+    await vi.waitFor(() => expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ended",
+      reason: "state_machine",
+    })));
+    expect(mocks.completeCustomDialogue).toHaveBeenCalledWith(
+      "custom-complete",
+      "local-session",
+      expect.any(String),
+    );
+  });
+
+  it("retries provider binding and reports the final bind failure", async () => {
+    wsAckMode = "reject-bind";
+    mocks.requestAuthenticated.mockResolvedValueOnce(backend({ providerSessionId: undefined }));
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+
+    await client.handleEvent({
+      type: "session.created",
+      session: { id: "provider-bind-failure" },
+    });
+
+    expect(createdSockets[0].sent.filter((message) => message.type === "bind")).toHaveLength(2);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.backend_warning",
+      message: "服务商会话绑定失败：bind rejected",
+    }));
+
+    // Keep teardown independent from the deliberately rejected binding.
+    wsAckMode = "normal";
+    await client.stop({ notifyBackend: false, reason: "bind_failure_cleanup" });
+  });
+
+  it("surfaces custom completionError after all evaluation recovery attempts fail", async () => {
+    mocks.completeCustomDialogue.mockRejectedValueOnce(new Error("custom completion failed"));
+    mocks.getCustomDialogueEvaluation.mockRejectedValue(new Error("evaluation still unavailable"));
+    const events = [];
+    const client = await startClient({
+      sceneId: "custom-no-recovery",
+      sceneType: "custom",
+      onEvent: (event) => events.push(event),
+    });
+
+    await expect(client.stop({ awaitEvaluations: false })).rejects.toThrow("custom completion failed");
+    expect(mocks.getCustomDialogueEvaluation).toHaveBeenCalledTimes(3);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.backend_warning",
+      message: "custom completion failed",
+    }));
+    expect(client.isActive()).toBe(false);
+  });
+
+  it("surfaces interview completionError when no report can be recovered", async () => {
+    mocks.endInterview.mockRejectedValueOnce(new Error("interview completion failed"));
+    mocks.getInterviewReport.mockRejectedValue(new Error("report still unavailable"));
+    const events = [];
+    const client = await startClient({
+      sceneId: "interview-no-recovery",
+      sceneType: "interview",
+      onEvent: (event) => events.push(event),
+    });
+
+    await expect(client.stop({ awaitEvaluations: false })).rejects.toThrow("interview completion failed");
+    expect(mocks.getInterviewReport).toHaveBeenCalledTimes(3);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.backend_warning",
+      message: "interview completion failed",
+    }));
+    expect(client.isActive()).toBe(false);
+  });
+
+  it("handles request and instruction updates when no session or channel exists", async () => {
+    const events = [];
+    const client = createRealtimeClient({ onEvent: (event) => events.push(event) });
+
+    expect(client.isActive()).toBe(false);
+    expect(client.requestResponse()).toBe(false);
+    await expect(client.updateInstructions("before start")).rejects.toThrow("实时数据通道尚未连接");
+    await expect(client.handleEvent({
+      type: "response.audio_transcript.done",
+      item_id: "orphan-assistant",
+      transcript: "This cannot be persisted yet",
+    })).rejects.toThrow("会话 ID 尚未建立");
+    await client.interrupt();
+    await client.stop({ reason: "no_session" });
+
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "local.ended",
+      reason: "no_session",
+      completion: null,
+    }));
+    expect(client.isActive()).toBe(false);
+  });
+
+  it("rejects updates after transport shutdown and keeps requestResponse safe", async () => {
+    const client = await startClient();
+    await client.stop({ notifyBackend: false, reason: "request_cleanup" });
+
+    expect(client.requestResponse()).toBe(false);
+    await expect(client.updateInstructions("after stop")).rejects.toThrow("实时数据通道尚未连接");
+  });
+
+  it("surfaces provider send failures from request and instruction updates", async () => {
+    const events = [];
+    const client = await startClient({ onEvent: (event) => events.push(event) });
+    channelMode.sendError = true;
+
+    expect(() => client.requestResponse()).toThrow("data channel send failed");
+    await expect(client.updateInstructions("send failure")).rejects.toThrow("data channel send failed");
+    expect(events).toContainEqual(expect.objectContaining({ type: "local.connected" }));
+
+    channelMode.sendError = false;
+    await client.stop({ notifyBackend: false, reason: "send_failure_cleanup" });
+  });
+});

--- a/frontend/web/src/websocket/__tests__/realtimeClient.main-flow.test.js
+++ b/frontend/web/src/websocket/__tests__/realtimeClient.main-flow.test.js
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(() => "access-token"),
+  requestAuthenticated: vi.fn(),
+  advanceCustomDialogueState: vi.fn(),
+  advanceIeltsDialogueState: vi.fn(),
+  advanceIeltsPart2State: vi.fn(),
+  completeCustomDialogue: vi.fn(),
+  endInterview: vi.fn(),
+  evaluateCustomDialogueTurn: vi.fn(),
+  evaluateIeltsDialogueTurn: vi.fn(),
+  getCustomDialogueEvaluation: vi.fn(),
+  getInterviewReport: vi.fn(),
+  getRealtimeIceConfiguration: vi.fn(),
+  submitInterviewTurn: vi.fn(),
+  createPcmWavSegmentRecorder: vi.fn(),
+  createRtcTelemetryMonitor: vi.fn(),
+}));
+
+vi.mock("../../infrastructure/http/apiClient.js", () => mocks);
+vi.mock("../../infrastructure/audio/audioRecorder.js", () => ({
+  createPcmWavSegmentRecorder: mocks.createPcmWavSegmentRecorder,
+}));
+vi.mock("../../telemetry/rtcTelemetry.js", () => ({
+  createRtcTelemetryMonitor: mocks.createRtcTelemetryMonitor,
+}));
+
+import { createRealtimeClient } from "../realtimeClient.js";
+
+class FakeChannel {
+  static OPEN = 1;
+
+  constructor() {
+    this.readyState = "open";
+    this.sent = [];
+    this.listeners = {};
+    this.close = vi.fn(() => { this.readyState = "closed"; this.listeners.close?.forEach((fn) => fn()); });
+  }
+
+  addEventListener(type, handler) {
+    (this.listeners[type] ||= []).push(handler);
+  }
+
+  removeEventListener(type, handler) {
+    this.listeners[type] = (this.listeners[type] || []).filter((fn) => fn !== handler);
+  }
+
+  send(payload) {
+    this.sent.push(JSON.parse(payload));
+  }
+}
+
+class FakePeer {
+  constructor(configuration) {
+    this.configuration = configuration;
+    this.iceGatheringState = "new";
+    this.iceConnectionState = "connected";
+    this.connectionState = "connected";
+    this.signalingState = "stable";
+    this.listeners = {};
+    this.channel = null;
+    this.localStream = null;
+    this.close = vi.fn(() => { this.signalingState = "closed"; });
+  }
+
+  addEventListener(type, handler) { (this.listeners[type] ||= []).push(handler); }
+  removeEventListener(type, handler) { this.listeners[type] = (this.listeners[type] || []).filter((fn) => fn !== handler); }
+  addTrack(track, stream) {
+    this.localStream = stream;
+    return { track: null, replaceTrack: vi.fn(async (nextTrack) => { this.senderTrack = nextTrack; }) };
+  }
+  createDataChannel() { this.channel = new FakeChannel(); return this.channel; }
+  async createOffer() { return { type: "offer", sdp: "v=0\n" }; }
+  async setLocalDescription(offer) {
+    this.localDescription = { ...offer, sdp: "v=0\r\na=candidate:1 1 UDP 1 127.0.0.1 9 typ host\r\n" };
+    this.iceGatheringState = "complete";
+  }
+  async setRemoteDescription(description) { this.remoteDescription = description; }
+  async getStats() { return []; }
+}
+
+class FakeWebSocket {
+  static OPEN = 1;
+  static CONNECTING = 0;
+
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.listeners = {};
+    this.sent = [];
+    queueMicrotask(() => {
+      this.readyState = FakeWebSocket.OPEN;
+      this.onopen?.();
+      this.listeners.open?.forEach((fn) => fn());
+    });
+  }
+
+  addEventListener(type, handler) { (this.listeners[type] ||= []).push(handler); }
+  removeEventListener(type, handler) { this.listeners[type] = (this.listeners[type] || []).filter((fn) => fn !== handler); }
+  send(payload) {
+    const message = JSON.parse(payload);
+    this.sent.push(message);
+    if (["activate", "bind", "end", "message"].includes(message.type)) {
+      queueMicrotask(() => this.onmessage?.({ data: JSON.stringify({ type: `session.${message.type}.accepted`, success: true }) }));
+    }
+  }
+  close = vi.fn(() => { this.readyState = 3; this.onclose?.(); });
+}
+
+function makeStream() {
+  const track = { enabled: false, stop: vi.fn() };
+  return { track, getAudioTracks: () => [track], getTracks: () => [track] };
+}
+
+function installBrowserFakes() {
+  const stream = makeStream();
+  Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: { getUserMedia: vi.fn(async () => stream) } });
+  vi.stubGlobal("RTCPeerConnection", FakePeer);
+  vi.stubGlobal("WebSocket", FakeWebSocket);
+  return stream;
+}
+
+function backend(overrides = {}) {
+  return {
+    sessionId: "local-session",
+    providerSessionId: "provider-session",
+    answerSdp: "v=0\n",
+    systemPrompt: "You are a helpful speaking partner.",
+    voiceId: "Tina",
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  installBrowserFakes();
+  mocks.requestAuthenticated.mockResolvedValue(backend());
+  mocks.getRealtimeIceConfiguration.mockResolvedValue({ turnEnabled: false, iceServers: [] });
+  mocks.createRtcTelemetryMonitor.mockReturnValue({ stateChanged: vi.fn(), connected: vi.fn(), stop: vi.fn() });
+  mocks.completeCustomDialogue.mockResolvedValue({ evaluation: { finalScore: 86 } });
+  mocks.endInterview.mockResolvedValue({ status: "PROCESSING" });
+  mocks.getCustomDialogueEvaluation.mockResolvedValue({ finalScore: 80 });
+  mocks.getInterviewReport.mockResolvedValue({ status: "PROCESSING" });
+  mocks.advanceCustomDialogueState.mockResolvedValue({ completed: false, controlInstruction: "Ask the next question" });
+  mocks.advanceIeltsDialogueState.mockResolvedValue({ completed: false, controlInstruction: "Ask the next IELTS question" });
+  mocks.advanceIeltsPart2State.mockResolvedValue({ completed: false, controlInstruction: "Begin the answer" });
+  mocks.evaluateCustomDialogueTurn.mockResolvedValue({ overallScore: 82 });
+  mocks.evaluateIeltsDialogueTurn.mockResolvedValue({ overallScore: 84 });
+  mocks.submitInterviewTurn.mockResolvedValue({ state: { shouldEnd: false, currentTopic: "experience" } });
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("createRealtimeClient main transport flow", () => {
+  it("starts free chat over WebRTC and session WebSocket, handles provider events, and stops cleanly", async () => {
+    const events = [];
+    const remoteStream = { getTracks: () => [{ stop: vi.fn() }] };
+    const client = createRealtimeClient({ onEvent: (event) => events.push(event), onRemoteStream: vi.fn() });
+    const started = await client.start({ voice: "Tina", speechSpeed: "NATURAL" });
+    expect(started).toMatchObject({ sessionId: "local-session" });
+    expect(mocks.requestAuthenticated).toHaveBeenCalledWith("/api/scene-sessions", expect.objectContaining({ method: "POST" }));
+    expect(events.map((event) => event.type)).toContain("local.connected");
+    expect(client.isActive()).toBe(true);
+
+    const peer = globalThis.RTCPeerConnection.instances?.[0];
+    // The fake exposes the active transport through the constructor mock's instances only
+    // when a test needs it; find it from the constructor call instead.
+    const activePeer = vi.mocked(RTCPeerConnection).mock?.instances?.[0] || peer;
+    activePeer?.ontrack?.({ streams: [remoteStream] });
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "session.created", session: { id: "provider-session" } });
+    await client.handleEvent({ type: "response.audio_transcript.done", item_id: "assistant-1", transcript: "How are you?" });
+    expect(events.some((event) => event.type === "local.transcript.final")).toBe(true);
+
+    await client.pause();
+    await client.resume();
+    await client.interrupt();
+    expect(events.map((event) => event.type)).toEqual(expect.arrayContaining(["local.paused", "local.resumed", "local.interrupted"]));
+    await client.stop({ notifyBackend: false, reason: "test_stop" });
+    expect(events.at(-1)).toMatchObject({ type: "local.ended", reason: "test_stop" });
+    expect(client.isActive()).toBe(false);
+  });
+
+  it("persists custom scene turns, advances state, records audio, and completes automatically", async () => {
+    const events = [];
+    const recorder = { startSegment: vi.fn(), stopSegment: vi.fn(async () => new Blob(["wav"])), close: vi.fn() };
+    mocks.createPcmWavSegmentRecorder.mockResolvedValue(recorder);
+    mocks.advanceCustomDialogueState.mockResolvedValueOnce({ completed: false, controlInstruction: "Continue" }).mockResolvedValueOnce({ completed: true, controlInstruction: "Close the scene" });
+    const onRemoteAudioDrain = vi.fn(async () => undefined);
+    const client = createRealtimeClient({ sceneId: "scene-1", sceneType: "custom", onEvent: (event) => events.push(event), onRemoteAudioDrain });
+    await client.start();
+    await client.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await client.handleEvent({ type: "response.created" });
+    await client.handleEvent({ type: "response.done" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "input-1" });
+    await client.handleEvent({ type: "input_audio_buffer.speech_stopped" });
+    await client.handleEvent({ type: "conversation.item.input_audio_transcription.completed", item_id: "input-1", transcript: "I need help" });
+    await vi.waitFor(() => expect(mocks.advanceCustomDialogueState).toHaveBeenCalledWith("scene-1", "local-session", 1, "I need help"));
+    await vi.waitFor(() => expect(mocks.evaluateCustomDialogueTurn).toHaveBeenCalledWith(
+      "scene-1",
+      "local-session",
+      1,
+      "I need help",
+      expect.any(Blob),
+    ));
+    await client.handleEvent({ type: "response.done" });
+    expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "local.scenario_state" })]));
+    expect(recorder.startSegment).toHaveBeenCalled();
+    await client.stop({ notifyBackend: false, reason: "test_stop" });
+    expect(recorder.close).toHaveBeenCalled();
+  });
+
+  it("covers IELTS and interview startup-specific requests and input events", async () => {
+    const ieltsEvents = [];
+    const ieltsRecorder = { startSegment: vi.fn(), stopSegment: vi.fn(async () => new Blob(["ielts"])), close: vi.fn() };
+    mocks.createPcmWavSegmentRecorder.mockResolvedValue(ieltsRecorder);
+    mocks.requestAuthenticated.mockResolvedValue(backend({ currentStage: "PART_1", content: { part1: [{ question: "Where do you live?" }] } }));
+    const ielts = createRealtimeClient({ sceneId: "ielts-1", sceneType: "ielts", onEvent: (event) => ieltsEvents.push(event) });
+    await ielts.start({ voice: "Harvey", speechSpeed: "SLOWER" });
+    await ielts.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await ielts.handleEvent({ type: "response.created" });
+    await ielts.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "i-1" });
+    await ielts.handleEvent({ type: "input_audio_buffer.speech_stopped" });
+    await ielts.handleEvent({ type: "conversation.item.input_audio_transcription.completed", item_id: "i-1", transcript: "I live in Shanghai" });
+    await vi.waitFor(() => expect(mocks.advanceIeltsDialogueState).toHaveBeenCalled());
+    expect(mocks.evaluateIeltsDialogueTurn).toHaveBeenCalled();
+    await ielts.stop({ notifyBackend: false, reason: "test_stop" });
+
+    const interviewEvents = [];
+    mocks.requestAuthenticated.mockResolvedValue(backend());
+    const interview = createRealtimeClient({ sceneId: "interview-1", sceneType: "interview", onEvent: (event) => interviewEvents.push(event) });
+    await interview.start();
+    await interview.handleEvent({ type: "session.updated", session: { instructions: "ready" } });
+    await interview.handleEvent({ type: "response.created" });
+    await interview.handleEvent({ type: "input_audio_buffer.speech_started", item_id: "interview-input" });
+    await interview.handleEvent({ type: "input_audio_buffer.speech_stopped" });
+    await interview.handleEvent({ type: "conversation.item.input_audio_transcription.completed", item_id: "interview-input", transcript: "I led the project" });
+    await vi.waitFor(() => expect(mocks.submitInterviewTurn).toHaveBeenCalled());
+    expect(interviewEvents).toEqual(expect.arrayContaining([expect.objectContaining({ type: "local.interview_state" })]));
+    await interview.stop({ notifyBackend: false, reason: "test_stop" });
+  });
+
+  it("emits actionable errors when microphone setup fails", async () => {
+    navigator.mediaDevices.getUserMedia.mockRejectedValueOnce(Object.assign(new Error("denied"), { name: "NotAllowedError" }));
+    const events = [];
+    const client = createRealtimeClient({ onEvent: (event) => events.push(event) });
+    await expect(client.start()).rejects.toThrow();
+    expect(events).toEqual(expect.arrayContaining([expect.objectContaining({ type: "local.mic_error" })]));
+    expect(client.isActive()).toBe(false);
+  });
+});

--- a/frontend/web/src/websocket/__tests__/realtimeClient.test.js
+++ b/frontend/web/src/websocket/__tests__/realtimeClient.test.js
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  assistantResponseInvitesReply,
+  buildProviderSessionBindingFrame,
+  buildRealtimeSessionConfig,
+  buildRealtimeStartPayload,
+  buildResponseCreateEvent,
+  buildScenarioResponseRequest,
+  collectIceConnectionDiagnostics,
+  createTurnAudioCaptureController,
+  defaultIceServers,
+  extractCompletedAssistantMessage,
+  extractProviderSessionId,
+  isActiveResponseConflict,
+  isMicFailure,
+  isRealtimeChannelOpen,
+  micFailureMessage,
+  normalizeBaseUrl,
+  normalizeIceTransportPolicy,
+  normalizeProviderEvent,
+  realtimeFailureMessage,
+  realtimePeerConnectionConfig,
+  realtimeTurnEnabled,
+  releaseRealtimeTransport,
+  resolveRealtimePeerConnectionConfig,
+  waitForIceGathering,
+  websocketUrl,
+} from "../realtimeClient.js";
+
+afterEach(() => vi.useRealTimers());
+
+describe("realtime client pure contracts", () => {
+  it("maps microphone and realtime failures to actionable messages", () => {
+    const cases = [
+      ["NotAllowedError", "权限被拒绝"], ["SecurityError", "权限被拒绝"],
+      ["NotFoundError", "未检测到"], ["DevicesNotFoundError", "未检测到"],
+      ["NotReadableError", "被其他应用占用"], ["AudioCaptureError", "被其他应用占用"],
+      ["OverconstrainedError", "不满足采集要求"],
+    ];
+    cases.forEach(([name, text]) => {
+      const error = { name };
+      expect(isMicFailure(error)).toBe(true);
+      expect(micFailureMessage(error)).toContain(text);
+    });
+    expect(isMicFailure({ name: "Other" })).toBe(false);
+    expect(micFailureMessage({ name: "Other" })).toBeNull();
+    expect(realtimeFailureMessage(new Error("AllocationQuota.FreeTierOnly"))).toContain("免费额度");
+    expect(realtimeFailureMessage(new Error("QWEN_SIGNALING_FAILED"))).toContain("拒绝了连接");
+    expect(realtimeFailureMessage(new Error("ICE connection failed"))).toContain("实时网络通道");
+    expect(realtimeFailureMessage()).toBe("无法开始实时对话");
+  });
+
+  it("normalizes URLs, ICE policies, payloads, and session configuration", () => {
+    expect(normalizeBaseUrl()).toBe("");
+    expect(normalizeBaseUrl(" /backend/ ")).toBe("/backend");
+    expect(normalizeBaseUrl("https://api.example.com/")).toBe("https://api.example.com");
+    expect(() => normalizeBaseUrl("ftp://example.com")).toThrow("HTTP 或 HTTPS");
+    expect(websocketUrl("/backend", "token", "https://app.example.com")).toBe("wss://app.example.com/backend/ws/session-messages?access_token=token");
+    expect(websocketUrl("https://api.example.com/base/", "")).toBe("wss://api.example.com/base/ws/session-messages");
+    expect(normalizeIceTransportPolicy(" RELAY ")).toBe("relay");
+    expect(normalizeIceTransportPolicy("bad")).toBe("all");
+    expect(realtimeTurnEnabled()).toBe(false);
+    expect(realtimePeerConnectionConfig([{ urls: "stun:test" }], "relay")).toEqual({ iceServers: [{ urls: "stun:test" }], iceTransportPolicy: "relay" });
+    expect(buildRealtimeStartPayload("offer", { ielts: false, voice: "  " })).toEqual({ offerSdp: "offer", voice: "Tina", translationEnabled: true });
+    expect(buildRealtimeStartPayload("offer", { ielts: true, voice: "Harvey" })).toEqual({ offerSdp: "offer", voiceId: "Harvey", translationEnabled: true });
+    expect(buildResponseCreateEvent({ id: "event-1", instructions: "  say hi  " })).toEqual({ event_id: "event-1", type: "response.create", response: { instructions: "say hi", modalities: ["text", "audio"] } });
+    expect(buildResponseCreateEvent()).toMatchObject({ type: "response.create" });
+    expect(buildScenarioResponseRequest(null)).toEqual({ closing: false, instructions: "" });
+    expect(buildScenarioResponseRequest({ completed: 1, controlInstruction: " next " })).toEqual({ closing: true, instructions: "next" });
+    expect(buildRealtimeSessionConfig({ systemPrompt: "system", voice: "Tina", speechSpeed: "slower", silenceDurationMs: 100, prefixPaddingMs: -1 })).toMatchObject({ voice: "Tina", instructions: expect.stringContaining("system"), turn_detection: { type: "semantic_vad", silence_duration_ms: 600, prefix_padding_ms: 0 } });
+    expect(buildRealtimeSessionConfig({ topic: "topic", includeVoice: false, model: "other-model", automaticTurnResponses: false, turnDetectionType: "server_vad", vadThreshold: 0 })).toMatchObject({ instructions: expect.stringContaining("topic"), turn_detection: { type: "server_vad", threshold: 0.5, create_response: false }, });
+  });
+
+  it("handles provider IDs, assistant message variants, and normalized errors", () => {
+    expect(extractProviderSessionId({ providerSessionId: " p " })).toBe("p");
+    expect(extractProviderSessionId({ session: { id: "s" } })).toBe("s");
+    expect(extractProviderSessionId({})).toBeNull();
+    expect(buildProviderSessionBindingFrame(" local ", { session: { id: "provider" } })).toEqual({ type: "bind", sessionId: "local", providerSessionId: "provider" });
+    expect(buildProviderSessionBindingFrame("", { providerSessionId: "p" })).toBeNull();
+    expect(extractCompletedAssistantMessage({ type: "response.audio_transcript.done", item_id: "a", transcript: "hello" })).toEqual({ id: "a", text: "hello" });
+    expect(extractCompletedAssistantMessage({ type: "response.text.done", response_id: "b", text: "text" })).toEqual({ id: "b", text: "text" });
+    expect(extractCompletedAssistantMessage({ type: "response.content_part.done", event_id: "c", part: { text: "part" } })).toEqual({ id: "c", text: "part" });
+    expect(extractCompletedAssistantMessage({ type: "response.output_item.done", item: { id: "d", role: "assistant", content: [{ text: " first " }, { transcript: "second" }] } })).toEqual({ id: "d", text: "first second" });
+    expect(extractCompletedAssistantMessage({ type: "response.done", response: { output: [{ role: "user", content: [] }] } })).toBeNull();
+    expect(extractCompletedAssistantMessage({ type: "other" })).toBeNull();
+    expect(assistantResponseInvitesReply("Are you ready?\" ")).toBe(true);
+    expect(assistantResponseInvitesReply("No, thanks.")).toBe(false);
+    expect(isActiveResponseConflict({ type: "error", error: { message: "conversation already has an active response" } })).toBe(true);
+    expect(isActiveResponseConflict({ type: "other", message: "conversation already has an active response" })).toBe(false);
+    expect(normalizeProviderEvent({ type: "rtid.error", error: "bad" })).toMatchObject({ type: "error", providerEventType: "rtid.error", error: { message: "bad" } });
+    const normal = { type: "ready" };
+    expect(normalizeProviderEvent(normal)).toBe(normal);
+  });
+
+  it("coordinates turn audio capture state", async () => {
+    const recorder = { startSegment: vi.fn(), stopSegment: vi.fn(async () => "audio") };
+    const capture = createTurnAudioCaptureController(recorder);
+    expect(capture.start()).toBe(true);
+    expect(capture.start()).toBe(false);
+    expect(capture.stop()).toBe(true);
+    expect(capture.stop()).toBe(false);
+    await expect(capture.take()).resolves.toBe("audio");
+    expect(capture.start()).toBe(true);
+    await expect(capture.take()).resolves.toBe("audio");
+    expect(createTurnAudioCaptureController(null).start()).toBe(false);
+    expect(recorder.startSegment).toHaveBeenCalledTimes(2);
+  });
+
+  it("summarizes ICE gathering and safe transport cleanup", async () => {
+    const completePeer = { iceGatheringState: "complete", localDescription: { sdp: "a=candidate:1 1 udp 1 127.0.0.1 1 typ host\r\n" } };
+    await expect(waitForIceGathering(completePeer)).resolves.toMatchObject({ complete: true, candidates: { host: 1 } });
+
+    vi.useFakeTimers();
+    const listeners = {};
+    const peer = {
+      iceGatheringState: "gathering",
+      signalingState: "stable",
+      localDescription: { sdp: "" },
+      addEventListener: vi.fn((type, fn) => { listeners[type] = fn; }),
+      removeEventListener: vi.fn(),
+    };
+    const pending = waitForIceGathering(peer, { timeoutMs: 100 });
+    listeners.icecandidate({ candidate: { type: "relay", protocol: "udp" } });
+    peer.iceGatheringState = "complete";
+    listeners.icegatheringstatechange({});
+    await expect(pending).resolves.toMatchObject({ complete: true, candidates: { relay: 1, protocols: { udp: 1 } } });
+
+    const timeoutPeer = { iceGatheringState: "gathering", localDescription: { sdp: "" }, addEventListener() {}, removeEventListener() {} };
+    const noCandidate = waitForIceGathering(timeoutPeer, { timeoutMs: 10 });
+    vi.advanceTimersByTime(10);
+    await expect(noCandidate).rejects.toMatchObject({ code: "WEBRTC_ICE_GATHERING_NO_CANDIDATE" });
+    const candidateTimeoutPeer = { iceGatheringState: "gathering", localDescription: { sdp: "" }, addEventListener(type, fn) { if (type === "icecandidate") fn({ candidate: "candidate:1 1 UDP 1 1 1 typ host" }); }, removeEventListener() {} };
+    const timedOut = waitForIceGathering(candidateTimeoutPeer, { timeoutMs: 10 });
+    vi.advanceTimersByTime(10);
+    await expect(timedOut).resolves.toMatchObject({ timedOut: true, candidates: { host: 1 } });
+
+    const track = { stop: vi.fn() };
+    const channel = { close: vi.fn(), onopen: vi.fn(), onmessage: vi.fn(), onerror: vi.fn(), onclose: vi.fn() };
+    const peerToClose = { close: vi.fn(), ontrack: vi.fn(), ondatachannel: vi.fn(), onconnectionstatechange: vi.fn() };
+    const sender = { replaceTrack: vi.fn(() => Promise.resolve()) };
+    releaseRealtimeTransport({ peer: peerToClose, channels: [channel], localStream: { getTracks: () => [track] }, remoteStreams: [{ getTracks: () => [track] }], audioSender: sender });
+    expect(sender.replaceTrack).toHaveBeenCalledWith(null);
+    expect(track.stop).toHaveBeenCalledTimes(2);
+    expect(channel.close).toHaveBeenCalled();
+    expect(peerToClose.close).toHaveBeenCalled();
+    expect(isRealtimeChannelOpen({ readyState: "open" })).toBe(true);
+    expect(isRealtimeChannelOpen({ readyState: "closed" })).toBe(false);
+  });
+
+  it("collects selected candidate diagnostics and falls back safely", async () => {
+    const reports = [
+      { type: "local-candidate", id: "l", candidateType: "relay", protocol: "udp", relayProtocol: "udp" },
+      { type: "remote-candidate", id: "r", candidateType: "srflx" },
+      { type: "candidate-pair", state: "succeeded", nominated: true, localCandidateId: "l", remoteCandidateId: "r" },
+      { type: "candidate-pair", state: "waiting", nominated: false },
+    ];
+    const result = await collectIceConnectionDiagnostics({ getStats: async () => reports }, { relay: 1 });
+    expect(result).toMatchObject({ selectedCandidatePair: { localCandidateType: "relay", remoteCandidateType: "srflx", relayProtocol: "udp" }, relayProtocols: { udp: 1 } });
+    await expect(collectIceConnectionDiagnostics({ getStats: async () => { throw new Error("stats"); } })).resolves.toMatchObject({ selectedCandidatePair: null });
+    expect(defaultIceServers()).toEqual(expect.any(Array));
+    await expect(resolveRealtimePeerConnectionConfig({ turnEnabled: false, forceRelay: false })).resolves.toEqual(realtimePeerConnectionConfig());
+    await expect(resolveRealtimePeerConnectionConfig({ forceRelay: true, loadConfiguration: async () => ({ turnEnabled: false, iceServers: [] }) })).rejects.toMatchObject({ code: "WEBRTC_TURN_NOT_CONFIGURED" });
+    await expect(resolveRealtimePeerConnectionConfig({ turnEnabled: true, forceRelay: false, loadConfiguration: async () => { throw new Error("not configured"); } })).resolves.toEqual(realtimePeerConnectionConfig());
+  });
+});

--- a/frontend/web/vitest.config.mjs
+++ b/frontend/web/vitest.config.mjs
@@ -1,0 +1,25 @@
+import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.js"],
+    include: ["src/**/__tests__/**/*.{test,spec}.{js,jsx}"],
+    testTimeout: 15_000,
+    fileParallelism: false,
+    pool: "threads",
+    poolOptions: {
+      threads: {
+        singleThread: true,
+      },
+    },
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "json-summary", "lcov"],
+      include: ["src/**/*.{js,jsx}"],
+      exclude: ["src/**/__tests__/**", "src/test/**"],
+    },
+  },
+});


### PR DESCRIPTION
## Summary

- 为 Web 前端引入 Vitest、React Testing Library、jsdom 和 V8 coverage
- 为认证、路由、App、Realtime/WebRTC、IELTS、Interview、Profile、Help、Achievement、API、Telemetry 等模块补充自动化测试
- 新增 Web 独立 Codecov flag，并将 partial-line 覆盖率门禁设为 85%
- 在 CI 中执行 Web 测试、覆盖率检查、生产构建和 LCOV 上传

## Validation

- `npm run test:checks`
- `npm test`
- `npm run test:coverage`
- Codecov partial-line coverage checker: passed at 86.75%
- `npm run build`
Close #171 