### PR TITLE
fix: preserve deployment backups during source sync

### DIFF
--- a/deploy/scripts/sync-build-deploy.sh
+++ b/deploy/scripts/sync-build-deploy.sh
@@ -48,8 +48,8 @@ fi
 log "同步源码：$current_sha -> $target_sha"
 git -C "$BASE_DIR" reset --hard "$target_sha"
 # Keep server-owned runtime files while removing unexpected untracked files.
-git -C "$BASE_DIR" clean -fd -e deploy/env/ -e runtime-logs/ -e .source-deploy-state
-unexpected="$(git -C "$BASE_DIR" status --porcelain --untracked-files=all | grep -v '^?? deploy/env/' | grep -v '^?? runtime-logs/' || true)"
+git -C "$BASE_DIR" clean -fd -e deploy/env/ -e backups/ -e runtime-logs/ -e .source-deploy-state
+unexpected="$(git -C "$BASE_DIR" status --porcelain --untracked-files=all | grep -v '^?? deploy/env/' | grep -v '^?? backups/' | grep -v '^?? runtime-logs/' || true)"
 [[ -z "$unexpected" ]] || fail "同步后工作区仍有未预期改动：$unexpected"
 
 monitoring_network="$(sed -n 's/^MONITORING_NETWORK_NAME=//p' "$ENV_FILE" | head -n 1 | tr -d "'\"")"

--- a/docs/deployment-source.md
+++ b/docs/deployment-source.md
@@ -43,18 +43,18 @@ test "$(stat -c '%a' /opt/unispeaking/deploy/env/.env)" = 600
 
 ## 同步工作区
 
-以下操作会让跟踪文件严格匹配远程 `main`，并删除工作区内未跟踪的临时文件；服务器私有 `.env` 和 `runtime-logs/` 会保留：
+以下操作会让跟踪文件严格匹配远程 `main`，并删除工作区内未跟踪的临时文件；服务器私有 `.env`、`backups/` 和 `runtime-logs/` 会保留：
 
 ```bash
 cd /opt/unispeaking
 git remote set-url origin https://github.com/1024XEngineer/UniSpeaking.git
 git fetch --prune origin main
 git reset --hard origin/main
-git clean -fd -e deploy/env/ -e runtime-logs/ -e .source-deploy-state
+git clean -fd -e deploy/env/ -e backups/ -e runtime-logs/ -e .source-deploy-state
 git status --short
 ```
 
-`git status --short` 只能显示服务器保留的 `deploy/env/` 或 `runtime-logs/` 内容；若出现其他修改，应停止并人工确认。
+`git status --short` 只能显示服务器保留的 `deploy/env/`、`backups/` 或 `runtime-logs/` 内容；若出现其他修改，应停止并人工确认。
 
 ## 安装定时部署
 
@@ -142,7 +142,7 @@ git log --oneline -10
 
 ```bash
 git reset --hard <GOOD_SHA>
-git clean -fd -e deploy/env/ -e runtime-logs/ -e .source-deploy-state
+git clean -fd -e deploy/env/ -e backups/ -e runtime-logs/ -e .source-deploy-state
 systemctl start unispeaking-source-deploy.service
 journalctl -u unispeaking-source-deploy.service -n 200 --no-pager
 ```


### PR DESCRIPTION
## 问题

生产服务器 `/opt/unispeaking` 内存在数据库和代码备份。原源码同步脚本执行 `git clean` 时没有保护 `backups/`，可能误删服务器备份文件。

## 修复

- 同步脚本的 `git clean` 增加 `backups/` 保留规则；
- 工作区异常检查允许保留 `backups/`；
- 更新生产部署文档，明确 `deploy/env/`、`backups/` 和 `runtime-logs/` 均为服务器保留目录。

## 安全性

- 不修改数据库 Volume；
- 不执行 `docker compose down -v`；
- 不执行 `docker volume prune`；
- 不修改定时器频率；
- 不涉及应用业务代码。